### PR TITLE
feat(security): 게시물/댓글 HTML sanitization 적용

### DIFF
--- a/main-server/build.gradle.kts
+++ b/main-server/build.gradle.kts
@@ -78,6 +78,9 @@ dependencies {
     // Caffeine Cache
     implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
+
+    // HTML Sanitization
+    implementation("org.jsoup:jsoup:1.18.3")
 }
 
 kotlin {

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteService.kt
@@ -6,6 +6,7 @@ import com.techtaurant.mainserver.comment.entity.Comment
 import com.techtaurant.mainserver.comment.enums.CommentStatus
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepository
 import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.common.util.HtmlSanitizer
 import com.techtaurant.mainserver.post.application.PostDailyStatsService
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.enums.PostStatus
@@ -50,7 +51,7 @@ class CommentWriteService(
 
         val comment =
             Comment(
-                content = request.content,
+                content = HtmlSanitizer.sanitizeContent(request.content),
                 post = post,
                 author = author,
                 parent = parent,

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/common/util/HtmlSanitizer.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/common/util/HtmlSanitizer.kt
@@ -1,0 +1,102 @@
+package com.techtaurant.mainserver.common.util
+
+import org.jsoup.Jsoup
+import org.jsoup.safety.Cleaner
+import org.jsoup.safety.Safelist
+
+/**
+ * HTML sanitization 유틸리티
+ * GitHub에서 허용하는 HTML 태그/속성만 통과시키고, 나머지는 제거합니다.
+ */
+object HtmlSanitizer {
+    private val GITHUB_SAFELIST: Safelist =
+        Safelist()
+            .addTags(
+                "h1",
+                "h2",
+                "h3",
+                "h4",
+                "h5",
+                "h6",
+                "p",
+                "div",
+                "span",
+                "br",
+                "hr",
+                "b",
+                "i",
+                "em",
+                "strong",
+                "del",
+                "s",
+                "strike",
+                "sup",
+                "sub",
+                "u",
+                "mark",
+                "ul",
+                "ol",
+                "li",
+                "dl",
+                "dt",
+                "dd",
+                "a",
+                "img",
+                "pre",
+                "code",
+                "blockquote",
+                "table",
+                "thead",
+                "tbody",
+                "tfoot",
+                "tr",
+                "th",
+                "td",
+                "details",
+                "summary",
+                "kbd",
+                "abbr",
+                "ruby",
+                "rt",
+                "var",
+                "samp",
+                "figure",
+                "figcaption",
+                "picture",
+                "source",
+            )
+            .addAttributes("a", "href", "title")
+            .addAttributes("img", "src", "alt", "width", "height", "title")
+            .addAttributes("td", "align")
+            .addAttributes("th", "align")
+            .addAttributes("details", "open")
+            .addAttributes("source", "srcset", "type", "media")
+            .addAttributes("ol", "start", "type")
+            .addAttributes("li", "value")
+            .addProtocols("a", "href", "http", "https", "mailto")
+            .addProtocols("img", "src", "http", "https")
+
+    /**
+     * HTML 본문을 sanitize합니다.
+     * GitHub에서 허용하는 태그와 속성만 유지하고, 나머지는 제거합니다.
+     *
+     * @param html sanitize할 HTML 문자열
+     * @return sanitize된 HTML 문자열
+     */
+    fun sanitizeContent(html: String): String {
+        val dirty = Jsoup.parseBodyFragment(html)
+        val clean = Cleaner(GITHUB_SAFELIST).clean(dirty)
+        clean.outputSettings().prettyPrint(false)
+        return clean.body().html()
+    }
+
+    /**
+     * 제목에서 모든 HTML 태그를 제거합니다.
+     *
+     * @param text sanitize할 제목 문자열
+     * @return 태그가 제거된 plain text
+     */
+    fun sanitizeTitle(text: String): String {
+        return Jsoup.clean(text, Safelist.none())
+    }
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -2,6 +2,7 @@ package com.techtaurant.mainserver.post.application
 
 import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.common.lock.DistributedLock
+import com.techtaurant.mainserver.common.util.HtmlSanitizer
 import com.techtaurant.mainserver.post.dto.CreatePostRequest
 import com.techtaurant.mainserver.post.dto.PostResponse
 import com.techtaurant.mainserver.post.dto.UpdatePostRequest
@@ -77,8 +78,8 @@ class PostWriteService(
 
         val post =
             Post(
-                title = title,
-                content = content,
+                title = HtmlSanitizer.sanitizeTitle(title),
+                content = HtmlSanitizer.sanitizeContent(content),
                 author = author,
                 category = category,
                 tags = tags.toMutableSet(),
@@ -114,8 +115,8 @@ class PostWriteService(
             throw ApiException(PostStatus.CANNOT_MODIFY_OTHERS_POST)
         }
 
-        request.title?.let { post.title = it }
-        request.content?.let { post.content = it }
+        request.title?.let { post.title = HtmlSanitizer.sanitizeTitle(it) }
+        request.content?.let { post.content = HtmlSanitizer.sanitizeContent(it) }
         request.categoryPath?.let { post.category = resolveCategory(it, post.author) }
         request.tags?.let { post.tags = resolveTags(it).toMutableSet() }
 

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteServiceTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteServiceTest.kt
@@ -21,6 +21,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ActiveProfiles
@@ -301,6 +302,91 @@ class CommentWriteServiceTest : IntegrationTest() {
         }
             .isInstanceOf(ApiException::class.java)
             .hasFieldOrPropertyWithValue("status", CommentStatus.COMMENT_MAX_DEPTH_EXCEEDED)
+    }
+
+    @Nested
+    @DisplayName("댓글 생성 시 HTML sanitization")
+    inner class CreateCommentSanitization {
+        @Test
+        @DisplayName("댓글 content에서 script 태그가 제거된다")
+        fun createComment_contentScriptTagRemoved() {
+            // Given
+            val request =
+                CreateCommentRequest(
+                    postId = testPost.id!!,
+                    content = "<p>좋은 글이네요!</p><script>alert('xss')</script>",
+                    parentId = null,
+                )
+
+            // When
+            val response = commentWriteService.createComment(testUser.id!!, request)
+
+            // Then
+            val savedComment = commentRepository.findById(response.id).orElseThrow()
+            assertThat(savedComment.content).contains("좋은 글이네요!")
+            assertThat(savedComment.content).doesNotContain("<script>")
+            assertThat(savedComment.content).doesNotContain("alert")
+        }
+
+        @Test
+        @DisplayName("댓글 content에서 GitHub 허용 태그는 유지된다")
+        fun createComment_contentAllowedTagsPreserved() {
+            // Given
+            val request =
+                CreateCommentRequest(
+                    postId = testPost.id!!,
+                    content = "<p><strong>강조</strong> 텍스트와 <code>코드</code></p>",
+                    parentId = null,
+                )
+
+            // When
+            val response = commentWriteService.createComment(testUser.id!!, request)
+
+            // Then
+            val savedComment = commentRepository.findById(response.id).orElseThrow()
+            assertThat(savedComment.content).contains("<strong>강조</strong>")
+            assertThat(savedComment.content).contains("<code>코드</code>")
+        }
+
+        @Test
+        @DisplayName("댓글 content에서 이벤트 핸들러 속성이 제거된다")
+        fun createComment_contentEventHandlersRemoved() {
+            // Given
+            val request =
+                CreateCommentRequest(
+                    postId = testPost.id!!,
+                    content = """<div onclick="alert('xss')">내용</div>""",
+                    parentId = null,
+                )
+
+            // When
+            val response = commentWriteService.createComment(testUser.id!!, request)
+
+            // Then
+            val savedComment = commentRepository.findById(response.id).orElseThrow()
+            assertThat(savedComment.content).doesNotContain("onclick")
+            assertThat(savedComment.content).contains("내용")
+        }
+
+        @Test
+        @DisplayName("댓글 content에서 iframe 태그가 제거된다")
+        fun createComment_contentIframeRemoved() {
+            // Given
+            val request =
+                CreateCommentRequest(
+                    postId = testPost.id!!,
+                    content = """댓글 내용<iframe src="https://evil.com"></iframe>""",
+                    parentId = null,
+                )
+
+            // When
+            val response = commentWriteService.createComment(testUser.id!!, request)
+
+            // Then
+            val savedComment = commentRepository.findById(response.id).orElseThrow()
+            assertThat(savedComment.content).contains("댓글 내용")
+            assertThat(savedComment.content).doesNotContain("<iframe")
+        }
     }
 
     @Test

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/common/util/HtmlSanitizerTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/common/util/HtmlSanitizerTest.kt
@@ -1,0 +1,221 @@
+package com.techtaurant.mainserver.common.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class HtmlSanitizerTest {
+    @Nested
+    @DisplayName("sanitizeContent")
+    inner class SanitizeContent {
+        @Test
+        @DisplayName("허용된 텍스트 서식 태그가 유지된다")
+        fun allowedTextFormattingTagsPreserved() {
+            // Given
+            val html = "<p><strong>굵게</strong> <em>기울임</em> <del>취소선</del> <code>코드</code></p>"
+
+            // When
+            val result = HtmlSanitizer.sanitizeContent(html)
+
+            // Then
+            assertThat(result).isEqualTo("<p><strong>굵게</strong> <em>기울임</em> <del>취소선</del> <code>코드</code></p>")
+        }
+
+        @Test
+        @DisplayName("허용된 구조 태그가 유지된다")
+        fun allowedStructuralTagsPreserved() {
+            // Given
+            val html = "<h1>제목</h1><blockquote>인용</blockquote><ul><li>항목</li></ul><hr>"
+
+            // When
+            val result = HtmlSanitizer.sanitizeContent(html)
+
+            // Then
+            assertThat(result).contains("<h1>제목</h1>")
+            assertThat(result).contains("<blockquote>인용</blockquote>")
+            assertThat(result).contains("<ul><li>항목</li></ul>")
+            assertThat(result).contains("<hr>")
+        }
+
+        @Test
+        @DisplayName("a 태그의 href, title 속성이 유지된다")
+        fun anchorTagAttributesPreserved() {
+            // Given
+            val html = """<a href="https://github.com" title="GitHub">링크</a>"""
+
+            // When
+            val result = HtmlSanitizer.sanitizeContent(html)
+
+            // Then
+            assertThat(result).contains("""href="https://github.com"""")
+            assertThat(result).contains("""title="GitHub"""")
+            assertThat(result).contains("링크</a>")
+        }
+
+        @Test
+        @DisplayName("img 태그의 src, alt, width, height 속성이 유지된다")
+        fun imgTagAttributesPreserved() {
+            // Given
+            val html = """<img src="https://example.com/img.png" alt="이미지" width="100" height="50">"""
+
+            // When
+            val result = HtmlSanitizer.sanitizeContent(html)
+
+            // Then
+            assertThat(result).contains("""src="https://example.com/img.png"""")
+            assertThat(result).contains("""alt="이미지"""")
+            assertThat(result).contains("""width="100"""")
+            assertThat(result).contains("""height="50"""")
+        }
+
+        @Test
+        @DisplayName("table 관련 태그가 유지된다")
+        fun tableTagsPreserved() {
+            // Given
+            val html = "<table><thead><tr><th>헤더</th></tr></thead><tbody><tr><td>데이터</td></tr></tbody></table>"
+
+            // When
+            val result = HtmlSanitizer.sanitizeContent(html)
+
+            // Then
+            assertThat(result).contains("<table>")
+            assertThat(result).contains("<thead>")
+            assertThat(result).contains("<th>헤더</th>")
+            assertThat(result).contains("<td>데이터</td>")
+        }
+
+        @Test
+        @DisplayName("details, summary 태그가 유지된다")
+        fun detailsSummaryTagsPreserved() {
+            // Given
+            val html = """<details open><summary>펼치기</summary><p>내용</p></details>"""
+
+            // When
+            val result = HtmlSanitizer.sanitizeContent(html)
+
+            // Then
+            assertThat(result).contains("<details open>")
+            assertThat(result).contains("<summary>펼치기</summary>")
+        }
+
+        @Test
+        @DisplayName("script 태그가 제거된다")
+        fun scriptTagRemoved() {
+            // Given
+            val html = "<p>안전한 텍스트</p><script>alert('xss')</script>"
+
+            // When
+            val result = HtmlSanitizer.sanitizeContent(html)
+
+            // Then
+            assertThat(result).doesNotContain("<script>")
+            assertThat(result).doesNotContain("alert")
+            assertThat(result).contains("<p>안전한 텍스트</p>")
+        }
+
+        @Test
+        @DisplayName("이벤트 핸들러 속성이 제거된다")
+        fun eventHandlerAttributesRemoved() {
+            // Given
+            val html = """<div onclick="alert('xss')" onmouseover="hack()">내용</div>"""
+
+            // When
+            val result = HtmlSanitizer.sanitizeContent(html)
+
+            // Then
+            assertThat(result).doesNotContain("onclick")
+            assertThat(result).doesNotContain("onmouseover")
+            assertThat(result).contains("내용")
+        }
+
+        @Test
+        @DisplayName("style 태그가 제거된다")
+        fun styleTagRemoved() {
+            // Given
+            val html = "<style>body{display:none}</style><p>내용</p>"
+
+            // When
+            val result = HtmlSanitizer.sanitizeContent(html)
+
+            // Then
+            assertThat(result).doesNotContain("<style>")
+            assertThat(result).doesNotContain("display:none")
+            assertThat(result).contains("<p>내용</p>")
+        }
+
+        @Test
+        @DisplayName("iframe, object, embed 태그가 제거된다")
+        fun dangerousEmbedTagsRemoved() {
+            // Given
+            val html = """<iframe src="https://evil.com"></iframe><object data="x"></object><embed src="y">"""
+
+            // When
+            val result = HtmlSanitizer.sanitizeContent(html)
+
+            // Then
+            assertThat(result).doesNotContain("<iframe")
+            assertThat(result).doesNotContain("<object")
+            assertThat(result).doesNotContain("<embed")
+        }
+
+        @Test
+        @DisplayName("허용되지 않는 속성이 제거된다")
+        fun disallowedAttributesRemoved() {
+            // Given
+            val html = """<p class="danger" id="secret" style="color:red">내용</p>"""
+
+            // When
+            val result = HtmlSanitizer.sanitizeContent(html)
+
+            // Then
+            assertThat(result).doesNotContain("class=")
+            assertThat(result).doesNotContain("id=")
+            assertThat(result).doesNotContain("style=")
+            assertThat(result).contains("<p>내용</p>")
+        }
+
+        @Test
+        @DisplayName("javascript: 프로토콜이 포함된 href가 제거된다")
+        fun javascriptProtocolInHrefRemoved() {
+            // Given
+            val html = """<a href="javascript:alert('xss')">클릭</a>"""
+
+            // When
+            val result = HtmlSanitizer.sanitizeContent(html)
+
+            // Then
+            assertThat(result).doesNotContain("javascript:")
+        }
+    }
+
+    @Nested
+    @DisplayName("sanitizeTitle")
+    inner class SanitizeTitle {
+        @Test
+        @DisplayName("모든 HTML 태그가 제거된다")
+        fun allHtmlTagsRemoved() {
+            // Given
+            val html = "<h1>제목</h1><script>alert('xss')</script>"
+
+            // When
+            val result = HtmlSanitizer.sanitizeTitle(html)
+
+            // Then
+            assertThat(result).isEqualTo("제목")
+        }
+
+        @Test
+        @DisplayName("일반 텍스트는 그대로 유지된다")
+        fun plainTextPreserved() {
+            // Given
+            val text = "Spring Boot 시작하기"
+
+            // When
+            val result = HtmlSanitizer.sanitizeTitle(text)
+
+            // Then
+            assertThat(result).isEqualTo("Spring Boot 시작하기")
+        }
+    }
+}

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceTest.kt
@@ -1,0 +1,244 @@
+package com.techtaurant.mainserver.post.application
+
+import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.post.dto.CreatePostRequest
+import com.techtaurant.mainserver.post.dto.UpdatePostRequest
+import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Transactional
+@ActiveProfiles("test")
+class PostWriteServiceTest : IntegrationTest() {
+    @Autowired
+    private lateinit var postWriteService: PostWriteService
+
+    @Autowired
+    private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    private lateinit var testUser: User
+
+    @BeforeEach
+    fun setUpTestData() {
+        testUser =
+            userRepository.save(
+                User(
+                    name = "테스트 사용자",
+                    email = "test@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "test-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/profile.jpg",
+                ),
+            )
+    }
+
+    @Nested
+    @DisplayName("게시물 생성 시 HTML sanitization")
+    inner class CreatePostSanitization {
+        @Test
+        @DisplayName("title에서 모든 HTML 태그가 제거된다")
+        fun createPost_titleHtmlTagsStripped() {
+            // Given
+            val request =
+                CreatePostRequest(
+                    title = "<h1>제목</h1><script>alert('xss')</script>",
+                    content = "본문 내용",
+                    status = PostStatusEnum.PUBLISHED,
+                )
+
+            // When
+            val response = postWriteService.createPost(testUser.id!!, request)
+
+            // Then
+            assertThat(response.title).isEqualTo("제목")
+            assertThat(response.title).doesNotContain("<h1>", "<script>")
+        }
+
+        @Test
+        @DisplayName("content에서 script 태그가 제거된다")
+        fun createPost_contentScriptTagRemoved() {
+            // Given
+            val request =
+                CreatePostRequest(
+                    title = "테스트 게시물",
+                    content = "<p>안전한 내용</p><script>alert('xss')</script>",
+                    status = PostStatusEnum.PUBLISHED,
+                )
+
+            // When
+            val response = postWriteService.createPost(testUser.id!!, request)
+
+            // Then
+            assertThat(response.content).contains("<p>안전한 내용</p>")
+            assertThat(response.content).doesNotContain("<script>")
+            assertThat(response.content).doesNotContain("alert")
+        }
+
+        @Test
+        @DisplayName("content에서 GitHub 허용 태그는 유지된다")
+        fun createPost_contentAllowedTagsPreserved() {
+            // Given
+            val request =
+                CreatePostRequest(
+                    title = "테스트 게시물",
+                    content = "<h2>소제목</h2><p><strong>굵게</strong> <em>기울임</em></p><pre><code>코드</code></pre>",
+                    status = PostStatusEnum.PUBLISHED,
+                )
+
+            // When
+            val response = postWriteService.createPost(testUser.id!!, request)
+
+            // Then
+            assertThat(response.content).contains("<h2>소제목</h2>")
+            assertThat(response.content).contains("<strong>굵게</strong>")
+            assertThat(response.content).contains("<em>기울임</em>")
+            assertThat(response.content).contains("<pre><code>코드</code></pre>")
+        }
+
+        @Test
+        @DisplayName("content에서 이벤트 핸들러 속성이 제거된다")
+        fun createPost_contentEventHandlersRemoved() {
+            // Given
+            val request =
+                CreatePostRequest(
+                    title = "테스트 게시물",
+                    content = """<div onclick="alert('xss')">내용</div>""",
+                    status = PostStatusEnum.PUBLISHED,
+                )
+
+            // When
+            val response = postWriteService.createPost(testUser.id!!, request)
+
+            // Then
+            assertThat(response.content).doesNotContain("onclick")
+            assertThat(response.content).contains("내용")
+        }
+
+        @Test
+        @DisplayName("content에서 iframe 태그가 제거된다")
+        fun createPost_contentIframeRemoved() {
+            // Given
+            val request =
+                CreatePostRequest(
+                    title = "테스트 게시물",
+                    content = """<p>본문</p><iframe src="https://evil.com"></iframe>""",
+                    status = PostStatusEnum.PUBLISHED,
+                )
+
+            // When
+            val response = postWriteService.createPost(testUser.id!!, request)
+
+            // Then
+            assertThat(response.content).contains("<p>본문</p>")
+            assertThat(response.content).doesNotContain("<iframe")
+        }
+
+        @Test
+        @DisplayName("content에서 a 태그의 href 속성이 유지된다")
+        fun createPost_contentAnchorHrefPreserved() {
+            // Given
+            val request =
+                CreatePostRequest(
+                    title = "테스트 게시물",
+                    content = """<a href="https://github.com">GitHub</a>""",
+                    status = PostStatusEnum.PUBLISHED,
+                )
+
+            // When
+            val response = postWriteService.createPost(testUser.id!!, request)
+
+            // Then
+            assertThat(response.content).contains("""href="https://github.com"""")
+            assertThat(response.content).contains("GitHub</a>")
+        }
+
+        @Test
+        @DisplayName("content에서 javascript: 프로토콜이 차단된다")
+        fun createPost_contentJavascriptProtocolBlocked() {
+            // Given
+            val request =
+                CreatePostRequest(
+                    title = "테스트 게시물",
+                    content = """<a href="javascript:alert('xss')">클릭</a>""",
+                    status = PostStatusEnum.PUBLISHED,
+                )
+
+            // When
+            val response = postWriteService.createPost(testUser.id!!, request)
+
+            // Then
+            assertThat(response.content).doesNotContain("javascript:")
+        }
+    }
+
+    @Nested
+    @DisplayName("게시물 수정 시 HTML sanitization")
+    inner class UpdatePostSanitization {
+        @Test
+        @DisplayName("수정 시 title에서 HTML 태그가 제거된다")
+        fun updatePost_titleHtmlTagsStripped() {
+            // Given
+            val createRequest =
+                CreatePostRequest(
+                    title = "원본 제목",
+                    content = "원본 본문",
+                    status = PostStatusEnum.PUBLISHED,
+                )
+            val created = postWriteService.createPost(testUser.id!!, createRequest)
+
+            val updateRequest =
+                UpdatePostRequest(
+                    title = "<b>수정된 제목</b><script>hack()</script>",
+                )
+
+            // When
+            val response = postWriteService.updatePost(created.id, updateRequest, testUser.id!!)
+
+            // Then
+            assertThat(response.title).isEqualTo("수정된 제목")
+            assertThat(response.title).doesNotContain("<b>", "<script>")
+        }
+
+        @Test
+        @DisplayName("수정 시 content에서 위험한 태그가 제거되고 안전한 태그는 유지된다")
+        fun updatePost_contentSanitized() {
+            // Given
+            val createRequest =
+                CreatePostRequest(
+                    title = "원본 제목",
+                    content = "원본 본문",
+                    status = PostStatusEnum.PUBLISHED,
+                )
+            val created = postWriteService.createPost(testUser.id!!, createRequest)
+
+            val updateRequest =
+                UpdatePostRequest(
+                    content = "<p>수정된 본문</p><script>alert('xss')</script><style>body{display:none}</style>",
+                )
+
+            // When
+            val response = postWriteService.updatePost(created.id, updateRequest, testUser.id!!)
+
+            // Then
+            assertThat(response.content).contains("<p>수정된 본문</p>")
+            assertThat(response.content).doesNotContain("<script>")
+            assertThat(response.content).doesNotContain("<style>")
+        }
+    }
+}


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/post/2602/22-html-sanitization.plan.md)

## 어떤 작업인가요?
- 게시물/댓글 작성·수정 시 XSS 공격을 방지하기 위해 서버 사이드 HTML sanitization 적용

## 어떻게 해결했나요?
**jsoup 기반 HTML Sanitizer 구현**
- jsoup 라이브러리의 `Cleaner` + `Safelist`를 활용하여 GitHub에서 허용하는 HTML 태그/속성만 통과
- 허용되지 않는 태그(script, iframe, style 등), 이벤트 핸들러(onclick 등), javascript: 프로토콜 자동 제거

**게시물/댓글 서비스에 sanitization 적용**
- `PostWriteService.createPost()` / `updatePost()`: title은 모든 태그 제거, content는 GitHub 허용 태그만 유지
- `CommentWriteService.createComment()`: content에 동일한 sanitization 적용

**테스트 커버리지 확보**
- HtmlSanitizer 단위 테스트 14개
- PostWriteService 통합 테스트 9개 (생성/수정 시 sanitization 검증)
- CommentWriteService 통합 테스트 4개 추가 (sanitization 검증)

## 중요한 변경 사항은 무엇인가요?
### HTML Sanitizer 유틸리티 신규 생성

**`HtmlSanitizer.sanitizeContent()`**
- **변경 이유**: 사용자 입력 HTML에서 XSS 공격 벡터를 제거하면서 GitHub 호환 마크업은 유지
- **수정 파일**: `common/util/HtmlSanitizer.kt`

**`HtmlSanitizer.sanitizeTitle()`**
- **변경 이유**: 게시물 제목은 plain text만 허용
- **수정 파일**: `common/util/HtmlSanitizer.kt`

### 게시물/댓글 서비스 수정

**PostWriteService에 sanitize 호출 추가**
- **변경 이유**: DB 저장 전 HTML을 정제하여 저장 시점부터 안전한 데이터 보장
- **수정 파일**: `post/application/PostWriteService.kt`

**CommentWriteService에 sanitize 호출 추가**
- **변경 이유**: 댓글에도 동일한 보안 정책 적용
- **수정 파일**: `comment/application/CommentWriteService.kt`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
