### PR TITLE
modify: Swagger 보안 설정 자동화 및 API 경로 상수화

### DIFF
--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/security/SecurityConstants.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/security/SecurityConstants.kt
@@ -2,4 +2,7 @@ package com.techtaurant.mainserver.security
 
 object SecurityConstants {
     const val ERROR_ATTRIBUTE = "jwtStatus"
+
+    const val OPEN_API_PREFIX = "/open-api"
+    const val API_PREFIX = "/api"
 }

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/security/config/SecurityConfig.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/security/config/SecurityConfig.kt
@@ -1,11 +1,13 @@
 package com.techtaurant.mainserver.security.config
 
+import com.techtaurant.mainserver.security.SecurityConstants
 import com.techtaurant.mainserver.security.handler.CustomAccessDeniedHandler
 import com.techtaurant.mainserver.security.handler.CustomAuthenticationEntryPoint
 import com.techtaurant.mainserver.security.jwt.JwtAuthenticationFilter
 import com.techtaurant.mainserver.security.oauth.handler.OAuth2FailureHandler
 import com.techtaurant.mainserver.security.oauth.handler.OAuth2SuccessHandler
 import com.techtaurant.mainserver.security.oauth.service.CustomOAuth2UserService
+import com.techtaurant.mainserver.user.enums.UserRole
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -52,8 +54,13 @@ class SecurityConfig(
                         "/login/**",
                     ).permitAll()
                     .requestMatchers(
-                        "/open-api/**"
+                        "${SecurityConstants.OPEN_API_PREFIX}/**"
                     ).permitAll()
