### PR TITLE
feat(like)!: isLiked Boolean을 LikeStatus enum으로 변경

### DIFF
--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentLikeLogService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentLikeLogService.kt
@@ -4,6 +4,7 @@ import com.techtaurant.mainserver.comment.entity.CommentLikeLog
 import com.techtaurant.mainserver.comment.enums.CommentStatus
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentLikeLogRepository
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepository
+import com.techtaurant.mainserver.common.enums.LikeStatus
 import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.user.enums.UserStatus
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
@@ -22,19 +23,19 @@ class CommentLikeLogService(
     private val userRepository: UserRepository,
 ) {
     /**
-     * 댓글 좋아요/싫어요 로그를 생성하거나 수정합니다.
-     * 동일한 사용자의 기존 로그가 있으면 isLiked 값만 업데이트하고, 없으면 새로 생성합니다.
+     * 댓글 좋아요 상태를 기록합니다.
+     * LikeStatus에 따라 로그를 생성, 수정, 또는 삭제합니다.
      *
      * @param commentId 평가할 댓글 ID
      * @param userId 평가한 사용자 ID
-     * @param isLiked true이면 좋아요, false이면 싫어요
+     * @param likeStatus 좋아요 상태 (NONE: 취소, LIKE: 좋아요, DISLIKE: 싫어요)
      * @throws ApiException 댓글 또는 사용자가 존재하지 않는 경우
      */
     @Transactional
     fun recordLike(
         commentId: UUID,
         userId: UUID,
-        isLiked: Boolean,
+        likeStatus: LikeStatus,
     ) {
         val comment =
             commentRepository.findById(commentId).orElseThrow {
@@ -50,35 +51,40 @@ class CommentLikeLogService(
 
         if (existingLog != null) {
             val previousIsLiked = existingLog.isLiked
-            if (previousIsLiked != isLiked) {
-                existingLog.isLiked = isLiked
-                commentLikeLogRepository.save(existingLog)
 
-                // 좋아요/싫어요 상태 변경 시:
-                // 1. 이전 상태 취소 (±1)
-                // 2. 새 상태 적용 (±1)
-                // 총 변경량: ±2
-                //
-                // 예시:
-                // - 좋아요(true) → 싫어요(false): -1(취소) + -1(싫어요) = -2
-                // - 싫어요(false) → 좋아요(true): +1(취소) + +1(좋아요) = +2
-                updateLikeCount(commentId, isLiked) // 이전 상태 취소
-                updateLikeCount(commentId, isLiked) // 새 상태 적용
+            when (likeStatus) {
+                LikeStatus.NONE -> {
+                    commentLikeLogRepository.delete(existingLog)
+                    updateLikeCount(commentId, !previousIsLiked)
+                }
+                LikeStatus.LIKE -> {
+                    if (!previousIsLiked) {
+                        existingLog.isLiked = true
+                        commentLikeLogRepository.save(existingLog)
+                        updateLikeCount(commentId, true)
+                        updateLikeCount(commentId, true)
+                    }
+                }
+                LikeStatus.DISLIKE -> {
+                    if (previousIsLiked) {
+                        existingLog.isLiked = false
+                        commentLikeLogRepository.save(existingLog)
+                        updateLikeCount(commentId, false)
+                        updateLikeCount(commentId, false)
+                    }
+                }
             }
         } else {
-            val newLog =
-                CommentLikeLog(
-                    comment = comment,
-                    user = user,
-                    isLiked = isLiked,
-                )
-            commentLikeLogRepository.save(newLog)
-
-            // 중립 상태에서 좋아요/싫어요 적용
-            if (isLiked) {
-                updateLikeCount(commentId, true) // 좋아요 +1
-            } else {
-                updateLikeCount(commentId, false) // 싫어요 -1
+            when (likeStatus) {
+                LikeStatus.NONE -> { }
+                LikeStatus.LIKE -> {
+                    commentLikeLogRepository.save(CommentLikeLog(comment = comment, user = user, isLiked = true))
+                    updateLikeCount(commentId, true)
+                }
+                LikeStatus.DISLIKE -> {
+                    commentLikeLogRepository.save(CommentLikeLog(comment = comment, user = user, isLiked = false))
+                    updateLikeCount(commentId, false)
+                }
             }
         }
     }

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentReadService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentReadService.kt
@@ -2,9 +2,12 @@ package com.techtaurant.mainserver.comment.application
 
 import com.techtaurant.mainserver.comment.dto.CommentCursor
 import com.techtaurant.mainserver.comment.dto.CommentListResponse
+import com.techtaurant.mainserver.comment.entity.Comment
 import com.techtaurant.mainserver.comment.enums.CommentSortType
+import com.techtaurant.mainserver.comment.infrastructure.out.CommentLikeLogRepository
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepositoryCustom
 import com.techtaurant.mainserver.common.dto.CursorPageResponse
+import com.techtaurant.mainserver.common.enums.LikeStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -17,6 +20,7 @@ import java.util.UUID
 @Transactional(readOnly = true)
 class CommentReadService(
     private val commentRepository: CommentRepositoryCustom,
+    private val commentLikeLogRepository: CommentLikeLogRepository,
 ) {
     /**
      * 부모 댓글 목록을 커서 기반 페이지네이션으로 조회합니다.
@@ -32,6 +36,7 @@ class CommentReadService(
         cursor: String?,
         size: Int,
         sortType: CommentSortType = CommentSortType.LATEST,
+        userId: UUID? = null,
     ): CursorPageResponse<CommentListResponse> {
         val commentCursor = cursor?.let { CommentCursor.decode(it) }
 
@@ -63,7 +68,7 @@ class CommentReadService(
             }
 
         return CursorPageResponse(
-            content = content.map { CommentListResponse.from(it) },
+            content = mapCommentsWithLikeStatus(content, userId),
             nextCursor = nextCursor,
             hasNext = hasNext,
             size = content.size,
@@ -84,6 +89,7 @@ class CommentReadService(
         cursor: String?,
         size: Int,
         sortType: CommentSortType = CommentSortType.LATEST,
+        userId: UUID? = null,
     ): CursorPageResponse<CommentListResponse> {
         val commentCursor = cursor?.let { CommentCursor.decode(it) }
 
@@ -115,10 +121,37 @@ class CommentReadService(
             }
 
         return CursorPageResponse(
-            content = content.map { CommentListResponse.from(it) },
+            content = mapCommentsWithLikeStatus(content, userId),
             nextCursor = nextCursor,
             hasNext = hasNext,
             size = content.size,
         )
+    }
+
+    /**
+     * 댓글 목록에 사용자의 좋아요 상태를 매핑합니다.
+     *
+     * @param comments 댓글 목록
+     * @param userId 사용자 ID (비회원인 경우 null)
+     * @return 좋아요 상태가 포함된 응답 목록
+     */
+    private fun mapCommentsWithLikeStatus(
+        comments: List<Comment>,
+        userId: UUID?,
+    ): List<CommentListResponse> {
+        if (userId == null || comments.isEmpty()) {
+            return comments.map { CommentListResponse.from(it) }
+        }
+
+        val commentIds = comments.map { it.id!! }
+        val likeLogs = commentLikeLogRepository.findByCommentIdInAndUserId(commentIds, userId)
+        val likeStatusMap =
+            likeLogs.associate { log ->
+                log.comment.id!! to if (log.isLiked) LikeStatus.LIKE else LikeStatus.DISLIKE
+            }
+
+        return comments.map { comment ->
+            CommentListResponse.from(comment, likeStatusMap[comment.id!!] ?: LikeStatus.NONE)
+        }
     }
 }

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentListResponse.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentListResponse.kt
@@ -1,6 +1,7 @@
 package com.techtaurant.mainserver.comment.dto
 
 import com.techtaurant.mainserver.comment.entity.Comment
+import com.techtaurant.mainserver.common.enums.LikeStatus
 import io.swagger.v3.oas.annotations.media.Schema
 import java.util.*
 
@@ -29,13 +30,18 @@ data class CommentListResponse(
     val likeCount: Long,
     @field:Schema(description = "대댓글 수")
     val replyCount: Long,
+    @field:Schema(description = "현재 사용자의 좋아요 상태")
+    val likeStatus: LikeStatus,
     @field:Schema(description = "생성 시각")
     val createdAt: Date,
     @field:Schema(description = "수정 시각")
     val updatedAt: Date,
 ) {
     companion object {
-        fun from(comment: Comment): CommentListResponse {
+        fun from(
+            comment: Comment,
+            likeStatus: LikeStatus = LikeStatus.NONE,
+        ): CommentListResponse {
             return CommentListResponse(
                 id = comment.id!!,
                 content = comment.content,
@@ -47,6 +53,7 @@ data class CommentListResponse(
                 depth = comment.depth,
                 likeCount = comment.likeCount,
                 replyCount = comment.replyCount,
+                likeStatus = likeStatus,
                 createdAt = comment.createdAt,
                 updatedAt = comment.updatedAt,
             )

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/dto/RecordCommentLikeRequest.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/dto/RecordCommentLikeRequest.kt
@@ -1,21 +1,22 @@
 package com.techtaurant.mainserver.comment.dto
 
+import com.techtaurant.mainserver.common.enums.LikeStatus
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotNull
 
 /**
- * 댓글 좋아요/취소 기록 요청 DTO
- * 사용자의 댓글에 대한 좋아요를 기록합니다.
+ * 댓글 좋아요 상태 기록 요청 DTO
+ * 사용자의 댓글에 대한 좋아요 상태를 기록합니다.
  *
- * @property isLiked TRUE이면 좋아요, FALSE이면 좋아요 취소를 의미합니다.
+ * @property likeStatus 좋아요 상태 (NONE: 취소, LIKE: 좋아요, DISLIKE: 싫어요)
  */
-@Schema(description = "댓글 좋아요/취소 기록 요청")
+@Schema(description = "댓글 좋아요 상태 기록 요청")
 data class RecordCommentLikeRequest(
-    @field:NotNull(message = "좋아요 여부는 필수입니다")
+    @field:NotNull(message = "좋아요 상태는 필수입니다")
     @field:Schema(
-        description = "좋아요 여부 (true: 좋아요, false: 좋아요 취소)",
-        example = "true",
+        description = "좋아요 상태 (NONE: 취소, LIKE: 좋아요, DISLIKE: 싫어요)",
+        example = "LIKE",
         required = true,
     )
-    var isLiked: Boolean,
+    var likeStatus: LikeStatus,
 )

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentLikeController.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentLikeController.kt
@@ -20,7 +20,7 @@ class CommentLikeController(
     private val commentLikeLogService: CommentLikeLogService,
 ) {
     @PostMapping("/{commentId}/like")
-    @Operation(summary = "댓글 좋아요/취소", description = "댓글에 대한 좋아요 또는 취소를 기록합니다. 인증된 사용자만 호출 가능합니다.")
+    @Operation(summary = "댓글 좋아요 상태 변경", description = "댓글에 대한 좋아요 상태(NONE/LIKE/DISLIKE)를 기록합니다. 인증된 사용자만 호출 가능합니다.")
     @ApiResponses(
         value = [
             io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -49,7 +49,7 @@ class CommentLikeController(
         commentLikeLogService.recordLike(
             commentId = commentId,
             userId = userId,
-            isLiked = request.isLiked,
+            likeStatus = request.likeStatus,
         )
 
         return ApiResponse.ok(Unit)

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadOpenApiController.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadOpenApiController.kt
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -47,6 +48,7 @@ class CommentReadController(
     )
     @GetMapping("/posts/{postId}")
     fun getParentComments(
+        @AuthenticationPrincipal userId: UUID?,
         @Parameter(description = "게시물 ID")
         @PathVariable postId: UUID,
         @Parameter(description = "이전 응답의 nextCursor (첫 페이지는 생략)")
@@ -61,7 +63,7 @@ class CommentReadController(
         @RequestParam(defaultValue = "LATEST")
         sort: CommentSortType,
     ): ApiResponse<CursorPageResponse<CommentListResponse>> {
-        return ApiResponse.ok(commentReadService.getParentComments(postId, cursor, size, sort))
+        return ApiResponse.ok(commentReadService.getParentComments(postId, cursor, size, sort, userId))
     }
 
     @Operation(
@@ -82,6 +84,7 @@ class CommentReadController(
     )
     @GetMapping("/{commentId}/replies")
     fun getReplies(
+        @AuthenticationPrincipal userId: UUID?,
         @Parameter(description = "부모 댓글 ID")
         @PathVariable commentId: UUID,
         @Parameter(description = "이전 응답의 nextCursor (첫 페이지는 생략)")
@@ -96,6 +99,6 @@ class CommentReadController(
         @RequestParam(defaultValue = "LATEST")
         sort: CommentSortType,
     ): ApiResponse<CursorPageResponse<CommentListResponse>> {
-        return ApiResponse.ok(commentReadService.getReplies(commentId, cursor, size, sort))
+        return ApiResponse.ok(commentReadService.getReplies(commentId, cursor, size, sort, userId))
     }
 }

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/out/CommentLikeLogRepository.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/out/CommentLikeLogRepository.kt
@@ -17,4 +17,16 @@ interface CommentLikeLogRepository : JpaRepository<CommentLikeLog, UUID> {
         commentId: UUID,
         userId: UUID,
     ): CommentLikeLog?
+
+    /**
+     * 여러 댓글에 대한 특정 사용자의 좋아요 로그를 일괄 조회합니다.
+     *
+     * @param commentIds 댓글 ID 목록
+     * @param userId 사용자 ID
+     * @return 좋아요 로그 목록
+     */
+    fun findByCommentIdInAndUserId(
+        commentIds: List<UUID>,
+        userId: UUID,
+    ): List<CommentLikeLog>
 }

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/common/enums/LikeStatus.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/common/enums/LikeStatus.kt
@@ -1,0 +1,14 @@
+package com.techtaurant.mainserver.common.enums
+
+/**
+ * 좋아요 상태를 나타내는 enum
+ *
+ * @property NONE 중립 (좋아요/싫어요 없음)
+ * @property LIKE 좋아요
+ * @property DISLIKE 싫어요
+ */
+enum class LikeStatus {
+    NONE,
+    LIKE,
+    DISLIKE,
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt
@@ -1,5 +1,6 @@
 package com.techtaurant.mainserver.post.application
 
+import com.techtaurant.mainserver.common.enums.LikeStatus
 import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.post.dto.PostDetailResponse
 import com.techtaurant.mainserver.post.enums.PostStatus
@@ -57,11 +58,16 @@ class PostDetailReadService(
             userAgent = userAgent,
         )
 
-        val isLiked =
+        val likeStatus =
             userId?.let {
-                postLikeLogRepository.findByPostIdAndUserId(postId, it)?.isLiked ?: false
-            } ?: false
+                val log = postLikeLogRepository.findByPostIdAndUserId(postId, it)
+                when {
+                    log == null -> LikeStatus.NONE
+                    log.isLiked -> LikeStatus.LIKE
+                    else -> LikeStatus.DISLIKE
+                }
+            } ?: LikeStatus.NONE
 
-        return PostDetailResponse.from(post, isLiked)
+        return PostDetailResponse.from(post, likeStatus)
     }
 }

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostLikeLogService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostLikeLogService.kt
@@ -1,5 +1,6 @@
 package com.techtaurant.mainserver.post.application
 
+import com.techtaurant.mainserver.common.enums.LikeStatus
 import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.post.entity.PostLikeLog
 import com.techtaurant.mainserver.post.enums.PostStatus
@@ -23,19 +24,19 @@ class PostLikeLogService(
     private val postDailyStatsService: PostDailyStatsService,
 ) {
     /**
-     * 게시글 좋아요/싫어요 로그를 생성하거나 수정합니다.
-     * 동일한 사용자의 기존 로그가 있으면 isLiked 값만 업데이트하고, 없으면 새로 생성합니다.
+     * 게시글 좋아요 상태를 기록합니다.
+     * 동일한 사용자의 기존 로그가 있으면 상태를 전이하고, 없으면 새로 생성합니다.
      *
      * @param postId 평가할 게시글 ID
      * @param userId 평가한 사용자 ID
-     * @param isLiked true이면 좋아요, false이면 싫어요
+     * @param likeStatus 좋아요 상태 (NONE: 취소, LIKE: 좋아요, DISLIKE: 싫어요)
      * @throws ApiException 게시글 또는 사용자가 존재하지 않는 경우
      */
     @Transactional
     fun recordLike(
         postId: UUID,
         userId: UUID,
-        isLiked: Boolean,
+        likeStatus: LikeStatus,
     ) {
         val post =
             postRepository.findById(postId).orElseThrow {
@@ -51,35 +52,43 @@ class PostLikeLogService(
 
         if (existingLog != null) {
             val previousIsLiked = existingLog.isLiked
-            if (previousIsLiked != isLiked) {
-                existingLog.isLiked = isLiked
-                postLikeLogRepository.save(existingLog)
 
-                // 좋아요/싫어요 상태 변경 시:
-                // 1. 이전 상태 취소 (±1)
-                // 2. 새 상태 적용 (±1)
-                // 총 변경량: ±2
-                //
-                // 예시:
-                // - 좋아요(true) → 싫어요(false): -1(취소) + -1(싫어요) = -2
-                // - 싫어요(false) → 좋아요(true): +1(취소) + +1(좋아요) = +2
-                updateLikeCount(postId, isLiked) // 이전 상태 취소
-                updateLikeCount(postId, isLiked) // 새 상태 적용
+            when (likeStatus) {
+                LikeStatus.NONE -> {
+                    // 좋아요/싫어요 취소 → 로그 삭제, 카운트 복원
+                    postLikeLogRepository.delete(existingLog)
+                    updateLikeCount(postId, !previousIsLiked)
+                }
+                LikeStatus.LIKE -> {
+                    if (!previousIsLiked) {
+                        // DISLIKE → LIKE: +2
+                        existingLog.isLiked = true
+                        postLikeLogRepository.save(existingLog)
+                        updateLikeCount(postId, true)
+                        updateLikeCount(postId, true)
+                    }
+                }
+                LikeStatus.DISLIKE -> {
+                    if (previousIsLiked) {
+                        // LIKE → DISLIKE: -2
+                        existingLog.isLiked = false
+                        postLikeLogRepository.save(existingLog)
+                        updateLikeCount(postId, false)
+                        updateLikeCount(postId, false)
+                    }
+                }
             }
         } else {
-            val newLog =
-                PostLikeLog(
-                    post = post,
-                    user = user,
-                    isLiked = isLiked,
-                )
-            postLikeLogRepository.save(newLog)
-
-            // 중립 상태에서 좋아요/싫어요 적용
-            if (isLiked) {
-                updateLikeCount(postId, true) // 좋아요 +1
-            } else {
-                updateLikeCount(postId, false) // 싫어요 -1
+            when (likeStatus) {
+                LikeStatus.NONE -> { /* 이미 중립 상태, 무시 */ }
+                LikeStatus.LIKE -> {
+                    postLikeLogRepository.save(PostLikeLog(post = post, user = user, isLiked = true))
+                    updateLikeCount(postId, true)
+                }
+                LikeStatus.DISLIKE -> {
+                    postLikeLogRepository.save(PostLikeLog(post = post, user = user, isLiked = false))
+                    updateLikeCount(postId, false)
+                }
             }
         }
     }

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostDetailResponse.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostDetailResponse.kt
@@ -1,5 +1,6 @@
 package com.techtaurant.mainserver.post.dto
 
+import com.techtaurant.mainserver.common.enums.LikeStatus
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.user.entity.User
 import io.swagger.v3.oas.annotations.media.Schema
@@ -18,7 +19,7 @@ import java.util.UUID
  * @property viewCount 조회수
  * @property likeCount 좋아요수
  * @property commentCount 댓글수
- * @property isLiked 현재 사용자의 좋아요 여부
+ * @property likeStatus 현재 사용자의 좋아요 상태
  * @property createdAt 작성일
  * @property updatedAt 수정일
  */
@@ -42,8 +43,8 @@ data class PostDetailResponse(
     val likeCount: Long,
     @field:Schema(description = "댓글수")
     val commentCount: Long,
-    @field:Schema(description = "현재 사용자의 좋아요 여부")
-    val isLiked: Boolean,
+    @field:Schema(description = "현재 사용자의 좋아요 상태")
+    val likeStatus: LikeStatus,
     @field:Schema(description = "작성일")
     val createdAt: Date,
     @field:Schema(description = "수정일")
@@ -54,12 +55,12 @@ data class PostDetailResponse(
          * Post 엔티티를 PostDetailResponse로 변환합니다.
          *
          * @param post 게시물 엔티티
-         * @param isLiked 현재 사용자의 좋아요 여부
+         * @param likeStatus 현재 사용자의 좋아요 상태
          * @return 게시물 상세 응답 DTO
          */
         fun from(
             post: Post,
-            isLiked: Boolean,
+            likeStatus: LikeStatus,
         ): PostDetailResponse =
             PostDetailResponse(
                 id = post.id!!,
@@ -71,7 +72,7 @@ data class PostDetailResponse(
                 viewCount = post.viewCount,
                 likeCount = post.likeCount,
                 commentCount = post.commentCount,
-                isLiked = isLiked,
+                likeStatus = likeStatus,
                 createdAt = post.createdAt,
                 updatedAt = post.updatedAt,
             )

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/dto/RecordPostLikeRequest.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/dto/RecordPostLikeRequest.kt
@@ -1,21 +1,22 @@
 package com.techtaurant.mainserver.post.dto
 
+import com.techtaurant.mainserver.common.enums.LikeStatus
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotNull
 
 /**
- * 게시글 좋아요/싫어요 기록 요청 DTO
+ * 좋아요 상태 기록 요청 DTO
  * 사용자의 게시글에 대한 평가를 기록합니다.
  *
- * @property isLiked TRUE이면 좋아요, FALSE이면 싫어요를 의미합니다.
+ * @property likeStatus 좋아요 상태 (NONE: 취소, LIKE: 좋아요, DISLIKE: 싫어요)
  */
-@Schema(description = "게시글 좋아요/싫어요 기록 요청")
+@Schema(description = "좋아요 상태 기록 요청")
 data class RecordPostLikeRequest(
-    @field:NotNull(message = "좋아요 여부는 필수입니다")
+    @field:NotNull(message = "좋아요 상태는 필수입니다")
     @field:Schema(
-        description = "좋아요 여부 (true: 좋아요, false: 싫어요)",
-        example = "true",
+        description = "좋아요 상태 (NONE: 취소, LIKE: 좋아요, DISLIKE: 싫어요)",
+        example = "LIKE",
         required = true,
     )
-    val isLiked: Boolean,
+    val likeStatus: LikeStatus,
 )

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostLikeController.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostLikeController.kt
@@ -24,7 +24,7 @@ class PostLikeController(
     private val postLikeLogService: PostLikeLogService,
 ) {
     @PostMapping("/{postId}/like")
-    @Operation(summary = "게시글 좋아요/싫어요", description = "게시글에 대한 좋아요 또는 싫어요를 기록합니다. 인증된 사용자만 호출 가능합니다.")
+    @Operation(summary = "게시글 좋아요 상태 변경", description = "게시글에 대한 좋아요 상태를 변경합니다. NONE: 취소, LIKE: 좋아요, DISLIKE: 싫어요. 인증된 사용자만 호출 가능합니다.")
     @ApiResponses(
         value = [
             io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -49,7 +49,7 @@ class PostLikeController(
         postLikeLogService.recordLike(
             postId = postId,
             userId = userId,
-            isLiked = request.isLiked,
+            likeStatus = request.likeStatus,
         )
 
         return ApiResponse.ok(Unit)

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/comment/application/CommentLikeLogServiceTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/comment/application/CommentLikeLogServiceTest.kt
@@ -5,6 +5,7 @@ import com.techtaurant.mainserver.comment.entity.Comment
 import com.techtaurant.mainserver.comment.enums.CommentStatus
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentLikeLogRepository
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepository
+import com.techtaurant.mainserver.common.enums.LikeStatus
 import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
@@ -115,7 +116,7 @@ class CommentLikeLogServiceTest : IntegrationTest() {
         // Given - 초기 likeCount = 0
 
         // When - 좋아요 기록
-        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, true)
+        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, LikeStatus.LIKE)
 
         // Then - 변경사항 DB 반영 및 1차 캐시 갱신
         entityManager.flush()
@@ -136,7 +137,7 @@ class CommentLikeLogServiceTest : IntegrationTest() {
         // Given - 초기 likeCount = 0
 
         // When - 싫어요 기록
-        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, false)
+        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, LikeStatus.DISLIKE)
 
         // Then - 변경사항 DB 반영 및 1차 캐시 갱신
         entityManager.flush()
@@ -155,13 +156,13 @@ class CommentLikeLogServiceTest : IntegrationTest() {
     @DisplayName("좋아요 상태에서 싫어요로 변경하면 likeCount가 2 감소한다")
     fun recordLike_fromLikeToDislike_shouldDecrementLikeCountByTwo() {
         // Given - 이미 좋아요한 상태 (likeCount = 1)
-        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, true)
+        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, LikeStatus.LIKE)
         entityManager.flush()
         entityManager.refresh(testComment)
         val initialLikeCount = testComment.likeCount
 
         // When - 싫어요로 변경
-        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, false)
+        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, LikeStatus.DISLIKE)
 
         // Then - 변경사항 DB 반영 및 1차 캐시 갱신
         entityManager.flush()
@@ -180,13 +181,13 @@ class CommentLikeLogServiceTest : IntegrationTest() {
     @DisplayName("싫어요 상태에서 좋아요로 변경하면 likeCount가 2 증가한다")
     fun recordLike_fromDislikeToLike_shouldIncrementLikeCountByTwo() {
         // Given - 이미 싫어요한 상태 (likeCount = -1)
-        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, false)
+        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, LikeStatus.DISLIKE)
         entityManager.flush()
         entityManager.refresh(testComment)
         val initialLikeCount = testComment.likeCount
 
         // When - 좋아요로 변경
-        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, true)
+        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, LikeStatus.LIKE)
 
         // Then - 변경사항 DB 반영 및 1차 캐시 갱신
         entityManager.flush()
@@ -205,13 +206,13 @@ class CommentLikeLogServiceTest : IntegrationTest() {
     @DisplayName("이미 좋아요한 상태에서 다시 좋아요를 기록하면 likeCount 변화가 없다")
     fun recordLike_duplicateLike_shouldNotChangeLikeCount() {
         // Given - 이미 좋아요한 상태
-        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, true)
+        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, LikeStatus.LIKE)
         entityManager.flush()
         entityManager.refresh(testComment)
         val initialLikeCount = testComment.likeCount
 
         // When - 다시 좋아요 기록
-        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, true)
+        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, LikeStatus.LIKE)
 
         // Then - 변경사항 DB 반영 및 1차 캐시 갱신
         entityManager.flush()
@@ -230,13 +231,13 @@ class CommentLikeLogServiceTest : IntegrationTest() {
     @DisplayName("이미 싫어요한 상태에서 다시 싫어요를 기록하면 likeCount 변화가 없다")
     fun recordLike_duplicateDislike_shouldNotChangeLikeCount() {
         // Given - 이미 싫어요한 상태
-        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, false)
+        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, LikeStatus.DISLIKE)
         entityManager.flush()
         entityManager.refresh(testComment)
         val initialLikeCount = testComment.likeCount
 
         // When - 다시 싫어요 기록
-        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, false)
+        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, LikeStatus.DISLIKE)
 
         // Then - 변경사항 DB 반영 및 1차 캐시 갱신
         entityManager.flush()
@@ -259,7 +260,7 @@ class CommentLikeLogServiceTest : IntegrationTest() {
 
         // When & Then - ApiException 발생
         assertThatThrownBy {
-            commentLikeLogService.recordLike(nonExistentCommentId, testUser.id!!, true)
+            commentLikeLogService.recordLike(nonExistentCommentId, testUser.id!!, LikeStatus.LIKE)
         }
             .isInstanceOf(ApiException::class.java)
             .extracting { (it as ApiException).status }
@@ -274,7 +275,7 @@ class CommentLikeLogServiceTest : IntegrationTest() {
 
         // When & Then - ApiException 발생
         assertThatThrownBy {
-            commentLikeLogService.recordLike(testComment.id!!, nonExistentUserId, true)
+            commentLikeLogService.recordLike(testComment.id!!, nonExistentUserId, LikeStatus.LIKE)
         }
             .isInstanceOf(ApiException::class.java)
             .extracting { (it as ApiException).status }
@@ -298,10 +299,10 @@ class CommentLikeLogServiceTest : IntegrationTest() {
             )
 
         // When - 첫 번째 사용자가 좋아요
-        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, true)
+        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, LikeStatus.LIKE)
 
         // When - 두 번째 사용자가 싫어요
-        commentLikeLogService.recordLike(testComment.id!!, anotherUser.id!!, false)
+        commentLikeLogService.recordLike(testComment.id!!, anotherUser.id!!, LikeStatus.DISLIKE)
 
         // Then - 변경사항 DB 반영 및 1차 캐시 갱신
         entityManager.flush()
@@ -334,7 +335,7 @@ class CommentLikeLogServiceTest : IntegrationTest() {
             )
 
         // When - 대댓글에 좋아요
-        commentLikeLogService.recordLike(reply.id!!, testUser.id!!, true)
+        commentLikeLogService.recordLike(reply.id!!, testUser.id!!, LikeStatus.LIKE)
 
         // Then - 변경사항 DB 반영 및 1차 캐시 갱신
         entityManager.flush()

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentLikeControllerIntegrationTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentLikeControllerIntegrationTest.kt
@@ -6,6 +6,7 @@ import com.techtaurant.mainserver.comment.dto.RecordCommentLikeRequest
 import com.techtaurant.mainserver.comment.entity.Comment
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentLikeLogRepository
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepository
+import com.techtaurant.mainserver.common.enums.LikeStatus
 import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.infrastructure.out.CategoryRepository
@@ -115,7 +116,7 @@ class CommentLikeControllerIntegrationTest : IntegrationTest() {
     @DisplayName("댓글 좋아요 성공 - 유효한 요청으로 좋아요 기록")
     fun recordLike_withValidRequest_shouldRecordLike() {
         // Given - 좋아요 요청 데이터
-        val request = RecordCommentLikeRequest(isLiked = true)
+        val request = RecordCommentLikeRequest(likeStatus = LikeStatus.LIKE)
 
         // When - 좋아요 요청
         val response =
@@ -143,8 +144,8 @@ class CommentLikeControllerIntegrationTest : IntegrationTest() {
     @DisplayName("댓글 좋아요 성공 - 싫어요로 변경")
     fun recordLike_withDislikeRequest_shouldChangeToDislike() {
         // Given - 이미 좋아요한 상태 (likeCount = 1)
-        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, true)
-        val request = RecordCommentLikeRequest(isLiked = false)
+        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, LikeStatus.LIKE)
+        val request = RecordCommentLikeRequest(likeStatus = LikeStatus.DISLIKE)
 
         // When - 싫어요로 변경 요청
         val response =
@@ -172,9 +173,9 @@ class CommentLikeControllerIntegrationTest : IntegrationTest() {
     @DisplayName("댓글 좋아요 성공 - 중복 좋아요 무시")
     fun recordLike_withDuplicateRequest_shouldIgnore() {
         // Given - 이미 좋아요한 상태
-        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, true)
+        commentLikeLogService.recordLike(testComment.id!!, testUser.id!!, LikeStatus.LIKE)
         val initialLikeCount = commentRepository.findById(testComment.id!!).get().likeCount
-        val request = RecordCommentLikeRequest(isLiked = true)
+        val request = RecordCommentLikeRequest(likeStatus = LikeStatus.LIKE)
 
         // When - 다시 좋아요 요청
         val response =
@@ -197,7 +198,7 @@ class CommentLikeControllerIntegrationTest : IntegrationTest() {
     @DisplayName("댓글 좋아요 실패 - 인증되지 않은 사용자")
     fun recordLike_withoutAuthentication_shouldReturnUnauthorized() {
         // Given - 좋아요 요청 데이터
-        val request = RecordCommentLikeRequest(isLiked = true)
+        val request = RecordCommentLikeRequest(likeStatus = LikeStatus.LIKE)
 
         // When - 인증 헤더 없이 요청
         val response =
@@ -216,7 +217,7 @@ class CommentLikeControllerIntegrationTest : IntegrationTest() {
     fun recordLike_withNonExistentComment_shouldReturnNotFound() {
         // Given - 존재하지 않는 댓글 ID
         val nonExistentCommentId = UUID.randomUUID()
-        val request = RecordCommentLikeRequest(isLiked = true)
+        val request = RecordCommentLikeRequest(likeStatus = LikeStatus.LIKE)
 
         // When - 좋아요 요청
         val response =

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostLikeLogServiceTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostLikeLogServiceTest.kt
@@ -1,6 +1,7 @@
 package com.techtaurant.mainserver.post.application
 
 import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.common.enums.LikeStatus
 import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
@@ -100,7 +101,7 @@ class PostLikeLogServiceTest : IntegrationTest() {
         // Given - 초기 likeCount = 0
 
         // When - 좋아요 기록
-        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, true)
+        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, LikeStatus.LIKE)
 
         // Then - 변경사항 DB 반영 및 1차 캐시 갱신
         entityManager.flush()
@@ -121,7 +122,7 @@ class PostLikeLogServiceTest : IntegrationTest() {
         // Given - 초기 likeCount = 0
 
         // When - 싫어요 기록
-        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, false)
+        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, LikeStatus.DISLIKE)
 
         // Then - 원자적 UPDATE 쿼리 이후 영속성 컨텍스트 초기화 및 DB 재조회
         entityManager.flush()
@@ -141,13 +142,13 @@ class PostLikeLogServiceTest : IntegrationTest() {
     @DisplayName("좋아요 상태에서 싫어요로 변경하면 likeCount가 2 감소한다")
     fun recordLike_fromLikeToDislike_shouldDecrementLikeCountByTwo() {
         // Given - 이미 좋아요한 상태 (likeCount = 1)
-        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, true)
+        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, LikeStatus.LIKE)
         entityManager.flush()
         entityManager.clear()
         val initialLikeCount = postRepository.findById(testPost.id!!).get().likeCount
 
         // When - 싫어요로 변경
-        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, false)
+        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, LikeStatus.DISLIKE)
 
         // Then - 원자적 UPDATE 쿼리 이후 영속성 컨텍스트 초기화 및 DB 재조회
         entityManager.flush()
@@ -167,13 +168,13 @@ class PostLikeLogServiceTest : IntegrationTest() {
     @DisplayName("싫어요 상태에서 좋아요로 변경하면 likeCount가 2 증가한다")
     fun recordLike_fromDislikeToLike_shouldIncrementLikeCountByTwo() {
         // Given - 이미 싫어요한 상태 (likeCount = -1)
-        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, false)
+        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, LikeStatus.DISLIKE)
         entityManager.flush()
         entityManager.clear()
         val initialLikeCount = postRepository.findById(testPost.id!!).get().likeCount
 
         // When - 좋아요로 변경
-        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, true)
+        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, LikeStatus.LIKE)
 
         // Then - 원자적 UPDATE 쿼리 이후 영속성 컨텍스트 초기화 및 DB 재조회
         entityManager.flush()
@@ -193,11 +194,11 @@ class PostLikeLogServiceTest : IntegrationTest() {
     @DisplayName("이미 좋아요한 상태에서 다시 좋아요를 기록하면 likeCount 변화가 없다")
     fun recordLike_duplicateLike_shouldNotChangeLikeCount() {
         // Given - 이미 좋아요한 상태
-        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, true)
+        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, LikeStatus.LIKE)
         val initialLikeCount = postRepository.findById(testPost.id!!).get().likeCount
 
         // When - 다시 좋아요 기록
-        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, true)
+        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, LikeStatus.LIKE)
 
         // Then - likeCount 변화 없음
         val updatedPost = postRepository.findById(testPost.id!!).get()
@@ -213,11 +214,11 @@ class PostLikeLogServiceTest : IntegrationTest() {
     @DisplayName("이미 싫어요한 상태에서 다시 싫어요를 기록하면 likeCount 변화가 없다")
     fun recordLike_duplicateDislike_shouldNotChangeLikeCount() {
         // Given - 이미 싫어요한 상태
-        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, false)
+        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, LikeStatus.DISLIKE)
         val initialLikeCount = postRepository.findById(testPost.id!!).get().likeCount
 
         // When - 다시 싫어요 기록
-        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, false)
+        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, LikeStatus.DISLIKE)
 
         // Then - likeCount 변화 없음
         val updatedPost = postRepository.findById(testPost.id!!).get()
@@ -237,7 +238,7 @@ class PostLikeLogServiceTest : IntegrationTest() {
 
         // When & Then - ApiException 발생
         assertThatThrownBy {
-            postLikeLogService.recordLike(nonExistentPostId, testUser.id!!, true)
+            postLikeLogService.recordLike(nonExistentPostId, testUser.id!!, LikeStatus.LIKE)
         }
             .isInstanceOf(ApiException::class.java)
             .extracting { (it as ApiException).status }
@@ -252,7 +253,7 @@ class PostLikeLogServiceTest : IntegrationTest() {
 
         // When & Then - ApiException 발생
         assertThatThrownBy {
-            postLikeLogService.recordLike(testPost.id!!, nonExistentUserId, true)
+            postLikeLogService.recordLike(testPost.id!!, nonExistentUserId, LikeStatus.LIKE)
         }
             .isInstanceOf(ApiException::class.java)
             .extracting { (it as ApiException).status }
@@ -276,10 +277,10 @@ class PostLikeLogServiceTest : IntegrationTest() {
             )
 
         // When - 첫 번째 사용자가 좋아요
-        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, true)
+        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, LikeStatus.LIKE)
 
         // When - 두 번째 사용자가 싫어요
-        postLikeLogService.recordLike(testPost.id!!, anotherUser.id!!, false)
+        postLikeLogService.recordLike(testPost.id!!, anotherUser.id!!, LikeStatus.DISLIKE)
 
         // Then - likeCount는 0 (좋아요 +1, 싫어요 -1)
         val updatedPost = postRepository.findById(testPost.id!!).get()

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostLikeControllerTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostLikeControllerTest.kt
@@ -1,0 +1,206 @@
+package com.techtaurant.mainserver.post.infrastructure.`in`
+
+import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.enums.LikeStatus
+import com.techtaurant.mainserver.post.dto.RecordPostLikeRequest
+import com.techtaurant.mainserver.post.entity.Category
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.entity.PostLikeLog
+import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import com.techtaurant.mainserver.post.infrastructure.out.CategoryRepository
+import com.techtaurant.mainserver.post.infrastructure.out.PostLikeLogRepository
+import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import io.restassured.RestAssured
+import io.restassured.common.mapper.TypeRef
+import io.restassured.http.ContentType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+
+@DisplayName("게시물 좋아요 API")
+class PostLikeControllerTest : IntegrationTest() {
+    @Autowired
+    private lateinit var postLikeLogRepository: PostLikeLogRepository
+
+    @Autowired
+    private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var categoryRepository: CategoryRepository
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    private lateinit var testUser: User
+    private lateinit var testPost: Post
+    private lateinit var accessToken: String
+
+    @BeforeEach
+    fun setup() {
+        // Cleanup in correct order (foreign key constraints)
+        postLikeLogRepository.deleteAllInBatch()
+        postRepository.deleteAllInBatch()
+        categoryRepository.deleteAllInBatch()
+        userRepository.deleteAllInBatch()
+
+        // Create test user
+        testUser =
+            userRepository.save(
+                User(
+                    name = "Test User",
+                    email = "test@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "test-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/profile.jpg",
+                ),
+            )
+
+        // Create test category
+        val testCategory =
+            categoryRepository.save(
+                Category(
+                    user = testUser,
+                    name = "테스트 카테고리",
+                    path = "테스트 카테고리",
+                    depth = 1,
+                ),
+            )
+
+        // Create test post
+        testPost =
+            postRepository.save(
+                Post(
+                    title = "테스트 게시물",
+                    content = "테스트 내용",
+                    author = testUser,
+                    category = testCategory,
+                    status = PostStatusEnum.PUBLISHED,
+                ),
+            )
+
+        // Generate JWT token
+        accessToken = jwtTokenProvider.createAccessToken(testUser.id!!, testUser.role)
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 성공 - NONE 상태로 변경하면 로그가 DB에서 제거된다")
+    fun recordLike_withNoneStatus_shouldDeleteLog() {
+        // Given: 사용자가 게시물에 좋아요를 누른 상태
+        val likeLog =
+            postLikeLogRepository.save(
+                PostLikeLog(
+                    post = testPost,
+                    user = testUser,
+                    isLiked = true,
+                ),
+            )
+        val likeLogId = likeLog.id!!
+        val request = RecordPostLikeRequest(likeStatus = LikeStatus.NONE)
+
+        // When: POST /api/posts/{postId}/like 호출 (NONE 상태)
+        val response =
+            RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer $accessToken")
+                .body(request)
+                .`when`()
+                .post("/api/posts/${testPost.id}/like")
+                .then()
+                .statusCode(200)
+                .extract()
+                .`as`(object : TypeRef<ApiResponse<Unit>>() {})
+
+        // Then: 응답 성공 확인
+        assertNotNull(response)
+        assertEquals(200, response.status)
+
+        // Then: DB에서 좋아요 로그가 삭제되었는지 확인
+        val deletedLog = postLikeLogRepository.findById(likeLogId)
+        assertFalse(deletedLog.isPresent, "좋아요 로그가 DB에서 삭제되어야 함")
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 실패 - 존재하지 않는 게시물 ID로 요청하면 404 NOT_FOUND 반환")
+    fun recordLike_withNonExistentPost_shouldReturn404() {
+        // Given: 존재하지 않는 게시물 ID
+        val nonExistentPostId = UUID.randomUUID()
+        val request = RecordPostLikeRequest(likeStatus = LikeStatus.LIKE)
+
+        // When: POST 요청
+        val response =
+            RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer $accessToken")
+                .body(request)
+                .`when`()
+                .post("/api/posts/$nonExistentPostId/like")
+                .then()
+                .statusCode(404)
+                .extract()
+                .`as`(object : TypeRef<ApiResponse<Unit>>() {})
+
+        // Then: 에러 응답 확인
+        assertNotNull(response)
+        assertEquals(3001, response.status, "POST_NOT_FOUND 에러 코드 (3001)가 반환되어야 함")
+        assertNotNull(response.message)
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 - 이미 중립 상태에서 NONE 요청 시 정상 처리")
+    fun recordLike_withNoneOnNeutral_shouldSucceed() {
+        // Given: 좋아요를 누르지 않은 상태 (좋아요 로그 없음)
+        val request = RecordPostLikeRequest(likeStatus = LikeStatus.NONE)
+
+        // When: POST 요청
+        val response =
+            RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer $accessToken")
+                .body(request)
+                .`when`()
+                .post("/api/posts/${testPost.id}/like")
+                .then()
+                .statusCode(200)
+                .extract()
+                .`as`(object : TypeRef<ApiResponse<Unit>>() {})
+
+        // Then: 정상 응답
+        assertNotNull(response)
+        assertEquals(200, response.status)
+    }
+
+    @Test
+    @DisplayName("좋아요 실패 - JWT 토큰 없이 요청하면 401 UNAUTHORIZED 반환")
+    fun recordLike_withoutAuthentication_shouldReturn401() {
+        // Given: 좋아요 요청
+        val request = RecordPostLikeRequest(likeStatus = LikeStatus.LIKE)
+
+        // When: 인증 헤더 없이 POST 요청
+        RestAssured
+            .given()
+            .contentType(ContentType.JSON)
+            .body(request)
+            .`when`()
+            .post("/api/posts/${testPost.id}/like")
+            .then()
+            .statusCode(401)
+    }
+}


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/like/2602/08-like-status-enum-refactor.plan.md)

## 어떤 작업인가요?
- 좋아요/싫어요 상태를 `isLiked: Boolean` 대신 `LikeStatus` enum(`NONE`, `LIKE`, `DISLIKE`)으로 표현하여 3가지 상태(좋아요, 싫어요, 중립)를 명확히 구분하도록 리팩토링

## 어떻게 해결했나요?
**LikeStatus enum 도입**
- `common/enums/LikeStatus.kt`에 `NONE`, `LIKE`, `DISLIKE` 3가지 상태를 정의
- Post/Comment 양쪽 도메인에서 공용으로 사용

**recordLike API 통합**
- 기존 `recordLike`(좋아요/싫어요) + `deleteLike`(취소)를 하나의 `recordLike` API로 통합
- `LikeStatus.NONE` 입력 시 로그 삭제 및 카운트 복원 처리

**CommentListResponse에 likeStatus 추가**
- 댓글 목록 조회 시 현재 사용자의 좋아요 상태를 포함
- N+1 방지를 위해 `findByCommentIdInAndUserId` 일괄 조회 사용

## 중요한 변경 사항은 무엇인가요?
### LikeStatus enum 적용

**isLiked Boolean → likeStatus LikeStatus 변경**
- **변경 이유**: Boolean으로는 좋아요/싫어요/중립 3가지 상태를 명확히 구분할 수 없음
- **수정 파일**: `PostDetailResponse.kt`, `RecordPostLikeRequest.kt`, `RecordCommentLikeRequest.kt`, `CommentListResponse.kt`

**상태 전환 매트릭스 구현**
- **변경 이유**: `deleteLike` 엔드포인트 없이 `recordLike`에서 모든 상태 전환 처리
- **수정 파일**: `PostLikeLogService.kt`, `CommentLikeLogService.kt`

### API 엔드포인트 변경 (Breaking Change)

**DELETE /api/posts/{postId}/like 엔드포인트 제거**
- **변경 이유**: `POST /api/posts/{postId}/like`에서 `LikeStatus.NONE`으로 취소 처리 가능
- **수정 파일**: `PostLikeController.kt`, `PostStatus.kt` (`LIKE_NOT_FOUND` 제거)

### 댓글 목록에 likeStatus 추가

**CommentReadService에 userId 기반 likeStatus 매핑**
- **변경 이유**: 댓글 목록에서도 현재 사용자의 좋아요 상태 표시 필요
- **수정 파일**: `CommentReadService.kt`, `CommentReadOpenApiController.kt`, `CommentLikeLogRepository.kt`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
