### PR TITLE
debug(oauth): OAuth2 인증 실패 원인 추적용 로깅 추가

### DIFF
--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2FailureHandler.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2FailureHandler.kt
@@ -28,10 +28,12 @@ class OAuth2FailureHandler(
         val oauthProvider = extractOAuthProvider(request.requestURI)
 
         logger.error(
-            "OAuth2 authentication failed: provider={}, error={}, clientIp={}",
+            "OAuth2 authentication failed: provider={}, error={}, errorClass={}, clientIp={}",
             oauthProvider,
             exception.message,
+            exception.javaClass.simpleName,
             clientIp,
+            exception,
         )
 
         val status = OAuthStatus.OAUTH_AUTHENTICATION_FAILED

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2RedirectResolver.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2RedirectResolver.kt
@@ -4,6 +4,7 @@ import com.techtaurant.mainserver.security.config.CorsProperties
 import com.techtaurant.mainserver.security.helper.CookieHelper
 import com.techtaurant.mainserver.security.oauth.repository.HttpCookieOAuth2AuthorizationRequestRepository
 import jakarta.servlet.http.HttpServletRequest
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 /**
@@ -20,6 +21,8 @@ class OAuth2RedirectResolver(
     private val cookieHelper: CookieHelper,
     private val corsProperties: CorsProperties,
 ) {
+    private val logger = LoggerFactory.getLogger(OAuth2RedirectResolver::class.java)
+
     companion object {
         const val SUCCESS_PATH = "/oauth/callback"
         const val FAILURE_PATH = "/oauth/error"
@@ -41,13 +44,30 @@ class OAuth2RedirectResolver(
                 .map { it.trim() }
                 .filter { it.isNotEmpty() }
 
+        logger.info(
+            "resolve: originCookie={}, allowedOrigins={}, path={}",
+            origin,
+            allowedOrigins,
+            path,
+        )
+
+        val allCookieNames = request.cookies?.map { it.name } ?: emptyList()
+        logger.info("resolve: allCookies={}", allCookieNames)
+
         val validOrigin =
             if (origin != null && origin in allowedOrigins) {
                 origin
             } else {
+                logger.warn(
+                    "resolve: origin not in allowedOrigins, falling back. origin={}, allowedOrigins={}",
+                    origin,
+                    allowedOrigins,
+                )
                 allowedOrigins.firstOrNull() ?: "http://localhost:3000"
             }
 
-        return "$validOrigin$path"
+        val redirectUrl = "$validOrigin$path"
+        logger.info("resolve: redirectUrl={}", redirectUrl)
+        return redirectUrl
     }
 }

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepository.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepository.kt
@@ -23,7 +23,8 @@ import java.util.Base64
 class HttpCookieOAuth2AuthorizationRequestRepository(
     private val cookieHelper: CookieHelper,
 ) : AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
-    private val logger = LoggerFactory.getLogger(HttpCookieOAuth2AuthorizationRequestRepository::class.java)
+    private val logger =
+        LoggerFactory.getLogger(HttpCookieOAuth2AuthorizationRequestRepository::class.java)
 
     companion object {
         const val OAUTH2_AUTHORIZATION_REQUEST_COOKIE = "oauth2_auth_request"
@@ -32,8 +33,17 @@ class HttpCookieOAuth2AuthorizationRequestRepository(
     }
 
     override fun loadAuthorizationRequest(request: HttpServletRequest): OAuth2AuthorizationRequest? {
-        return cookieHelper.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE)
-            ?.let { deserialize(it) }
+        val cookieValue = cookieHelper.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE)
+        val originCookie = cookieHelper.getCookie(request, OAUTH2_ORIGIN_COOKIE)
+        logger.info(
+            "loadAuthorizationRequest: authRequestCookiePresent={}, originCookie={}, requestURI={}",
+            cookieValue != null,
+            originCookie,
+            request.requestURI,
+        )
+        val allCookieNames = request.cookies?.map { it.name } ?: emptyList()
+        logger.info("loadAuthorizationRequest: allCookies={}", allCookieNames)
+        return cookieValue?.let { deserialize(it) }
     }
 
     override fun saveAuthorizationRequest(
@@ -55,6 +65,12 @@ class HttpCookieOAuth2AuthorizationRequestRepository(
 
         // 요청의 Origin을 쿠키에 저장하여 인증 완료 후 원래 출처로 리다이렉트
         val origin = resolveOrigin(request)
+        logger.info(
+            "saveAuthorizationRequest: resolvedOrigin={}, requestURL={}, queryString={}",
+            origin,
+            request.requestURL,
+            request.queryString,
+        )
         if (origin != null) {
             cookieHelper.addCookie(
                 response,
@@ -62,6 +78,9 @@ class HttpCookieOAuth2AuthorizationRequestRepository(
                 origin,
                 COOKIE_EXPIRE_SECONDS,
             )
+            logger.info("saveAuthorizationRequest: oauth2_origin cookie set to {}", origin)
+        } else {
+            logger.warn("saveAuthorizationRequest: origin is null, oauth2_origin cookie NOT set")
         }
     }
 


### PR DESCRIPTION
## Summary
- OAuth2 플로우 핵심 지점(쿠키 저장/로드, 리다이렉트 결정, 인증 실패)에 상세 디버깅 로그 추가
- `origin` 쿼리 파라미터 누락 여부, 콜백 시 쿠키 유실 여부, 인증 실패 정확한 원인을 서버 로그에서 확인 가능

## Test plan
- [ ] 배포 후 `https://dev-api.techtaurant.com/oauth2/authorization/google?origin=https://localhost:3000` 접근
- [ ] `docker logs`에서 `saveAuthorizationRequest: resolvedOrigin=...` 로그 확인 (origin 쿼리 파라미터 읽기 성공 여부)
- [ ] `loadAuthorizationRequest: authRequestCookiePresent=...` 로그 확인 (콜백 시 쿠키 존재 여부)
- [ ] `OAuth2 authentication failed: errorClass=...` 로그 확인 (인증 실패 정확한 원인)
- [ ] 로그 분석 후 근본 원인 수정 브랜치 별도 생성