+                    .requestMatchers(
+                        "${SecurityConstants.API_PREFIX}/**"
+                    ).hasAnyAuthority(
+                        UserRole.ADMIN.key, UserRole.USER.key
+                    )
                     .anyRequest().authenticated()
             }
             .oauth2Login { oauth2 ->

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/security/config/SwaggerConfig.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/security/config/SwaggerConfig.kt
@@ -1,0 +1,80 @@
+package com.techtaurant.mainserver.security.config
+
+import com.techtaurant.mainserver.security.SecurityConstants
+import com.techtaurant.mainserver.security.jwt.JwtConstants
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springdoc.core.customizers.OpenApiCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Swagger OpenAPI 설정
+ *
+ * Cookie 기반 인증을 사용하여 /api/ 엔드포인트 테스트 가능
+ * OAuth 로그인 후 브라우저에 설정된 accessToken cookie를 통해 인증됨
+ */
+@Configuration
+class SwaggerConfig {
+
+    companion object {
+        private const val COOKIE_AUTH_SCHEME = "cookieAuth"
+    }
+
+    @Bean
+    fun openAPI(): OpenAPI {
+        return OpenAPI()
+            .info(apiInfo())
+            .components(securityComponents())
+            .addSecurityItem(SecurityRequirement().addList(COOKIE_AUTH_SCHEME))
+    }
+
+    @Bean
+    fun openApiCustomizer(): OpenApiCustomizer {
+        return OpenApiCustomizer { openApi ->
+            openApi.paths.forEach { (path, pathItem) ->
+                if (path.startsWith(SecurityConstants.OPEN_API_PREFIX)) {
+                    pathItem.readOperations().forEach { operation ->
+                        operation.security = emptyList()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun apiInfo(): Info {
+        return Info()
+            .title("Techtaurant API")
+            .description(buildDescription())
+            .version("1.0.0")
+    }
+
+    private fun buildDescription(): String {
+        return "Techtaurant Main Server API Documentation\n\n" +
+            "## 인증 방법\n" +
+            "`/api/` 엔드포인트는 로그인이 필요합니다.\n\n" +
+            "1. [Google OAuth 로그인](/oauth2/authorization/google)으로 로그인\n" +
+            "2. 로그인 성공 시 브라우저에 `accessToken` cookie가 설정됨\n" +
+            "3. Swagger UI에서 `/api/` 엔드포인트 테스트 가능\n\n" +
+            "> Note: 브라우저에서 Swagger UI를 사용할 때 cookie가 자동으로 전송됩니다."
+    }
+
+    /**
+     * Cookie 기반 인증 Security Scheme 설정
+     * accessToken cookie를 사용하여 API 인증
+     */
+    private fun securityComponents(): Components {
+        return Components()
+            .addSecuritySchemes(
+                COOKIE_AUTH_SCHEME,
+                SecurityScheme()
+                    .type(SecurityScheme.Type.APIKEY)
+                    .`in`(SecurityScheme.In.COOKIE)
+                    .name(JwtConstants.ACCESS_TOKEN_COOKIE)
+                    .description("OAuth 로그인 후 자동으로 설정되는 accessToken cookie")
+            )
+    }
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/security/infrastructure/in/AuthApiController.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/security/infrastructure/in/AuthApiController.kt
@@ -1,6 +1,7 @@
 package com.techtaurant.mainserver.security.infrastructure.`in`
 
 import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.security.SecurityConstants
 import com.techtaurant.mainserver.security.aop.AuthRestController
 import com.techtaurant.mainserver.security.service.LogoutService
 import io.swagger.v3.oas.annotations.Operation
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 
 @AuthRestController
-@RequestMapping("/api/auth")
+@RequestMapping("${SecurityConstants.API_PREFIX}/auth")
 class AuthApiController(
     private val logoutService: LogoutService
     ) {

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/security/infrastructure/in/AuthOpenApiController.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/security/infrastructure/in/AuthOpenApiController.kt
@@ -1,6 +1,7 @@
 package com.techtaurant.mainserver.security.infrastructure.`in`
 
 import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.security.SecurityConstants
 import com.techtaurant.mainserver.security.aop.AuthRestController
 import com.techtaurant.mainserver.security.service.TokenRefreshService
 import io.swagger.v3.oas.annotations.Operation
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 
 @AuthRestController
-@RequestMapping("/open-api/auth")
+@RequestMapping("${SecurityConstants.OPEN_API_PREFIX}/auth")
 class AuthOpenApiController(
     private val tokenRefreshService: TokenRefreshService,
 ) {
@@ -30,8 +31,8 @@ class AuthOpenApiController(
         ]
     )
     @PostMapping("/refresh")
-    fun refresh(request: HttpServletRequest, response: HttpServletResponse): ApiResponse<Unit> {
+    fun refresh(request: HttpServletRequest, response: HttpServletResponse): ApiResponse<Nothing> {
         tokenRefreshService.execute(request = request, response = response)
-        return ApiResponse.ok(Unit)
+        return ApiResponse.ok()
     }
 }

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt
@@ -2,6 +2,7 @@ package com.techtaurant.mainserver.user.infrastructure.`in`
 
 import com.techtaurant.mainserver.common.dto.ApiResponse
 import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.security.SecurityConstants
 import com.techtaurant.mainserver.user.application.UserReadService
 import com.techtaurant.mainserver.user.dto.UserResponse
 import com.techtaurant.mainserver.user.enums.UserStatus
@@ -17,7 +18,7 @@ import java.util.UUID
 
 @Tag(name = "User", description = "사용자 API")
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("${SecurityConstants.API_PREFIX}/users")
 class UserController(
     private val userReadService: UserReadService
 ) {

--- a/main-server/src/main/resources/application.yml
+++ b/main-server/src/main/resources/application.yml
@@ -68,3 +68,16 @@ cookie:
   http-only: ${COOKIE_HTTP_ONLY:true}
   same-site: ${COOKIE_SAME_SITE:Lax}
   path: ${COOKIE_PATH:/}
+
+# Springdoc OpenAPI
+springdoc:
+  swagger-ui:
+    # Cookie 전송을 위한 withCredentials 활성화
+    request-interceptor: >
+      function(request) {
+        request.credentials = 'include';
+        return request;
+      }
+    # 인증된 API 테스트를 위한 설정
+    persist-authorization: true
+    try-it-out-enabled: true


### PR DESCRIPTION
- OpenApiCustomizer를 사용하여 /open-api 경로의 보안 요구사항을 자동으로 제거하도록 개선
- SecurityConstants에 OPEN_API_PREFIX, API_PREFIX 상수를 추가하고 프로젝트 전반에 적용
- Swagger UI에서 쿠키 기반 인증이 원활하게 동작하도록 application.yml 설정 추가