### PR TITLE
fix(post): 기본 게시물 썸네일 URL에 API base URL prefix 추가

### DIFF
--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -27,6 +27,8 @@ class PostListReadService(
     private val postViewLogRepository: PostViewLogRepository,
     @param:Value("\${app.default-post-thumbnail-url}")
     private val defaultThumbnailUrl: String,
+    @param:Value("\${swagger.base-url}")
+    private val baseUrl: String,
 ) {
     /**
      * 게시물 목록을 커서 기반 페이지네이션으로 조회
@@ -180,7 +182,7 @@ class PostListReadService(
                 ?: post.pictures
                     .minByOrNull { it.displayOrder }
                     ?.pictureUrl
-                ?: defaultThumbnailUrl
+                ?: "$baseUrl$defaultThumbnailUrl"
 
         return PostListItemResponse(
             id = post.id!!,


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- 게시물 목록에서 기본 썸네일 이미지 URL에 API base URL이 누락되어 절대 경로가 아닌 상대 경로로 반환되던 문제를 수정

## 어떻게 해결했나요?
**기본 썸네일 URL에 base URL prefix 추가**
- `swagger.base-url` 값을 `PostListReadService`에 주입하여 기본 썸네일 URL 앞에 API base URL을 붙이도록 수정
- 사진이 없는 게시물의 썸네일이 `/static/images/post-thumbnail.png` 대신 `{base-url}/static/images/post-thumbnail.png` 형태로 반환

## 중요한 변경 사항은 무엇인가요?
### 기본 썸네일 URL 절대 경로 변환

**PostListReadService 생성자에 baseUrl 주입**
- **변경 이유**: 기본 썸네일 URL을 절대 경로로 만들기 위해 API base URL이 필요
- **수정 파일**: `PostListReadService.kt`

**convertToResponse에서 기본 썸네일에 baseUrl prefix 적용**
- **변경 이유**: `defaultThumbnailUrl`이 상대 경로(`/static/images/...`)이므로 base URL을 앞에 붙여야 클라이언트에서 정상 접근 가능
- **수정 파일**: `PostListReadService.kt`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
