### PR TITLE
perf(cd): Docker 빌드 캐시 최적화로 CD 빌드 시간 단축

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -45,6 +45,8 @@ jobs:
             --platform linux/arm64 \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} \
+            --cache-from type=gha \
+            --cache-to type=gha,mode=max \
             --push \
             ./main-server
 

--- a/main-server/Dockerfile
+++ b/main-server/Dockerfile
@@ -3,13 +3,18 @@ FROM eclipse-temurin:17-jdk AS builder
 
 WORKDIR /app
 
+# 의존성 캐시 레이어: 빌드 설정 파일만 먼저 복사하여 의존성 다운로드
 COPY gradlew .
 COPY gradle gradle
 COPY build.gradle.kts .
 COPY settings.gradle.kts .
-COPY src src
 
 RUN chmod +x ./gradlew
+RUN ./gradlew dependencies --no-daemon
+
+# 소스코드 복사 후 빌드 (의존성 캐시 활용)
+COPY src src
+
 RUN ./gradlew bootJar --no-daemon
 
 # Runtime stage


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- CD 파이프라인의 Docker 빌드 시간이 오래 걸리는 문제를 캐시 최적화로 개선

## 어떻게 해결했나요?
**Dockerfile 의존성 레이어 분리**
- Gradle 빌드 설정 파일과 소스코드 COPY를 분리하여 의존성 다운로드 레이어를 캐시 가능하게 변경
- 소스코드만 변경될 경우 의존성 다운로드 단계를 스킵

**GitHub Actions 캐시 적용**
- Docker Buildx에 GHA 캐시(`--cache-from type=gha`, `--cache-to type=gha,mode=max`) 추가
- 이전 빌드의 Docker 레이어를 재활용하여 빌드 시간 단축

## 중요한 변경 사항은 무엇인가요?
### Dockerfile 의존성 캐시 레이어 분리

**의존성 다운로드를 별도 빌드 스테이지로 분리**
- **변경 이유**: 매 빌드마다 Gradle 의존성을 재다운로드하는 비효율 제거
- **수정 파일**: `main-server/Dockerfile`

### CD 워크플로우 GHA 캐시 추가

**Docker Buildx에 GitHub Actions 캐시 옵션 추가**
- **변경 이유**: Docker 레이어 캐시를 빌드 간 공유하여 반복 빌드 시간 단축
- **수정 파일**: `.github/workflows/cd-dev.yml`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
