### PR TITLE
perf(cd): QEMU 에뮬레이션 제거 및 BuildKit 캐시로 빌드 시간 단축

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -37,6 +37,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Restore Gradle build cache
+        uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+        with:
+          cache-map: |
+            {
+              "gradle-cache": "/root/.gradle"
+            }
+
       - name: Build and Push Docker Image
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}

--- a/main-server/Dockerfile
+++ b/main-server/Dockerfile
@@ -1,5 +1,8 @@
-# Build stage
-FROM eclipse-temurin:17-jdk AS builder
+# syntax=docker/dockerfile:1
+
+# Build stage: 네이티브 플랫폼에서 실행하여 QEMU 에뮬레이션 오버헤드 제거
+# Java JAR은 플랫폼 독립적이므로 builder를 arm64로 에뮬레이션할 필요 없음
+FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jdk AS builder
 
 WORKDIR /app
 
@@ -9,15 +12,17 @@ COPY gradle gradle
 COPY build.gradle.kts .
 COPY settings.gradle.kts .
 
-RUN chmod +x ./gradlew
-RUN ./gradlew dependencies --no-daemon
+# Gradle 캐시를 BuildKit cache mount로 유지하여 빌드 간 의존성 재다운로드 방지
+RUN --mount=type=cache,target=/root/.gradle,sharing=locked \
+    chmod +x ./gradlew && ./gradlew dependencies --no-daemon
 
-# 소스코드 복사 후 빌드 (의존성 캐시 활용)
+# 소스코드 복사 후 빌드 (의존성 캐시 + Gradle 빌드 캐시 활용)
 COPY src src
 
-RUN ./gradlew bootJar --no-daemon
+RUN --mount=type=cache,target=/root/.gradle,sharing=locked \
+    ./gradlew bootJar --no-daemon
 
-# Runtime stage
+# Runtime stage: 타겟 플랫폼(arm64)의 JRE 이미지 사용
 FROM eclipse-temurin:17-jre
 
 WORKDIR /app


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/infra/2602/16-docker-build-qemu-elimination.plan.md)

## 어떤 작업인가요?
- CD 파이프라인의 Docker 빌드 시간이 ~27분 소요되는 문제를 해결합니다. GitHub Actions의 amd64 러너에서 arm64 이미지를 빌드할 때 발생하는 QEMU 에뮬레이션 오버헤드를 제거하고, Gradle 캐시를 빌드 간 유지하여 빌드 시간을 2~4분으로 단축합니다.

## 어떻게 해결했나요?
**QEMU 에뮬레이션 제거**
- builder 스테이지에 `--platform=$BUILDPLATFORM` 적용하여 네이티브 amd64에서 Gradle 컴파일 실행
- Java JAR은 플랫폼 독립적(JVM 바이트코드)이므로 arm64 에뮬레이션이 불필요

**BuildKit 캐시 마운트 + CI 캐시 연동**
- `RUN --mount=type=cache,target=/root/.gradle` 로 Gradle 캐시를 빌드 간 유지
- `buildkit-cache-dance` 액션으로 GitHub Actions에서도 캐시 마운트 내용 보존

## 중요한 변경 사항은 무엇인가요?
### QEMU 에뮬레이션 제거

**`FROM --platform=$BUILDPLATFORM` 적용**
- **변경 이유**: GitHub Actions의 amd64 러너에서 arm64 빌드 시 QEMU 에뮬레이션으로 5~22배 느려짐. builder 스테이지를 네이티브 플랫폼에서 실행하면 이 오버헤드가 완전히 제거됨
- **수정 파일**: `main-server/Dockerfile`

### BuildKit 캐시 마운트

**Gradle 캐시 유지**
- **변경 이유**: Docker 레이어 캐시(`type=gha`)는 Gradle 내부 캐시를 유지하지 못함. BuildKit cache mount를 사용하면 의존성 다운로드와 빌드 캐시가 빌드 간에 유지됨
- **수정 파일**: `main-server/Dockerfile`, `.github/workflows/cd-dev.yml`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
