### PR TITLE
fix(oauth): cross-origin OAuth 리다이렉트 origin 쿼리 파라미터 지원

### DIFF
--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepository.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepository.kt
@@ -79,9 +79,14 @@ class HttpCookieOAuth2AuthorizationRequestRepository(
 
     /**
      * 요청에서 클라이언트 origin을 추출한다.
-     * Origin 헤더를 우선 사용하고, 없으면 Referer 헤더에서 origin 부분만 추출한다.
+     * 쿼리 파라미터를 우선 사용하고, 없으면 Origin 헤더, Referer 헤더 순서로 추출한다.
      */
     private fun resolveOrigin(request: HttpServletRequest): String? {
+        val queryOrigin = request.getParameter("origin")
+        if (!queryOrigin.isNullOrBlank()) {
+            return queryOrigin
+        }
+
         val origin = request.getHeader("Origin")
         if (!origin.isNullOrBlank() && origin != "null") {
             return origin


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/auth/2602/16-fix-oauth-redirect-origin.plan.md)
- 이슈 : Techtaurant/fe#43

## 어떤 작업인가요?
- 로컬 프론트엔드(`localhost:3000`)에서 dev 백엔드의 OAuth 인증 시, 인증 완료 후 항상 `dev.techtaurant.com`으로 리다이렉트되는 문제 수정

## 어떻게 해결했나요?
**OAuth origin 쿼리 파라미터 지원 추가**
- `resolveOrigin()` 메서드에서 `origin` 쿼리 파라미터를 최우선으로 읽도록 변경
- 프론트엔드가 OAuth URL에 `?origin=`을 명시적으로 전달할 수 있게 함

## 중요한 변경 사항은 무엇인가요?
### resolveOrigin() origin 추출 우선순위 변경

**쿼리 파라미터 `origin` 우선 읽기 추가**
- **변경 이유**: 브라우저 cross-origin top-level navigation에서 `Origin` 헤더는 전송되지 않고, `Referer`도 정책에 따라 누락될 수 있어 안정적인 origin 전달이 불가능
- **수정 파일**: `HttpCookieOAuth2AuthorizationRequestRepository.kt`

**fallback 순서**: `?origin=` 쿼리 파라미터 → `Origin` 헤더 → `Referer` 헤더

> **참고**: 프론트엔드에서 OAuth 링크에 `?origin=${window.location.origin}` 추가 필요 (Techtaurant/fe#43)
