### PR TITLE
fix(cd): ARM64 플랫폼용 Docker 이미지 빌드로 변경

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -31,13 +31,22 @@ jobs:
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and Push Docker Image
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:latest -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} ./main-server
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
+          docker buildx build \
+            --platform linux/arm64 \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} \
+            --push \
+            ./main-server
 
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.2.0


### PR DESCRIPTION
## 어떤 작업인가요?
- dev CD 파이프라인에서 Docker 이미지를 ARM64 플랫폼용으로 빌드하도록 수정

## 어떻게 해결했나요?
**Docker Buildx를 사용한 ARM64 크로스 빌드**
- GitHub Actions 러너(amd64)에서 ARM64 이미지를 빌드할 수 있도록 QEMU + Docker Buildx 설정 추가
- `docker build` → `docker buildx build --platform linux/arm64 --push`로 변경

## 중요한 변경 사항은 무엇인가요?
### CD 워크플로우 ARM64 빌드 지원

**QEMU 및 Docker Buildx 설정 추가**
- **변경 이유**: EC2 Graviton(ARM64)에서 `no matching manifest for linux/arm64/v8` 에러로 이미지 pull 실패
- **수정 파일**: `.github/workflows/cd-dev.yml`

**빌드 커맨드 변경**
- **변경 이유**: `docker build`는 러너 아키텍처(amd64)로만 빌드하므로 `docker buildx build --platform linux/arm64`로 타겟 지정 필요
- **수정 파일**: `.github/workflows/cd-dev.yml`
