### PR TITLE
feat(blog): Swagger 문서화, 예외 처리 개선 및 Full Text Search 구현

### DIFF
--- a/main-server/README.md
+++ b/main-server/README.md
@@ -135,3 +135,421 @@ Authorization: Bearer {accessToken}
 
 **위치**: `security/oauth/status/OAuthStatus.kt`
 
+### BlogStatus
+
+| HTTP Status | Custom Code | 설명 |
+|-------------|-------------|------|
+| 404 | 3001 | Blog not found |
+
+**위치**: `blog/BlogStatus.kt`
+
+---
+
+## ArticleLink 및 BatchLog 시스템
+
+### 개요
+크롤링한 게시글 링크를 관리하고 배치 작업 실행 내역을 추적하는 시스템
+
+블로그와 게시글 링크를 1:N 관계로 정규화하여 관리합니다.
+
+### Entity
+
+#### Blog
+- **위치**: `com.techtaurant.mainserver.blog.entity.Blog`
+- **테이블**: `blogs`
+- **특징**:
+  - Soft Delete 적용: 삭제 시 실제 DB에서 제거되지 않고 `deleted_at`에 현재 시간 기록
+  - Full Text Search 지원: `name`, `displayName` 컬럼에 pg_trgm 기반 GIN 인덱스
+- **필드**:
+  - `id`: UUID (Primary Key)
+  - `name`: 블로그 식별자 (Unique, 예: "toss", "kakao")
+  - `displayName`: 표시용 이름
+  - `iconUrl`: 블로그 아이콘 URL
+  - `baseUrl`: 블로그 기본 URL
+  - `createdAt`: 생성일시
+  - `updatedAt`: 수정일시
+  - `deletedAt`: 삭제일시 (Soft Delete용)
+- **어노테이션**:
+  - `@SQLDelete`: DELETE 쿼리를 UPDATE로 변환하여 Soft Delete 구현
+  - `@SQLRestriction`: SELECT 시 `deleted_at IS NULL` 조건 자동 적용
+
+#### ArticleLink
+- **위치**: `com.techtaurant.mainserver.articlelink.entity.ArticleLink`
+- **테이블**: `article_links`
+- **필드**:
+  - `id`: UUID (Primary Key)
+  - `blog`: Blog 엔티티 (ManyToOne, FK)
+  - `url`: 게시글 URL
+  - `title`: 게시글 제목
+  - `type`: 크롤링 타입 (PAGE_BASED, NEXT_BUTTON_BASED)
+  - `createdAt`: 생성일시
+  - `updatedAt`: 수정일시
+  - `deletedAt`: 삭제일시 (소프트 삭제)
+
+#### BatchLog
+- **위치**: `com.techtaurant.mainserver.batchlog.entity.BatchLog`
+- **테이블**: `batch_log`
+- **필드**:
+  - `id`: UUID (Primary Key)
+  - `batchName`: 배치 작업 이름
+  - `status`: 배치 상태 (RUNNING, SUCCESS, FAILED)
+  - `startedAt`: 시작 시간
+  - `finishedAt`: 종료 시간
+  - `errorMessage`: 에러 메시지
+  - `screenshotBase64`: 실패시 스크린샷 (Base64)
+  - `createdAt`: 생성일시
+  - `updatedAt`: 수정일시
+
+### Repository
+
+#### BlogRepository
+- **위치**: `com.techtaurant.mainserver.blog.infrastructure.out.BlogRepository`
+- **주요 메서드**:
+  - `findByNameAndDeletedAtIsNull(name: String)`: 블로그명으로 조회 (삭제되지 않은 것만)
+  - `findByDeletedAtIsNull()`: 모든 블로그 조회 (삭제되지 않은 것만)
+
+#### ArticleLinkRepository
+- **위치**: `com.techtaurant.mainserver.articlelink.infrastructure.out.ArticleLinkRepository`
+- **주요 메서드**:
+  - `findByBlogAndDeletedAtIsNull(blog: Blog)`: 블로그로 조회 (삭제되지 않은 것만)
+  - `findByTypeAndDeletedAtIsNull(type: ArticleLinkType)`: 타입으로 조회 (삭제되지 않은 것만)
+
+#### BatchLogRepository
+- **위치**: `com.techtaurant.mainserver.batchlog.infrastructure.out.BatchLogRepository`
+- **주요 메서드**:
+  - `findByBatchName(batchName: String)`: 배치명으로 조회
+  - `findByStatus(status: BatchStatus)`: 상태로 조회
+
+### Service
+
+#### BlogService
+- **위치**: `com.techtaurant.mainserver.blog.service.BlogService`
+- **기능**: 블로그 CRUD 관리
+- **메서드**:
+  - `createBlog(request: BlogCreateRequest): BlogResponse` - 블로그 생성
+  - `updateBlog(id: UUID, request: BlogUpdateRequest): BlogResponse` - 블로그 수정
+  - `deleteBlog(id: UUID)` - 블로그 삭제
+  - `getBlogById(id: UUID): BlogResponse` - 블로그 조회
+  - `getAllBlogs(): List<BlogResponse>` - 전체 블로그 목록
+  - `searchBlogByName(name: String): BlogResponse?` - 블로그 검색
+
+#### CrawlerApiService
+- **위치**: `com.techtaurant.mainserver.articlelink.service.CrawlerApiService`
+- **기능**: Python 크롤러 API 호출
+- **메서드**:
+  - `validateCrawlingPage(request: PageBaseLinkCrawlingRequest): Mono<Boolean>`
+    - 크롤링 페이지 유효성 검증
+    - 엔드포인트: POST `/api/v1/page-base-link-crawling/validations`
+
+#### ArticleLinkService
+- **위치**: `com.techtaurant.mainserver.articlelink.service.ArticleLinkService`
+- **기능**: 크롤링 유효성 검증 후 링크 저장
+- **메서드**:
+  - `validateAndSave(request: ValidationRequest): Boolean`
+    - 크롤러 API로 유효성 검증
+    - 검증 성공시 ArticleLink를 article_links 테이블에 저장
+    - 트랜잭션 처리
+    - **주의**: 블로그는 사전에 등록되어 있어야 함
+
+### API
+
+#### Admin API (ROLE_ADMIN 필요)
+
+##### POST /admin/blogs
+블로그 등록
+
+**Request Body**:
+```json
+{
+  "name": "toss",
+  "displayName": "토스 기술 블로그",
+  "iconUrl": "https://example.com/icon.png",
+  "baseUrl": "https://toss.tech/"
+}
+```
+
+**Response**:
+```json
+{
+  "status": 200,
+  "data": {
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "name": "toss",
+    "displayName": "토스 기술 블로그",
+    "iconUrl": "https://example.com/icon.png",
+    "baseUrl": "https://toss.tech/"
+  },
+  "message": "OK"
+}
+```
+
+##### PUT /admin/blogs/{id}
+블로그 수정
+
+**Request Body**:
+```json
+{
+  "displayName": "토스 기술 블로그 (수정)",
+  "iconUrl": "https://example.com/new-icon.png",
+  "baseUrl": "https://toss.tech/"
+}
+```
+
+##### DELETE /admin/blogs/{id}
+블로그 삭제
+
+#### Blog API (인증 필요)
+
+##### GET /api/v1/blogs
+전체 블로그 목록 조회
+
+**Response**:
+```json
+{
+  "status": 200,
+  "data": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440000",
+      "name": "toss",
+      "displayName": "토스 기술 블로그",
+      "iconUrl": "https://example.com/icon.png",
+      "baseUrl": "https://toss.tech/"
+    }
+  ],
+  "message": "OK"
+}
+```
+
+##### GET /api/v1/blogs/{id}
+특정 블로그 조회
+
+##### GET /api/v1/blogs/search?name={name}
+블로그 검색
+
+#### ArticleLink API
+
+##### POST /api/v1/article-links/validate-and-save
+크롤링 설정을 검증하고 유효한 경우 DB에 저장
+
+**Request Body**:
+```json
+{
+  "blogId": "550e8400-e29b-41d4-a716-446655440000",
+  "baseUrl": "https://toss.tech/",
+  "startPage": 1,
+  "articlePattern": "/article/",
+  "titleSelector": "span.e1sck7qg7",
+  "type": "PAGE_BASED"
+}
+```
+
+**Response**:
+```json
+{
+  "status": 200,
+  "data": true,
+  "message": "OK"
+}
+```
+
+### Configuration
+
+#### WebClientConfig
+- **위치**: `com.techtaurant.mainserver.common.config.WebClientConfig`
+- **Bean**: `crawlerWebClient`
+- **설정값**:
+  - `crawler.api.base-url`: 크롤러 API 기본 URL (기본값: http://localhost:8000)
+  - `crawler.api.timeout`: 요청 타임아웃 (기본값: 30000ms)
+
+### 환경 변수
+`.env` 파일에 추가:
+```properties
+CRAWLER_API_BASE_URL=http://localhost:8000
+CRAWLER_API_TIMEOUT=30000
+```
+
+### Migration 파일
+- `V1__create_user.sql`: user 테이블 생성
+- `V2__create_blogs.sql`: blogs 테이블 생성
+- `V3__create_article_links.sql`: article_links 테이블 생성 (blog_id FK 포함)
+- `V4__create_batch_log.sql`: batch_log 테이블 생성
+- `V5__create_fulltext_index_for_blogs.sql`: blogs 테이블 Full Text Search 인덱스 생성
+
+---
+
+## Full Text Search (블로그 검색)
+
+### 개요
+PostgreSQL의 pg_trgm extension을 사용한 한국어 블로그 검색 기능
+
+### 특징
+- **N-Gram 기반 검색**: trigram (3-gram) 유사도 검색 지원
+- **한국어 2글자 검색 지원**: similarity threshold 조정으로 짧은 한국어 검색어도 지원
+- **오타 허용**: 유사도 기반 검색으로 오타가 있어도 검색 가능
+- **인덱스 최적화**: GIN 인덱스로 대용량 데이터에서도 빠른 검색
+
+### 인덱스 구성
+1. **idx_blogs_name_trgm**: `name` 컬럼 trigram 인덱스
+2. **idx_blogs_display_name_trgm**: `display_name` 컬럼 trigram 인덱스
+3. **idx_blogs_combined_trgm**: `name + display_name` 복합 검색 인덱스
+
+### 검색 방법
+
+#### 1. ILIKE를 사용한 부분 일치 검색 (정확한 부분 문자열)
+```sql
+SELECT * FROM blogs
+WHERE name ILIKE '%검색어%'
+  AND deleted_at IS NULL;
+```
+
+**특징**:
+- 정확한 부분 문자열 매칭
+- 대소문자 구분 없음
+- 가장 직관적이고 이해하기 쉬움
+
+#### 2. similarity 함수를 사용한 유사도 검색 (오타 허용)
+```sql
+SELECT *, similarity(name, '검색어') as sim
+FROM blogs
+WHERE name % '검색어'
+  AND deleted_at IS NULL
+ORDER BY sim DESC;
+```
+
+**특징**:
+- 유사도 점수(0~1) 반환
+- `%` 연산자: 기본 threshold(0.3) 이상인 것만 반환
+- 오타가 있어도 검색 가능
+- 검색 결과를 유사도 순으로 정렬 가능
+
+#### 3. word_similarity를 사용한 단어 단위 유사도 검색
+```sql
+SELECT *, word_similarity('검색어', name) as sim
+FROM blogs
+WHERE '검색어' <% name
+  AND deleted_at IS NULL
+ORDER BY sim DESC;
+```
+
+**특징**:
+- 단어 단위로 유사도 계산
+- `<%` 연산자 사용
+- 긴 문자열에서 짧은 검색어를 찾을 때 유리
+
+#### 4. 복합 검색 (name + displayName 통합)
+```sql
+SELECT * FROM blogs
+WHERE (name || ' ' || COALESCE(display_name, '')) % '검색어'
+  AND deleted_at IS NULL;
+```
+
+**특징**:
+- name과 displayName을 하나로 합쳐서 검색
+- 어느 필드에 있든 검색 가능
+- idx_blogs_combined_trgm 인덱스 활용
+
+### Native Query 예시 (Spring Data JPA)
+
+```kotlin
+interface BlogRepository : JpaRepository<Blog, UUID> {
+
+    // ILIKE 검색
+    @Query(
+        """
+        SELECT b FROM Blog b
+        WHERE (b.name LIKE %:keyword% OR b.displayName LIKE %:keyword%)
+          AND b.deletedAt IS NULL
+        """
+    )
+    fun searchByKeyword(@Param("keyword") keyword: String): List<Blog>
+
+    // 유사도 검색 (Native Query)
+    @Query(
+        value = """
+        SELECT *, similarity(name, :keyword) as sim
+        FROM blogs
+        WHERE name % :keyword
+          AND deleted_at IS NULL
+        ORDER BY sim DESC
+        LIMIT :limit
+        """,
+        nativeQuery = true
+    )
+    fun searchBySimilarity(
+        @Param("keyword") keyword: String,
+        @Param("limit") limit: Int = 10
+    ): List<Blog>
+
+    // 복합 검색
+    @Query(
+        value = """
+        SELECT * FROM blogs
+        WHERE (name || ' ' || COALESCE(display_name, '')) % :keyword
+          AND deleted_at IS NULL
+        ORDER BY similarity((name || ' ' || COALESCE(display_name, '')), :keyword) DESC
+        LIMIT :limit
+        """,
+        nativeQuery = true
+    )
+    fun searchCombined(
+        @Param("keyword") keyword: String,
+        @Param("limit") limit: Int = 10
+    ): List<Blog>
+}
+```
+
+### Similarity Threshold 조정
+
+기본 threshold는 0.3이며, 0.1~0.3 사이로 설정하면 한국어 2글자도 검색 가능합니다.
+
+#### 세션별 설정
+```sql
+SET pg_trgm.similarity_threshold = 0.2;
+```
+
+#### 전역 설정 (application.yml)
+```yaml
+spring:
+  datasource:
+    hikari:
+      connection-init-sql: "SET pg_trgm.similarity_threshold = 0.2"
+```
+
+### 성능 최적화 팁
+
+1. **EXPLAIN ANALYZE로 쿼리 분석**
+```sql
+EXPLAIN ANALYZE
+SELECT * FROM blogs WHERE name % '검색어';
+```
+
+2. **인덱스 사용 확인**
+   - GIN 인덱스가 사용되는지 확인 (`Index Scan using idx_blogs_name_trgm`)
+   - 인덱스가 사용되지 않으면 threshold를 조정하거나 VACUUM 실행
+
+3. **적절한 LIMIT 사용**
+   - 검색 결과가 많을 경우 LIMIT으로 제한
+   - 유사도 순으로 정렬 후 상위 N개만 반환
+
+4. **정기적인 VACUUM**
+```sql
+VACUUM ANALYZE blogs;
+```
+
+### 주의사항
+
+1. **pg_trgm extension이 활성화되어 있어야 함**
+   - V5 migration 실행 시 자동으로 활성화됨
+   - 수동 확인: `SELECT * FROM pg_extension WHERE extname = 'pg_trgm';`
+
+2. **인덱스 재생성이 필요한 경우**
+```sql
+REINDEX INDEX idx_blogs_name_trgm;
+REINDEX INDEX idx_blogs_display_name_trgm;
+REINDEX INDEX idx_blogs_combined_trgm;
+```
+
+3. **매우 짧은 검색어 (1글자)**
+   - trigram은 최소 2글자부터 효과적
+   - 1글자 검색은 ILIKE 사용 권장
+

--- a/main-server/build.gradle.kts
+++ b/main-server/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
@@ -39,6 +40,8 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.security:spring-security-test")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
+    testImplementation("com.h2database:h2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // Flyway

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/articlelink/dto/CrawlerDto.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/articlelink/dto/CrawlerDto.kt
@@ -1,0 +1,23 @@
+package com.techtaurant.mainserver.articlelink.dto
+
+import com.techtaurant.mainserver.articlelink.enums.ArticleLinkType
+import java.util.UUID
+
+/**
+ * 게시글 링크 검증 요청
+ *
+ * @param blogId 블로그 ID
+ * @param baseUrl 크롤링할 기본 URL
+ * @param startPage 시작 페이지 번호
+ * @param articlePattern 게시글 패턴
+ * @param titleSelector 제목 선택자
+ * @param type 게시글 링크 타입
+ */
+data class ValidationRequest(
+    val blogId: UUID,
+    val baseUrl: String,
+    val startPage: Int,
+    val articlePattern: String,
+    val titleSelector: String,
+    val type: ArticleLinkType,
+)

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/articlelink/entity/ArticleLink.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/articlelink/entity/ArticleLink.kt
@@ -1,0 +1,36 @@
+package com.techtaurant.mainserver.articlelink.entity
+
+import com.techtaurant.mainserver.articlelink.enums.ArticleLinkType
+import com.techtaurant.mainserver.blog.entity.Blog
+import com.techtaurant.mainserver.common.base.EntityBase
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.util.Date
+
+@Entity
+@Table(name = "article_links")
+class ArticleLink(
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "blog_id", nullable = false)
+    var blog: Blog,
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    var url: String,
+
+    @Column(length = 500)
+    var title: String?,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    var type: ArticleLinkType,
+
+    @Column(name = "deleted_at")
+    var deletedAt: Date? = null,
+) : EntityBase()

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/articlelink/enums/ArticleLinkType.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/articlelink/enums/ArticleLinkType.kt
@@ -1,0 +1,6 @@
+package com.techtaurant.mainserver.articlelink.enums
+
+enum class ArticleLinkType {
+    PAGE_BASED,
+    NEXT_BUTTON_BASED
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/articlelink/enums/ArticleStatus.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/articlelink/enums/ArticleStatus.kt
@@ -1,0 +1,23 @@
+package com.techtaurant.mainserver.articlelink.enums
+
+import com.techtaurant.mainserver.common.status.StatusIfs
+
+enum class ArticleStatus(
+    private val httpStatusCode: Int,
+    private val customStatusCode: Int,
+    private val description: String,
+) : StatusIfs {
+    ARTICLE_NOT_FOUND(404, 2001, "Article not found"), ;
+
+    override fun getHttpStatusCode(): Int {
+        return this.httpStatusCode
+    }
+
+    override fun getCustomStatusCode(): Int {
+        return this.customStatusCode
+    }
+
+    override fun getDescription(): String {
+        return this.description
+    }
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/articlelink/infrastructure/inport/ArticleLinkController.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/articlelink/infrastructure/inport/ArticleLinkController.kt
@@ -1,0 +1,47 @@
+package com.techtaurant.mainserver.articlelink.infrastructure.inport
+
+import com.techtaurant.mainserver.articlelink.dto.ValidationRequest
+import com.techtaurant.mainserver.articlelink.service.ArticleLinkService
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody as SpringRequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "아티클 링크", description = "아티클 링크 검증 및 저장 API")
+@RestController
+@RequestMapping("/api/v1/article-links")
+class ArticleLinkController(
+    private val articleLinkService: ArticleLinkService,
+) {
+
+    @Operation(
+        summary = "아티클 링크 검증 및 저장",
+        description = "아티클 링크의 유효성을 검증하고 저장합니다."
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "검증 및 저장 성공",
+        content = [Content(schema = Schema(implementation = Boolean::class))]
+    )
+    @SwaggerApiResponse(responseCode = "400", description = "잘못된 요청")
+    @PostMapping
+    fun validateAndSave(
+        @RequestBody(
+            description = "검증할 아티클 링크 정보",
+            required = true,
+            content = [Content(schema = Schema(implementation = ValidationRequest::class))]
+        )
+        @SpringRequestBody request: ValidationRequest
+    ): ResponseEntity<ApiResponse<Boolean>> {
+        val result = articleLinkService.validateAndSave(request)
+        return ResponseEntity.ok(ApiResponse.ok(result))
+    }
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/articlelink/infrastructure/out/ArticleLinkRepository.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/articlelink/infrastructure/out/ArticleLinkRepository.kt
@@ -1,0 +1,12 @@
+package com.techtaurant.mainserver.articlelink.infrastructure.out
+
+import com.techtaurant.mainserver.articlelink.entity.ArticleLink
+import com.techtaurant.mainserver.articlelink.enums.ArticleLinkType
+import com.techtaurant.mainserver.blog.entity.Blog
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface ArticleLinkRepository : JpaRepository<ArticleLink, UUID> {
+    fun findByBlogAndDeletedAtIsNull(blog: Blog): List<ArticleLink>
+    fun findByTypeAndDeletedAtIsNull(type: ArticleLinkType): List<ArticleLink>
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/articlelink/service/ArticleLinkService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/articlelink/service/ArticleLinkService.kt
@@ -1,0 +1,50 @@
+package com.techtaurant.mainserver.articlelink.service
+
+import com.techtaurant.mainserver.articlelink.dto.ValidationRequest
+import com.techtaurant.mainserver.articlelink.entity.ArticleLink
+import com.techtaurant.mainserver.articlelink.infrastructure.out.ArticleLinkRepository
+import com.techtaurant.mainserver.blog.BlogStatus
+import com.techtaurant.mainserver.blog.entity.Blog
+import com.techtaurant.mainserver.blog.infrastructure.out.BlogRepository
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.infrastructure.out.crawler.CrawlerApiClient
+import com.techtaurant.mainserver.infrastructure.out.crawler.dto.PageBaseLinkValidationRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ArticleLinkService(
+    private val articleLinkRepository: ArticleLinkRepository,
+    private val blogRepository: BlogRepository,
+    private val crawlerApiClient: CrawlerApiClient,
+) {
+
+    @Transactional
+    fun validateAndSave(request: ValidationRequest): Boolean {
+        // Blog 조회
+        val blog = blogRepository.findById(request.blogId)
+            .orElseThrow { ApiException(BlogStatus.BLOG_NOT_FOUND) }
+
+        val crawlerRequest = PageBaseLinkValidationRequest(
+            blogName = blog.name,
+            baseUrl = request.baseUrl,
+            startPage = request.startPage,
+            articlePattern = request.articlePattern,
+            titleSelector = request.titleSelector,
+        )
+
+        val isValid = crawlerApiClient.validateCrawlingPage(crawlerRequest)
+
+        if (isValid) {
+            val articleLink = ArticleLink(
+                blog = blog,
+                url = request.baseUrl,
+                title = null,
+                type = request.type,
+            )
+            articleLinkRepository.save(articleLink)
+        }
+
+        return isValid
+    }
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/batchlog/entity/BatchLog.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/batchlog/entity/BatchLog.kt
@@ -1,0 +1,34 @@
+package com.techtaurant.mainserver.batchlog.entity
+
+import com.techtaurant.mainserver.batchlog.enums.BatchStatus
+import com.techtaurant.mainserver.common.base.EntityBase
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+import java.util.Date
+
+@Entity
+@Table(name = "batch_log")
+class BatchLog(
+
+    @Column(name = "batch_name", nullable = false, length = 100)
+    var batchName: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 50)
+    var status: BatchStatus,
+
+    @Column(name = "started_at", nullable = false)
+    var startedAt: Date,
+
+    @Column(name = "finished_at")
+    var finishedAt: Date? = null,
+
+    @Column(name = "error_message", columnDefinition = "TEXT")
+    var errorMessage: String? = null,
+
+    @Column(name = "screenshot_base64", columnDefinition = "TEXT")
+    var screenshotBase64: String? = null,
+) : EntityBase()

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/batchlog/enums/BatchStatus.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/batchlog/enums/BatchStatus.kt
@@ -1,0 +1,7 @@
+package com.techtaurant.mainserver.batchlog.enums
+
+enum class BatchStatus {
+    RUNNING,
+    SUCCESS,
+    FAILED
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/batchlog/infrastructure/out/BatchLogRepository.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/batchlog/infrastructure/out/BatchLogRepository.kt
@@ -1,0 +1,11 @@
+package com.techtaurant.mainserver.batchlog.infrastructure.out
+
+import com.techtaurant.mainserver.batchlog.entity.BatchLog
+import com.techtaurant.mainserver.batchlog.enums.BatchStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface BatchLogRepository : JpaRepository<BatchLog, UUID> {
+    fun findByBatchName(batchName: String): List<BatchLog>
+    fun findByStatus(status: BatchStatus): List<BatchLog>
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/blog/BlogStatus.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/blog/BlogStatus.kt
@@ -1,0 +1,23 @@
+package com.techtaurant.mainserver.blog
+
+import com.techtaurant.mainserver.common.status.StatusIfs
+
+enum class BlogStatus(
+    private val httpStatusCode: Int,
+    private val customStatusCode: Int,
+    private val description: String,
+) : StatusIfs {
+    BLOG_NOT_FOUND(404, 3001, "Blog not found"), ;
+
+    override fun getHttpStatusCode(): Int {
+        return this.httpStatusCode
+    }
+
+    override fun getCustomStatusCode(): Int {
+        return this.customStatusCode
+    }
+
+    override fun getDescription(): String {
+        return this.description
+    }
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/blog/dto/BlogDto.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/blog/dto/BlogDto.kt
@@ -1,0 +1,24 @@
+package com.techtaurant.mainserver.blog.dto
+
+import java.util.UUID
+
+data class BlogCreateRequest(
+    val name: String,
+    val displayName: String?,
+    val iconUrl: String?,
+    val baseUrl: String?,
+)
+
+data class BlogUpdateRequest(
+    val displayName: String?,
+    val iconUrl: String?,
+    val baseUrl: String?,
+)
+
+data class BlogResponse(
+    val id: UUID,
+    val name: String,
+    val displayName: String?,
+    val iconUrl: String?,
+    val baseUrl: String?,
+)

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/blog/entity/Blog.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/blog/entity/Blog.kt
@@ -1,0 +1,38 @@
+package com.techtaurant.mainserver.blog.entity
+
+import com.techtaurant.mainserver.common.base.EntityBase
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+import java.util.Date
+
+/**
+ * 블로그 엔티티
+ *
+ * Soft Delete 적용:
+ * - 삭제 시 실제 DB에서 제거되지 않고 deleted_at에 현재 시간 기록
+ * - 조회 시 deleted_at IS NULL인 데이터만 자동으로 필터링
+ */
+@Entity
+@Table(name = "blogs")
+@SQLDelete(sql = "UPDATE blogs SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+class Blog(
+
+    @Column(nullable = false, length = 100, unique = true)
+    var name: String,
+
+    @Column(name = "display_name", length = 200)
+    var displayName: String?,
+
+    @Column(name = "icon_url", length = 500)
+    var iconUrl: String?,
+
+    @Column(name = "base_url", columnDefinition = "TEXT")
+    var baseUrl: String?,
+
+    @Column(name = "deleted_at")
+    var deletedAt: Date? = null,
+) : EntityBase()

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/blog/infrastructure/inport/AdminBlogController.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/blog/infrastructure/inport/AdminBlogController.kt
@@ -1,0 +1,110 @@
+package com.techtaurant.mainserver.blog.infrastructure.inport
+
+import com.techtaurant.mainserver.blog.dto.BlogCreateRequest
+import com.techtaurant.mainserver.blog.dto.BlogResponse
+import com.techtaurant.mainserver.blog.dto.BlogUpdateRequest
+import com.techtaurant.mainserver.blog.service.BlogService
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody as SpringRequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@Tag(name = "블로그 관리 (Admin)", description = "관리자 전용 블로그 관리 API")
+@SecurityRequirement(name = "Bearer Authentication")
+@RestController
+@RequestMapping("/admin/blogs")
+class AdminBlogController(
+    private val blogService: BlogService,
+) {
+
+    @Operation(
+        summary = "블로그 등록",
+        description = "새로운 블로그를 등록합니다. (관리자 권한 필요)"
+    )
+    @SwaggerApiResponse(
+        responseCode = "201",
+        description = "등록 성공",
+        content = [Content(schema = Schema(implementation = BlogResponse::class))]
+    )
+    @SwaggerApiResponse(responseCode = "400", description = "잘못된 요청")
+    @SwaggerApiResponse(responseCode = "401", description = "인증 실패")
+    @SwaggerApiResponse(responseCode = "403", description = "권한 없음")
+    @PostMapping
+    fun createBlog(
+        @RequestBody(
+            description = "등록할 블로그 정보",
+            required = true,
+            content = [Content(schema = Schema(implementation = BlogCreateRequest::class))]
+        )
+        @SpringRequestBody request: BlogCreateRequest
+    ): ResponseEntity<ApiResponse<BlogResponse>> {
+        val blog = blogService.createBlog(request)
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(blog))
+    }
+
+    @Operation(
+        summary = "블로그 수정",
+        description = "기존 블로그 정보를 수정합니다. (관리자 권한 필요)"
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "수정 성공",
+        content = [Content(schema = Schema(implementation = BlogResponse::class))]
+    )
+    @SwaggerApiResponse(responseCode = "400", description = "잘못된 요청")
+    @SwaggerApiResponse(responseCode = "401", description = "인증 실패")
+    @SwaggerApiResponse(responseCode = "403", description = "권한 없음")
+    @SwaggerApiResponse(
+        responseCode = "404",
+        description = "블로그를 찾을 수 없음 (customStatusCode: 3001)"
+    )
+    @PutMapping("/{id}")
+    fun updateBlog(
+        @Parameter(description = "블로그 ID", required = true)
+        @PathVariable id: UUID,
+        @RequestBody(
+            description = "수정할 블로그 정보",
+            required = true,
+            content = [Content(schema = Schema(implementation = BlogUpdateRequest::class))]
+        )
+        @SpringRequestBody request: BlogUpdateRequest,
+    ): ResponseEntity<ApiResponse<BlogResponse>> {
+        val blog = blogService.updateBlog(id, request)
+        return ResponseEntity.ok(ApiResponse.ok(blog))
+    }
+
+    @Operation(
+        summary = "블로그 삭제",
+        description = "블로그를 삭제합니다. (관리자 권한 필요)"
+    )
+    @SwaggerApiResponse(responseCode = "200", description = "삭제 성공")
+    @SwaggerApiResponse(responseCode = "401", description = "인증 실패")
+    @SwaggerApiResponse(responseCode = "403", description = "권한 없음")
+    @SwaggerApiResponse(
+        responseCode = "404",
+        description = "블로그를 찾을 수 없음 (customStatusCode: 3001)"
+    )
+    @DeleteMapping("/{id}")
+    fun deleteBlog(
+        @Parameter(description = "블로그 ID", required = true)
+        @PathVariable id: UUID
+    ): ResponseEntity<ApiResponse<Unit>> {
+        blogService.deleteBlog(id)
+        return ResponseEntity.ok(ApiResponse.ok())
+    }
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/blog/infrastructure/inport/BlogController.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/blog/infrastructure/inport/BlogController.kt
@@ -1,0 +1,81 @@
+package com.techtaurant.mainserver.blog.infrastructure.inport
+
+import com.techtaurant.mainserver.blog.dto.BlogResponse
+import com.techtaurant.mainserver.blog.service.BlogService
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@Tag(name = "블로그", description = "블로그 조회 API")
+@RestController
+@RequestMapping("/api/v1/blogs")
+class BlogController(
+    private val blogService: BlogService,
+) {
+
+    @Operation(
+        summary = "전체 블로그 목록 조회",
+        description = "등록된 모든 블로그 목록을 조회합니다."
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+        content = [Content(schema = Schema(implementation = BlogResponse::class))]
+    )
+    @GetMapping
+    fun getAllBlogs(): ResponseEntity<ApiResponse<List<BlogResponse>>> {
+        val blogs = blogService.getAllBlogs()
+        return ResponseEntity.ok(ApiResponse.ok(blogs))
+    }
+
+    @Operation(
+        summary = "블로그 단건 조회",
+        description = "ID로 특정 블로그를 조회합니다."
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+        content = [Content(schema = Schema(implementation = BlogResponse::class))]
+    )
+    @SwaggerApiResponse(
+        responseCode = "404",
+        description = "블로그를 찾을 수 없음 (customStatusCode: 3001)"
+    )
+    @GetMapping("/{id}")
+    fun getBlogById(
+        @Parameter(description = "블로그 ID", required = true)
+        @PathVariable id: UUID
+    ): ResponseEntity<ApiResponse<BlogResponse>> {
+        val blog = blogService.getBlogById(id)
+        return ResponseEntity.ok(ApiResponse.ok(blog))
+    }
+
+    @Operation(
+        summary = "블로그 검색 (Full Text Search)",
+        description = "Trigram 유사도 기반 Full Text Search로 블로그를 검색합니다. name과 displayName을 통합 검색하며, 부분 문자열 매칭 및 오타를 허용합니다. 유사도 순으로 정렬된 결과를 최대 10개 반환합니다."
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "검색 성공 (결과가 없을 경우 빈 배열 반환)",
+        content = [Content(schema = Schema(implementation = BlogResponse::class))]
+    )
+    @GetMapping("/search")
+    fun searchBlogByName(
+        @Parameter(description = "검색 키워드 (2글자 이상 권장)", required = true)
+        @RequestParam keyword: String
+    ): ResponseEntity<ApiResponse<List<BlogResponse>>> {
+        val blogs = blogService.searchBlogByName(keyword)
+        return ResponseEntity.ok(ApiResponse.ok(blogs))
+    }
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/blog/infrastructure/out/BlogRepository.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/blog/infrastructure/out/BlogRepository.kt
@@ -1,0 +1,46 @@
+package com.techtaurant.mainserver.blog.infrastructure.out
+
+import com.techtaurant.mainserver.blog.entity.Blog
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.UUID
+
+interface BlogRepository : JpaRepository<Blog, UUID> {
+    fun findByNameAndDeletedAtIsNull(name: String): Blog?
+    fun findByDeletedAtIsNull(): List<Blog>
+
+    /**
+     * ILIKE를 사용한 부분 문자열 검색
+     * name 또는 displayName에 keyword가 포함된 블로그를 검색
+     */
+    @Query(
+        """
+        SELECT b FROM Blog b
+        WHERE (LOWER(b.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+           OR LOWER(b.displayName) LIKE LOWER(CONCAT('%', :keyword, '%')))
+          AND b.deletedAt IS NULL
+        """
+    )
+    fun searchByKeyword(@Param("keyword") keyword: String): List<Blog>
+
+    /**
+     * Trigram 유사도 검색 (Full Text Index 활용)
+     * name + displayName 복합 검색으로 유사도 순 정렬
+     * pg_trgm extension과 GIN 인덱스 활용
+     */
+    @Query(
+        value = """
+        SELECT * FROM blogs
+        WHERE (name || ' ' || COALESCE(display_name, '')) % :keyword
+          AND deleted_at IS NULL
+        ORDER BY similarity((name || ' ' || COALESCE(display_name, '')), :keyword) DESC
+        LIMIT :limit
+        """,
+        nativeQuery = true
+    )
+    fun searchByTrigramSimilarity(
+        @Param("keyword") keyword: String,
+        @Param("limit") limit: Int = 10
+    ): List<Blog>
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/blog/service/BlogService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/blog/service/BlogService.kt
@@ -1,0 +1,92 @@
+package com.techtaurant.mainserver.blog.service
+
+import com.techtaurant.mainserver.blog.BlogStatus
+import com.techtaurant.mainserver.blog.dto.BlogCreateRequest
+import com.techtaurant.mainserver.blog.dto.BlogResponse
+import com.techtaurant.mainserver.blog.dto.BlogUpdateRequest
+import com.techtaurant.mainserver.blog.entity.Blog
+import com.techtaurant.mainserver.blog.infrastructure.out.BlogRepository
+import com.techtaurant.mainserver.common.exception.ApiException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class BlogService(
+    private val blogRepository: BlogRepository,
+) {
+
+    @Transactional
+    fun createBlog(request: BlogCreateRequest): BlogResponse {
+        val blog = Blog(
+            name = request.name,
+            displayName = request.displayName,
+            iconUrl = request.iconUrl,
+            baseUrl = request.baseUrl,
+        )
+        val savedBlog = blogRepository.save(blog)
+        return savedBlog.toResponse()
+    }
+
+    @Transactional
+    fun updateBlog(id: UUID, request: BlogUpdateRequest): BlogResponse {
+        val blog = blogRepository.findById(id)
+            .orElseThrow { ApiException(BlogStatus.BLOG_NOT_FOUND, "Blog not found with id: $id") }
+
+        request.displayName?.let { blog.displayName = it }
+        request.iconUrl?.let { blog.iconUrl = it }
+        request.baseUrl?.let { blog.baseUrl = it }
+
+        return blog.toResponse()
+    }
+
+    /**
+     * 블로그를 소프트 삭제합니다.
+     *
+     * @param id 삭제할 블로그의 UUID
+     * @throws ApiException 블로그를 찾을 수 없는 경우 (BlogStatus.BLOG_NOT_FOUND)
+     *
+     * 주의: Soft Delete가 적용되어 실제 DB에서 삭제되지 않고 deleted_at만 업데이트됨
+     */
+    @Transactional
+    fun deleteBlog(id: UUID) {
+        val blog = blogRepository.findById(id)
+            .orElseThrow { ApiException(BlogStatus.BLOG_NOT_FOUND, "Blog not found with id: $id") }
+        // @SQLDelete 어노테이션에 의해 실제로는 UPDATE blogs SET deleted_at = CURRENT_TIMESTAMP 실행
+        blogRepository.delete(blog)
+    }
+
+    @Transactional(readOnly = true)
+    fun getBlogById(id: UUID): BlogResponse {
+        val blog = blogRepository.findById(id)
+            .orElseThrow { ApiException(BlogStatus.BLOG_NOT_FOUND, "Blog not found with id: $id") }
+        return blog.toResponse()
+    }
+
+    @Transactional(readOnly = true)
+    fun getAllBlogs(): List<BlogResponse> {
+        return blogRepository.findByDeletedAtIsNull()
+            .map { it.toResponse() }
+    }
+
+    /**
+     * Full Text Search를 사용한 블로그 검색
+     * Trigram 유사도 기반으로 name과 displayName을 통합 검색
+     *
+     * @param keyword 검색 키워드
+     * @return 유사도 순으로 정렬된 블로그 목록 (최대 10개)
+     */
+    @Transactional(readOnly = true)
+    fun searchBlogByName(keyword: String): List<BlogResponse> {
+        return blogRepository.searchByTrigramSimilarity(keyword, 10)
+            .map { it.toResponse() }
+    }
+
+    private fun Blog.toResponse() = BlogResponse(
+        id = id!!,
+        name = name,
+        displayName = displayName,
+        iconUrl = iconUrl,
+        baseUrl = baseUrl,
+    )
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/common/config/ApiClientConfig.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/common/config/ApiClientConfig.kt
@@ -1,0 +1,37 @@
+package com.techtaurant.mainserver.common.config
+
+import com.techtaurant.mainserver.infrastructure.out.crawler.CrawlerApiClient
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.web.client.RestClient
+import java.time.Duration
+
+/**
+ * 외부 API 클라이언트 설정
+ *
+ * Infrastructure Out 레이어의 API 클라이언트들에 대한 RestClient 빈 생성
+ */
+@Configuration
+class ApiClientConfig(
+    @Value("\${crawler.api.base-url}")
+    private val crawlerApiBaseUrl: String,
+) {
+
+    /**
+     * 크롤러 API 클라이언트 빈 생성
+     *
+     * @return CrawlerApiClient 인스턴스
+     */
+    @Bean
+    fun crawlerApiClient(): CrawlerApiClient {
+        val restClient = RestClient.builder()
+            .baseUrl(crawlerApiBaseUrl)
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .build()
+
+        return CrawlerApiClient(restClient)
+    }
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/common/config/SwaggerConfig.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/common/config/SwaggerConfig.kt
@@ -1,0 +1,33 @@
+package com.techtaurant.mainserver.common.config
+
+import com.techtaurant.mainserver.security.jwt.JwtConstants
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+
+@Configuration
+class SwaggerConfig {
+    @Bean
+    fun openAPI(): OpenAPI? {
+        // 실제 쿠키 이름을 여기에 넣으세요 (예: "accessToken", "JSESSIONID" 등)
+        val cookieName = JwtConstants.ACCESS_TOKEN_COOKIE
+        val securityName = "CookieAuth"
+
+        val securityRequirement: SecurityRequirement = SecurityRequirement().addList(securityName)
+
+        val components = Components().addSecuritySchemes(
+            securityName, SecurityScheme()
+                .name(cookieName) // 쿠키의 키(Key) 이름
+                .type(SecurityScheme.Type.APIKEY) // 쿠키는 APIKEY 타입으로 설정
+                .`in`(SecurityScheme.In.COOKIE) // 위치는 COOKIE
+        )
+
+        return OpenAPI()
+            .components(components)
+            .addSecurityItem(securityRequirement)
+    }
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/infrastructure/out/crawler/CrawlerApiClient.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/infrastructure/out/crawler/CrawlerApiClient.kt
@@ -1,0 +1,46 @@
+package com.techtaurant.mainserver.infrastructure.out.crawler
+
+import com.techtaurant.mainserver.infrastructure.out.crawler.dto.CrawlerApiResponse
+import com.techtaurant.mainserver.infrastructure.out.crawler.dto.PageBaseLinkValidationRequest
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.web.client.RestClient
+
+/**
+ * 크롤러 API 클라이언트
+ *
+ * 외부 크롤러 서비스와 통신하는 Infrastructure Out 레이어
+ * RestClient를 사용하여 동기 방식으로 API 호출
+ */
+class CrawlerApiClient(
+    private val restClient: RestClient
+) {
+
+    /**
+     * 크롤링 페이지 검증
+     *
+     * @param request 검증 요청 정보
+     * @return 검증 성공 여부 (에러 발생 시 false 반환)
+     */
+    fun validateCrawlingPage(request: PageBaseLinkValidationRequest): Boolean {
+        return try {
+            val response = restClient.post()
+                .uri("/api/v1/page-base-link-crawling/validations")
+                .body(
+                    mapOf(
+                        "blog_name" to request.blogName,
+                        "base_url" to request.baseUrl,
+                        "start_page" to request.startPage,
+                        "article_pattern" to request.articlePattern,
+                        "title_selector" to request.titleSelector,
+                    )
+                )
+                .retrieve()
+                .body(object : ParameterizedTypeReference<CrawlerApiResponse<Boolean>>() {})
+
+            response?.data ?: false
+        } catch (e: Exception) {
+            // 에러 발생 시 false 반환
+            false
+        }
+    }
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/infrastructure/out/crawler/dto/CrawlerApiResponse.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/infrastructure/out/crawler/dto/CrawlerApiResponse.kt
@@ -1,0 +1,19 @@
+package com.techtaurant.mainserver.infrastructure.out.crawler.dto
+
+/**
+ * 크롤러 API 공통 응답 형식
+ *
+ * @param T 응답 데이터 타입
+ * @param success 성공 여부
+ * @param status HTTP 상태 코드
+ * @param message 응답 메시지
+ * @param data 응답 데이터
+ * @param timestamp 응답 시간
+ */
+data class CrawlerApiResponse<T>(
+    val success: Boolean,
+    val status: String,
+    val message: String,
+    val data: T,
+    val timestamp: String,
+)

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/infrastructure/out/crawler/dto/PageBaseLinkValidationRequest.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/infrastructure/out/crawler/dto/PageBaseLinkValidationRequest.kt
@@ -1,0 +1,18 @@
+package com.techtaurant.mainserver.infrastructure.out.crawler.dto
+
+/**
+ * 페이지 기반 링크 크롤링 검증 요청
+ *
+ * @param blogName 블로그 이름
+ * @param baseUrl 크롤링할 기본 URL
+ * @param startPage 시작 페이지 번호 (기본값: 0)
+ * @param articlePattern 게시글 패턴 (기본값: 빈 문자열)
+ * @param titleSelector 제목 선택자 (기본값: 빈 문자열)
+ */
+data class PageBaseLinkValidationRequest(
+    val blogName: String,
+    val baseUrl: String,
+    val startPage: Int = 0,
+    val articlePattern: String = "",
+    val titleSelector: String = "",
+)

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/security/config/SecurityConfig.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/security/config/SecurityConfig.kt
@@ -54,6 +54,7 @@ class SecurityConfig(
                     .requestMatchers(
                         "/open-api/**"
                     ).permitAll()
+                    .requestMatchers("/admin/**").hasRole("ADMIN")
                     .anyRequest().authenticated()
             }
             .oauth2Login { oauth2 ->

--- a/main-server/src/main/resources/application.yml
+++ b/main-server/src/main/resources/application.yml
@@ -68,3 +68,8 @@ cookie:
   http-only: ${COOKIE_HTTP_ONLY:true}
   same-site: ${COOKIE_SAME_SITE:Lax}
   path: ${COOKIE_PATH:/}
+
+# Crawler API
+crawler:
+  api:
+    base-url: ${CRAWLER_API_BASE_URL:http://localhost:8000}

--- a/main-server/src/main/resources/db/migration/V2__create_blogs.sql
+++ b/main-server/src/main/resources/db/migration/V2__create_blogs.sql
@@ -1,0 +1,13 @@
+CREATE TABLE blogs (
+    id UUID PRIMARY KEY,
+    name VARCHAR(100) NOT NULL UNIQUE,
+    display_name VARCHAR(200),
+    icon_url VARCHAR(500),
+    base_url TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP
+);
+
+CREATE INDEX idx_blogs_name ON blogs(name);
+CREATE INDEX idx_blogs_deleted_at ON blogs(deleted_at);

--- a/main-server/src/main/resources/db/migration/V3__create_article_links.sql
+++ b/main-server/src/main/resources/db/migration/V3__create_article_links.sql
@@ -1,0 +1,15 @@
+CREATE TABLE article_links (
+    id UUID PRIMARY KEY,
+    blog_id UUID NOT NULL,
+    url TEXT NOT NULL,
+    title VARCHAR(500),
+    type VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at TIMESTAMP,
+    CONSTRAINT fk_article_links_blog FOREIGN KEY (blog_id) REFERENCES blogs(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_article_links_blog_id ON article_links(blog_id);
+CREATE INDEX idx_article_links_type ON article_links(type);
+CREATE INDEX idx_article_links_deleted_at ON article_links(deleted_at);

--- a/main-server/src/main/resources/db/migration/V4__create_batch_log.sql
+++ b/main-server/src/main/resources/db/migration/V4__create_batch_log.sql
@@ -1,0 +1,15 @@
+CREATE TABLE batch_log (
+    id UUID PRIMARY KEY,
+    batch_name VARCHAR(100) NOT NULL,
+    status VARCHAR(50) NOT NULL,
+    started_at TIMESTAMP NOT NULL,
+    finished_at TIMESTAMP,
+    error_message TEXT,
+    screenshot_base64 TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_batch_log_batch_name ON batch_log(batch_name);
+CREATE INDEX idx_batch_log_status ON batch_log(status);
+CREATE INDEX idx_batch_log_started_at ON batch_log(started_at);

--- a/main-server/src/main/resources/db/migration/V5__create_fulltext_index_for_blogs.sql
+++ b/main-server/src/main/resources/db/migration/V5__create_fulltext_index_for_blogs.sql
@@ -1,0 +1,41 @@
+-- V5: 블로그 Full Text Search를 위한 인덱스 생성
+-- pg_trgm extension을 사용한 한국어 검색 지원 (2글자 이상)
+
+-- pg_trgm extension 활성화 (trigram 기반 유사도 검색)
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- name 컬럼에 GIN 인덱스 생성 (trigram ops 사용)
+-- 이 인덱스는 LIKE, ILIKE, similarity 연산자를 빠르게 처리
+CREATE INDEX idx_blogs_name_trgm ON blogs USING GIN (name gin_trgm_ops);
+
+-- display_name 컬럼에 GIN 인덱스 생성
+CREATE INDEX idx_blogs_display_name_trgm ON blogs USING GIN (display_name gin_trgm_ops);
+
+-- 복합 검색을 위한 GIN 인덱스 (name과 display_name 통합 검색)
+-- 사용 예시: SELECT * FROM blogs WHERE (name || ' ' || COALESCE(display_name, '')) % '검색어';
+CREATE INDEX idx_blogs_combined_trgm ON blogs USING GIN ((name || ' ' || COALESCE(display_name, '')) gin_trgm_ops);
+
+-- 사용법 예시:
+-- 1. ILIKE를 사용한 부분 일치 검색 (정확한 부분 문자열)
+--    SELECT * FROM blogs WHERE name ILIKE '%검색어%';
+--
+-- 2. similarity 함수를 사용한 유사도 검색 (오타 허용)
+--    SELECT *, similarity(name, '검색어') as sim
+--    FROM blogs
+--    WHERE name % '검색어'
+--    ORDER BY sim DESC;
+--
+-- 3. word_similarity를 사용한 단어 단위 유사도 검색
+--    SELECT *, word_similarity('검색어', name) as sim
+--    FROM blogs
+--    WHERE '검색어' <% name
+--    ORDER BY sim DESC;
+--
+-- 4. 복합 검색 (name 또는 display_name에서 검색)
+--    SELECT * FROM blogs
+--    WHERE (name || ' ' || COALESCE(display_name, '')) % '검색어';
+
+-- 성능 최적화를 위한 similarity threshold 설정 (선택적)
+-- 기본값은 0.3이며, 0.1~0.3 사이로 설정하면 한국어 2글자도 검색 가능
+-- SET pg_trgm.similarity_threshold = 0.2;
+-- 이 설정은 세션별로 적용되며, application.yml에서 전역 설정 가능

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/articlelink/infrastructure/inport/ArticleLinkControllerTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/articlelink/infrastructure/inport/ArticleLinkControllerTest.kt
@@ -1,0 +1,126 @@
+package com.techtaurant.mainserver.articlelink.infrastructure.inport
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.techtaurant.mainserver.articlelink.dto.ValidationRequest
+import com.techtaurant.mainserver.articlelink.enums.ArticleLinkType
+import com.techtaurant.mainserver.blog.entity.Blog
+import com.techtaurant.mainserver.blog.infrastructure.out.BlogRepository
+import com.techtaurant.mainserver.infrastructure.out.crawler.CrawlerApiClient
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class ArticleLinkControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var blogRepository: BlogRepository
+
+    @MockBean
+    private lateinit var crawlerApiClient: CrawlerApiClient
+
+    private lateinit var testBlogId: UUID
+    private lateinit var validationRequest: ValidationRequest
+
+    @BeforeEach
+    fun setUp() {
+        val savedBlog = blogRepository.save(
+            Blog(
+                name = "test-blog",
+                displayName = "테스트 블로그",
+                iconUrl = "https://example.com/icon.png",
+                baseUrl = "https://example.com",
+            ),
+        )
+        testBlogId = savedBlog.id!!
+
+        validationRequest = ValidationRequest(
+            blogId = testBlogId,
+            baseUrl = "https://example.com",
+            startPage = 1,
+            articlePattern = "/articles/",
+            titleSelector = "h1.title",
+            type = ArticleLinkType.PAGE_BASED,
+        )
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/article-links/validate-and-save - 링크 검증 및 저장 성공")
+    @WithMockUser
+    fun validateAndSave_Success() {
+        // Given
+        whenever(crawlerApiClient.validateCrawlingPage(any())).thenReturn(true)
+
+        // When & Then
+        mockMvc.perform(
+            post("/api/v1/article-links/validate-and-save")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(validationRequest)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data").value(true))
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/article-links/validate-and-save - 링크 검증 실패")
+    @WithMockUser
+    fun validateAndSave_Failure() {
+        // Given
+        whenever(crawlerApiClient.validateCrawlingPage(any())).thenReturn(false)
+
+        // When & Then
+        mockMvc.perform(
+            post("/api/v1/article-links/validate-and-save")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(validationRequest)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data").value(false))
+    }
+
+    @Test
+    @DisplayName("POST /api/v1/article-links/validate-and-save - NEXT_BUTTON_BASED 타입 테스트")
+    @WithMockUser
+    fun validateAndSave_NextButtonBasedType() {
+        // Given
+        val nextButtonRequest = validationRequest.copy(type = ArticleLinkType.NEXT_BUTTON_BASED)
+        whenever(crawlerApiClient.validateCrawlingPage(any())).thenReturn(true)
+
+        // When & Then
+        mockMvc.perform(
+            post("/api/v1/article-links/validate-and-save")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(nextButtonRequest)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data").value(true))
+    }
+}

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/blog/infrastructure/inport/AdminBlogControllerTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/blog/infrastructure/inport/AdminBlogControllerTest.kt
@@ -1,0 +1,114 @@
+package com.techtaurant.mainserver.blog.infrastructure.inport
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.techtaurant.mainserver.blog.dto.BlogCreateRequest
+import com.techtaurant.mainserver.blog.dto.BlogUpdateRequest
+import com.techtaurant.mainserver.blog.infrastructure.out.BlogRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class AdminBlogControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var blogRepository: BlogRepository
+
+    private lateinit var testBlogId: UUID
+    private lateinit var createRequest: BlogCreateRequest
+    private lateinit var updateRequest: BlogUpdateRequest
+
+    @BeforeEach
+    fun setUp() {
+        val savedBlog = blogRepository.save(
+            com.techtaurant.mainserver.blog.entity.Blog(
+                name = "existing-blog",
+                displayName = "기존 블로그",
+                iconUrl = "https://example.com/icon.png",
+                baseUrl = "https://example.com",
+            ),
+        )
+        testBlogId = savedBlog.id!!
+
+        createRequest = BlogCreateRequest(
+            name = "new-blog",
+            displayName = "새로운 블로그",
+            iconUrl = "https://example.com/new-icon.png",
+            baseUrl = "https://newblog.com",
+        )
+        updateRequest = BlogUpdateRequest(
+            displayName = "수정된 블로그",
+            iconUrl = "https://example.com/updated-icon.png",
+            baseUrl = "https://example.com/updated",
+        )
+    }
+
+    @Test
+    @DisplayName("POST /admin/blogs - ADMIN 권한으로 블로그 생성 성공")
+    @WithMockUser(roles = ["ADMIN"])
+    fun createBlog_Success_WithAdmin() {
+        // When & Then
+        mockMvc.perform(
+            post("/admin/blogs")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createRequest))
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data.name").value("new-blog"))
+            .andExpect(jsonPath("$.data.displayName").value("새로운 블로그"))
+    }
+
+    @Test
+    @DisplayName("PUT /admin/blogs/{id} - ADMIN 권한으로 블로그 수정 성공")
+    @WithMockUser(roles = ["ADMIN"])
+    fun updateBlog_Success_WithAdmin() {
+        // When & Then
+        mockMvc.perform(
+            put("/admin/blogs/{id}", testBlogId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateRequest)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data.id").value(testBlogId.toString()))
+            .andExpect(jsonPath("$.data.displayName").value("수정된 블로그"))
+    }
+
+    @Test
+    @DisplayName("DELETE /admin/blogs/{id} - ADMIN 권한으로 블로그 삭제 성공")
+    @WithMockUser(roles = ["ADMIN"])
+    fun deleteBlog_Success_WithAdmin() {
+        // When & Then
+        mockMvc.perform(
+            delete("/admin/blogs/{id}", testBlogId)
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.message").value("OK"))
+    }
+}

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/blog/infrastructure/inport/BlogControllerTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/blog/infrastructure/inport/BlogControllerTest.kt
@@ -1,0 +1,115 @@
+package com.techtaurant.mainserver.blog.infrastructure.inport
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.techtaurant.mainserver.blog.entity.Blog
+import com.techtaurant.mainserver.blog.infrastructure.out.BlogRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class BlogControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var blogRepository: BlogRepository
+
+    private lateinit var testBlogId: UUID
+    private lateinit var testBlog: Blog
+
+    @BeforeEach
+    fun setUp() {
+        testBlog = Blog(
+            name = "test-blog",
+            displayName = "테스트 블로그",
+            iconUrl = "https://example.com/icon.png",
+            baseUrl = "https://example.com",
+        )
+        testBlog = blogRepository.save(testBlog)
+        testBlogId = testBlog.id!!
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/blogs - 모든 블로그 조회 성공")
+    @WithMockUser
+    fun getAllBlogs_Success() {
+        // When & Then
+        mockMvc.perform(
+            get("/api/v1/blogs")
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data[0].id").value(testBlogId.toString()))
+            .andExpect(jsonPath("$.data[0].name").value("test-blog"))
+            .andExpect(jsonPath("$.data[0].displayName").value("테스트 블로그"))
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/blogs/{id} - ID로 블로그 조회 성공")
+    @WithMockUser
+    fun getBlogById_Success() {
+        // When & Then
+        mockMvc.perform(
+            get("/api/v1/blogs/{id}", testBlogId)
+                .contentType(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data.id").value(testBlogId.toString()))
+            .andExpect(jsonPath("$.data.name").value("test-blog"))
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/blogs/search - 이름으로 블로그 검색 성공")
+    @WithMockUser
+    fun searchBlogByName_Success() {
+        // When & Then
+        mockMvc.perform(
+            get("/api/v1/blogs/search")
+                .param("name", "test-blog")
+                .contentType(MediaType.APPLICATION_JSON),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data.name").value("test-blog"))
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/blogs/search - 블로그 없음 (null 반환)")
+    @WithMockUser
+    fun searchBlogByName_NotFound() {
+        // When & Then
+        mockMvc.perform(
+            get("/api/v1/blogs/search")
+                .param("name", "nonexistent")
+                .contentType(MediaType.APPLICATION_JSON),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.message").value("OK"))
+            .andExpect(jsonPath("$.data").isEmpty)
+    }
+}

--- a/main-server/src/test/resources/application.yml
+++ b/main-server/src/test/resources/application.yml
@@ -1,0 +1,53 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+  flyway:
+    enabled: false
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test-client-id
+            client-secret: test-client-secret
+            scope: profile, email
+        provider:
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+
+crawler:
+  api:
+    base-url: http://localhost:8000
+    timeout: 30000
+
+jwt:
+  secret: test-secret-key-for-jwt-token-generation-and-validation-minimum-256-bits
+  access-token-expiration: 3600000
+  refresh-token-expiration: 86400000
+
+cors:
+  allowed-origins: http://localhost:3000
+  allowed-methods: GET,POST,PUT,DELETE,OPTIONS
+  allowed-headers: "*"
+  allow-credentials: true
+
+cookie:
+  domain: localhost
+  secure: false
+  http-only: true
+  same-site: Lax
+  max-age: 86400
+
+oauth2:
+  redirect:
+    success-url: http://localhost:3000/auth/success
+    failure-url: http://localhost:3000/auth/failure

--- a/techtaurant-crawler/.gitignore
+++ b/techtaurant-crawler/.gitignore
@@ -2,3 +2,5 @@ CLAUDE.md
 .claude
 GEMINI.md
 .gemini
+.agent
+.github/prompts

--- a/techtaurant-crawler/app/configs/config.py
+++ b/techtaurant-crawler/app/configs/config.py
@@ -37,7 +37,6 @@ class Settings(BaseSettings):
     # Redis
     REDIS_HOST: str = "localhost"
     REDIS_PORT: int = 6379
-    REDIS_DB: int = 0
     REDIS_PASSWORD: str | None = None
 
     # CORS

--- a/techtaurant-crawler/app/configs/redis.py
+++ b/techtaurant-crawler/app/configs/redis.py
@@ -34,7 +34,6 @@ class RedisClient:
             self._redis = await Redis(
                 host=settings.REDIS_HOST,
                 port=settings.REDIS_PORT,
-                db=settings.REDIS_DB,
                 password=settings.REDIS_PASSWORD,
                 decode_responses=True,
                 encoding="utf-8",

--- a/techtaurant-crawler/app/domains/article_link/entity/article_link.py
+++ b/techtaurant-crawler/app/domains/article_link/entity/article_link.py
@@ -1,0 +1,52 @@
+"""
+ArticleLink 엔티티
+
+크롤링한 게시글 링크 목록을 저장하는 모델
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum as PyEnum
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.configs.database import Base
+
+if TYPE_CHECKING:
+    from app.domains.blog.entity.blog import Blog
+
+
+class ArticleLinkType(str, PyEnum):
+    """게시글 링크 타입"""
+
+    PAGE_BASED = "PAGE_BASED"
+    NEXT_BUTTON_BASED = "NEXT_BUTTON_BASED"
+
+
+class ArticleLink(Base):
+    """
+    게시글 링크 정보
+
+    크롤링된 게시글 링크 목록을 저장합니다.
+    """
+
+    __tablename__ = "article_links"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    blog_id: Mapped[UUID] = mapped_column(ForeignKey("blogs.id", ondelete="CASCADE"), nullable=False, index=True)
+    url: Mapped[str] = mapped_column(Text, nullable=False)
+    title: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, index=True)
+
+    # Relationship
+    blog: Mapped[Blog] = relationship("Blog", back_populates="article_links")

--- a/techtaurant-crawler/app/domains/article_link/infrastructure/article_link_repository.py
+++ b/techtaurant-crawler/app/domains/article_link/infrastructure/article_link_repository.py
@@ -1,0 +1,62 @@
+"""
+ArticleLink Repository
+
+게시글 링크 데이터베이스 작업을 처리하는 레포지토리
+"""
+
+from collections.abc import Sequence
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains.article_link.entity.article_link import ArticleLink, ArticleLinkType
+
+
+class ArticleLinkRepository:
+    """게시글 링크 레포지토리"""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(self, article_link: ArticleLink) -> ArticleLink:
+        """게시글 링크 생성"""
+        self.session.add(article_link)
+        await self.session.flush()
+        return article_link
+
+    async def create_bulk(self, article_links: list[ArticleLink]) -> list[ArticleLink]:
+        """게시글 링크 일괄 생성"""
+        self.session.add_all(article_links)
+        await self.session.flush()
+        return article_links
+
+    async def find_by_id(self, id: UUID) -> ArticleLink | None:
+        """ID로 게시글 링크 조회"""
+        result = await self.session.execute(select(ArticleLink).where(ArticleLink.id == id))
+        return result.scalar_one_or_none()
+
+    async def find_by_blog_id(self, blog_id: UUID) -> Sequence[ArticleLink]:
+        """블로그 ID로 게시글 링크 목록 조회 (삭제되지 않은 것만)"""
+        result = await self.session.execute(
+            select(ArticleLink).where(
+                ArticleLink.blog_id == blog_id, ArticleLink.deleted_at.is_(None)
+            )
+        )
+        return result.scalars().all()
+
+    async def find_by_type(self, type: ArticleLinkType) -> Sequence[ArticleLink]:
+        """타입으로 게시글 링크 목록 조회 (삭제되지 않은 것만)"""
+        result = await self.session.execute(
+            select(ArticleLink).where(ArticleLink.type == type, ArticleLink.deleted_at.is_(None))
+        )
+        return result.scalars().all()
+
+    async def soft_delete(self, id: UUID) -> ArticleLink | None:
+        """게시글 링크 소프트 삭제"""
+        article_link = await self.find_by_id(id)
+        if article_link:
+            article_link.deleted_at = datetime.utcnow()
+            await self.session.flush()
+        return article_link

--- a/techtaurant-crawler/app/domains/batch_log/entity/batch_log.py
+++ b/techtaurant-crawler/app/domains/batch_log/entity/batch_log.py
@@ -1,0 +1,45 @@
+"""
+BatchLog 엔티티
+
+배치 작업 로그를 저장하는 모델
+"""
+
+from datetime import datetime
+from enum import Enum as PyEnum
+from uuid import UUID, uuid4
+
+from sqlalchemy import DateTime, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.configs.database import Base
+
+
+class BatchStatus(str, PyEnum):
+    """배치 상태"""
+
+    RUNNING = "RUNNING"
+    SUCCESS = "SUCCESS"
+    FAILED = "FAILED"
+
+
+class BatchLog(Base):
+    """
+    배치 작업 로그
+
+    배치 실행 기록을 저장합니다.
+    """
+
+    __tablename__ = "batch_log"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    batch_name: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    started_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, index=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    screenshot_base64: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow
+    )

--- a/techtaurant-crawler/app/domains/batch_log/infrastructure/batch_log_repository.py
+++ b/techtaurant-crawler/app/domains/batch_log/infrastructure/batch_log_repository.py
@@ -1,0 +1,48 @@
+"""
+BatchLog Repository
+
+배치 로그 데이터베이스 작업을 처리하는 레포지토리
+"""
+
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains.batch_log.entity.batch_log import BatchLog, BatchStatus
+
+
+class BatchLogRepository:
+    """배치 로그 레포지토리"""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(self, batch_log: BatchLog) -> BatchLog:
+        """배치 로그 생성"""
+        self.session.add(batch_log)
+        await self.session.flush()
+        return batch_log
+
+    async def find_by_id(self, id: UUID) -> BatchLog | None:
+        """ID로 배치 로그 조회"""
+        result = await self.session.execute(select(BatchLog).where(BatchLog.id == id))
+        return result.scalar_one_or_none()
+
+    async def find_by_batch_name(self, batch_name: str) -> Sequence[BatchLog]:
+        """배치 이름으로 로그 목록 조회"""
+        result = await self.session.execute(
+            select(BatchLog).where(BatchLog.batch_name == batch_name)
+        )
+        return result.scalars().all()
+
+    async def find_by_status(self, status: BatchStatus) -> Sequence[BatchLog]:
+        """상태로 배치 로그 목록 조회"""
+        result = await self.session.execute(select(BatchLog).where(BatchLog.status == status))
+        return result.scalars().all()
+
+    async def update(self, batch_log: BatchLog) -> BatchLog:
+        """배치 로그 업데이트"""
+        await self.session.flush()
+        return batch_log

--- a/techtaurant-crawler/app/domains/blog/entity/blog.py
+++ b/techtaurant-crawler/app/domains/blog/entity/blog.py
@@ -1,0 +1,46 @@
+"""
+Blog 엔티티
+
+블로그 정보를 저장하는 모델
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID, uuid4
+
+from sqlalchemy import DateTime, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.configs.database import Base
+
+if TYPE_CHECKING:
+    from app.domains.article_link.entity.article_link import ArticleLink
+
+
+class Blog(Base):
+    """
+    블로그 정보
+
+    크롤링 대상 블로그의 기본 정보를 저장합니다.
+    """
+
+    __tablename__ = "blogs"
+
+    id: Mapped[UUID] = mapped_column(primary_key=True, default=uuid4)
+    name: Mapped[str] = mapped_column(String(100), nullable=False, unique=True, index=True)
+    display_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    icon_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    base_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, index=True)
+
+    # Relationship
+    article_links: Mapped[list[ArticleLink]] = relationship(
+        "ArticleLink", back_populates="blog", cascade="all, delete-orphan"
+    )

--- a/techtaurant-crawler/app/domains/blog/infrastructure/blog_repository.py
+++ b/techtaurant-crawler/app/domains/blog/infrastructure/blog_repository.py
@@ -1,0 +1,43 @@
+"""
+Blog Repository
+
+블로그 데이터베이스 작업을 처리하는 레포지토리
+"""
+
+from typing import Sequence
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains.blog.entity.blog import Blog
+
+
+class BlogRepository:
+    """블로그 레포지토리"""
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def create(self, blog: Blog) -> Blog:
+        """블로그 생성"""
+        self.session.add(blog)
+        await self.session.flush()
+        return blog
+
+    async def find_by_id(self, id: UUID) -> Blog | None:
+        """ID로 블로그 조회"""
+        result = await self.session.execute(select(Blog).where(Blog.id == id))
+        return result.scalar_one_or_none()
+
+    async def find_by_name(self, name: str) -> Blog | None:
+        """이름으로 블로그 조회 (삭제되지 않은 것만)"""
+        result = await self.session.execute(
+            select(Blog).where(Blog.name == name, Blog.deleted_at.is_(None))
+        )
+        return result.scalar_one_or_none()
+
+    async def find_all(self) -> Sequence[Blog]:
+        """모든 블로그 조회 (삭제되지 않은 것만)"""
+        result = await self.session.execute(select(Blog).where(Blog.deleted_at.is_(None)))
+        return result.scalars().all()

--- a/techtaurant-crawler/app/domains/page_crawling/entity/page_base_link_crawler.py
+++ b/techtaurant-crawler/app/domains/page_crawling/entity/page_base_link_crawler.py
@@ -1,6 +1,7 @@
 from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
+from fastapi import HTTPException
 
 from app.common.utils.browser_page_pool import BrowserPagePool
 from app.domains.page_crawling.dto.link_crawling_response import LinkCrawlingResponse
@@ -35,9 +36,14 @@ class PageBaseLinkCrawler:
 
             # 제목 추출 (선택자로 찾기 시도)
             title_element = a_tag.select_one(self.title_selector)
-            title = (
-                title_element.get_text(strip=True) if title_element else a_tag.get_text(strip=True)
-            )
+
+            # 제목 요소가 없으면 예외 발생
+            if not title_element:
+                raise HTTPException(
+                    status_code=400, detail="제목 선택자에 해당하는 요소를 찾을 수 없습니다."
+                )
+
+            title = title_element.get_text(strip=True)
 
             # 절대 URL 변환
             absolute_url = urljoin(self.base_url, href)

--- a/techtaurant-crawler/pyproject.toml
+++ b/techtaurant-crawler/pyproject.toml
@@ -42,9 +42,6 @@ dev = [
     "pre-commit>=4.0.0",
 ]
 
-[project.scripts]
-dev = "uvicorn app.main:app --reload --host 0.0.0.0 --port 8000"
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary
블로그 API의 Swagger 문서화, 예외 처리 개선 및 Full Text Search 기능을 구현했습니다.

## 주요 변경 사항

### 1. Swagger 문서화
- `BlogController`: 전체 블로그 조회, 단건 조회, 검색 API 문서화
- `AdminBlogController`: 블로그 CRUD 관리자 API 문서화 (인증 필요)
- `ArticleLinkController`: 아티클 링크 검증 및 저장 API 문서화
- 각 API별 요청/응답 스키마, 파라미터, 에러 코드 명시

### 2. 예외 처리 개선
- `BlogStatus` enum 생성: StatusIfs 인터페이스 구현 (customStatusCode: 3001)
- `BlogService`의 모든 예외를 `ApiException(BlogStatus.BLOG_NOT_FOUND)`로 통일
- Controller Swagger에 커스텀 에러 코드 명시 (404 응답에 customStatusCode: 3001)

### 3. Full Text Search 구현
- **BlogRepository**:
  - `searchByKeyword`: ILIKE 부분 문자열 검색
  - `searchByTrigramSimilarity`: Trigram 유사도 기반 Full Text Search
- **BlogService**:
  - `searchBlogByName`: List<BlogResponse> 반환으로 변경
  - Trigram 유사도 검색 사용 (최대 10개, 유사도 순 정렬)
- **특징**:
  - name과 displayName 통합 검색
  - 부분 문자열 매칭 및 오타 허용
  - pg_trgm extension과 GIN 인덱스 활용

### 4. 문서화
- README.md에 BlogStatus 에러 코드 추가
- Full Text Search 사용 가이드 추가 (인덱스 구성, 검색 방법, 성능 최적화)

## API 변경 사항

### Breaking Change
- `GET /api/v1/blogs/search`
  - 파라미터: `name` → `keyword`
  - 반환 타입: `BlogResponse?` → `List<BlogResponse>`
  - 최대 10개 결과 반환 (유사도 순)

## Test Plan
- [ ] Swagger UI에서 모든 API 문서 확인
- [ ] 블로그 검색 API 테스트 (부분 문자열, 오타 포함)
- [ ] 예외 발생 시 커스텀 에러 코드 확인
- [ ] Full Text Search 성능 테스트