### PR TITLE
feat(post): 게시물 읽음/안읽음 명시적 표시 기능 구현

### DIFF
--- a/.claude/plan/post/2602/22-post-read-mark.plan.md
+++ b/.claude/plan/post/2602/22-post-read-mark.plan.md
@@ -1,0 +1,216 @@
+# 게시물 읽음/안읽음 명시적 표시 기능
+
+## Business Goal
+사용자가 게시물을 명시적으로 읽음/안읽음 표시할 수 있도록 하여, 자동 조회 기록(PostViewLog)과 별개로 사용자 주도의 읽음 관리 기능을 제공한다.
+
+## Scope
+- **In Scope**: PostReadLog 엔티티, Repository, Service, Controller, Request DTO, PostDetailResponse에 isRead 추가, PostListReadService의 isRead 소스를 PostReadLog로 전환
+- **Out of Scope**: readCount 집계, 일괄 읽음 처리, 알림 연동, PostViewLog 삭제/변경
+
+## Codebase Analysis Summary
+- 기존 `PostLikeLog` 패턴(Entity + Repository + Service + Controller)이 참조 모델
+- `PostListItemResponse`에 이미 `isRead` 필드 존재 (현재 PostViewLog 기반)
+- `PostDetailResponse`에는 `isRead` 필드 없음 (추가 필요)
+- `PostListReadService`가 `postViewLogRepository.findDistinctPostIdsByUserIdAndPostIdIn()`으로 읽음 여부 판단 중 → PostReadLog로 전환 필요
+- 인증 필요 API는 `/api/posts` 경로 + `PostController`/`PostLikeController` 패턴
+- 공개 API는 `/open-api/posts` 경로 + `PostReadOpenApiController` 패턴
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `post/entity/PostReadLog.kt` | 읽음 기록 엔티티 | Create |
+| `post/infrastructure/out/PostReadLogRepository.kt` | 읽음 기록 Repository | Create |
+| `post/application/PostReadLogService.kt` | 읽음 토글 비즈니스 로직 | Create |
+| `post/dto/RecordPostReadRequest.kt` | 읽음 상태 변경 요청 DTO | Create |
+| `post/infrastructure/in/PostReadController.kt` | 읽음 표시 API 컨트롤러 | Create |
+| `post/dto/PostDetailResponse.kt` | 상세 응답 DTO | Modify (isRead 추가) |
+| `post/application/PostDetailReadService.kt` | 상세 조회 서비스 | Modify (isRead 조회 추가) |
+| `post/application/PostListReadService.kt` | 목록 조회 서비스 | Modify (PostReadLog로 전환) |
+| `post/entity/PostLikeLog.kt` | 좋아요 로그 엔티티 | Reference |
+| `post/infrastructure/in/PostLikeController.kt` | 좋아요 컨트롤러 | Reference |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| Entity 구조 | PostLikeLog | EntityBase 상속, @Entity, @Table, unique constraint, index |
+| UUID | EntityBase | uuid.v7() 자동 생성 |
+| Repository | PostLikeLogRepository | JpaRepository<Entity, UUID> 상속, 쿼리 메서드 정의 |
+| Service | PostLikeLogService | @Service, @Transactional, postRepository/userRepository로 존재 검증 |
+| Controller | PostLikeController | @Tag, @RestController, /api/posts 경로, @AuthenticationPrincipal, Swagger 어노테이션 |
+| DTO | RecordPostLikeRequest | data class, @Schema, @field:NotNull, validation message |
+| API 응답 | ApiResponse | ApiResponse.ok(Unit) 또는 ApiResponse.ok(data) |
+| 주석 | 전체 | KDoc 스타일, 한국어, @param/@return/@throws |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| API 방식 | POST /api/posts/{postId}/read + body {isRead} | PostLikeController 패턴과 일관성 | PUT/DELETE |
+| isRead 소스 | PostReadLog (명시적) | 사용자 의도 기반 읽음 상태 관리 | PostViewLog (자동) |
+| 기존 PostViewLog isRead | PostReadLog로 전환 | PostViewLog는 조회 분석용, isRead는 사용자 표시용 | 병행 유지 |
+| readCount | 미추가 | 개인 기록용이므로 전체 카운트 불필요 | Post에 추가 |
+
+## API Contracts
+
+### POST /api/posts/{postId}/read
+- Headers: Authorization: Bearer {token} (필수)
+- Request: `{ "isRead": true }`
+- Response: `{ "status": 200, "data": null, "message": "성공" }`
+- Note: isRead=true → 읽음 표시 (레코드 생성), isRead=false → 안읽음 표시 (레코드 삭제)
+
+## Data Models
+
+### PostReadLog
+| Field | Type | Constraints |
+|-------|------|-------------|
+| id | UUID | PK, uuid.v7() |
+| post_id | UUID | FK(posts), NOT NULL |
+| user_id | UUID | FK(users), NOT NULL |
+| created_at | Date | 자동 생성 |
+| updated_at | Date | 자동 갱신 |
+
+- Unique Constraint: (post_id, user_id)
+- Index: idx_post_read_log_user_post (user_id, post_id) — 목록 조회 시 일괄 확인용
+
+## Implementation Todos
+
+### Todo 1: PostReadLog 엔티티 생성
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 읽음 기록을 저장할 JPA 엔티티를 생성한다
+- **Work**:
+  - `post/entity/PostReadLog.kt` 파일 생성
+  - `PostLikeLog` 패턴을 따라 `@Entity`, `@Table` 정의
+  - `post`(ManyToOne, FetchType.LAZY), `user`(ManyToOne, FetchType.LAZY) 필드
+  - `uniqueConstraints = [UniqueConstraint(columnNames = ["post_id", "user_id"])]`
+  - `indexes = [Index(name = "idx_post_read_log_user_post", columnList = "user_id,post_id")]`
+  - `EntityBase()` 상속
+  - KDoc 주석 한국어로 작성
+- **Convention Notes**: PostLikeLog와 동일한 구조, isLiked 필드 없음 (레코드 존재 = 읽음)
+- **Verification**: 빌드 성공
+- **Exit Criteria**: PostReadLog 엔티티가 PostLikeLog와 동일한 패턴으로 생성됨
+- **Status**: completed
+
+### Todo 2: PostReadLogRepository 생성
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: PostReadLog 조회/삭제를 위한 Repository를 생성한다
+- **Work**:
+  - `post/infrastructure/out/PostReadLogRepository.kt` 파일 생성
+  - `JpaRepository<PostReadLog, UUID>` 상속
+  - `findByPostIdAndUserId(postId: UUID, userId: UUID): PostReadLog?`
+  - `existsByPostIdAndUserId(postId: UUID, userId: UUID): Boolean`
+  - `findByUserIdAndPostIdIn(userId: UUID, postIds: List<UUID>): List<PostReadLog>` — 목록 조회 시 일괄 확인용
+  - KDoc 주석
+- **Convention Notes**: PostLikeLogRepository 패턴 참조
+- **Verification**: 빌드 성공
+- **Exit Criteria**: Repository 인터페이스가 필요한 쿼리 메서드를 모두 포함
+- **Status**: completed
+
+### Todo 3: RecordPostReadRequest DTO 생성
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 읽음 상태 변경 요청 DTO를 생성한다
+- **Work**:
+  - `post/dto/RecordPostReadRequest.kt` 파일 생성
+  - `data class RecordPostReadRequest(val isRead: Boolean)`
+  - `@Schema(description = "읽음 상태 변경 요청")`
+  - `@field:NotNull`, `@field:Schema` 어노테이션
+  - KDoc 주석
+- **Convention Notes**: RecordPostLikeRequest와 동일한 패턴
+- **Verification**: 빌드 성공
+- **Exit Criteria**: DTO가 Swagger 명세와 validation을 포함
+- **Status**: completed
+
+### Todo 4: PostReadLogService 생성
+- **Priority**: 2
+- **Dependencies**: Todo 1, Todo 2
+- **Goal**: 읽음 토글 비즈니스 로직을 구현한다
+- **Work**:
+  - `post/application/PostReadLogService.kt` 파일 생성
+  - `@Service` 클래스, 생성자 주입: `postReadLogRepository`, `postRepository`, `userRepository`
+  - `@Transactional fun toggleReadStatus(postId: UUID, userId: UUID, isRead: Boolean)`:
+    - `postRepository.findById(postId)` 존재 검증 (없으면 `ApiException(PostStatus.POST_NOT_FOUND)`)
+    - `userRepository.findById(userId)` 존재 검증
+    - `isRead = true`: `findByPostIdAndUserId`로 기존 레코드 확인 → 없으면 생성
+    - `isRead = false`: `findByPostIdAndUserId`로 기존 레코드 확인 → 있으면 삭제
+  - KDoc 주석 한국어
+- **Convention Notes**: PostLikeLogService의 recordLike 패턴 참조, 단 카운트 업데이트 불필요
+- **Verification**: 빌드 성공
+- **Exit Criteria**: 토글 로직이 멱등성을 보장 (이미 읽음인데 읽음 요청 → 무시, 이미 안읽음인데 안읽음 요청 → 무시)
+- **Status**: completed
+
+### Todo 5: PostReadController 생성
+- **Priority**: 2
+- **Dependencies**: Todo 3, Todo 4
+- **Goal**: 읽음 표시/해제 API 엔드포인트를 생성한다
+- **Work**:
+  - `post/infrastructure/in/PostReadController.kt` 파일 생성
+  - `@Tag(name = "Post")`, `@RestController`, `@RequestMapping("/api/posts")`, `@Validated`
+  - `PostReadLogService` 생성자 주입
+  - `@PostMapping("/{postId}/read") fun toggleReadStatus(...)`:
+    - `@AuthenticationPrincipal userId: UUID`
+    - `@PathVariable postId: UUID`
+    - `@Valid @RequestBody request: RecordPostReadRequest`
+    - `return ApiResponse.ok(Unit)`
+  - Swagger `@Operation`, `@ApiResponses` (200, 401, 404)
+  - KDoc 주석
+- **Convention Notes**: PostLikeController와 동일한 패턴
+- **Verification**: 빌드 성공
+- **Exit Criteria**: POST /api/posts/{postId}/read 엔드포인트가 동작
+- **Status**: completed
+
+### Todo 6: PostDetailResponse에 isRead 추가 및 PostDetailReadService 수정
+- **Priority**: 2
+- **Dependencies**: Todo 2
+- **Goal**: 게시물 상세 응답에 isRead 필드를 추가하고 서비스에서 조회한다
+- **Work**:
+  - `PostDetailResponse`에 `isRead: Boolean` 필드 추가 (@field:Schema)
+  - `PostDetailResponse.from()` 메서드에 `isRead` 파라미터 추가
+  - `PostDetailReadService` 생성자에 `postReadLogRepository` 추가
+  - `getPostDetail()`에서 userId가 있으면 `postReadLogRepository.existsByPostIdAndUserId()` 조회
+  - `PostDetailResponse.from(post, likeStatus, isRead)` 호출로 수정
+  - KDoc에 `@property isRead` 추가
+- **Convention Notes**: likeStatus 조회 패턴과 동일하게 isRead 조회
+- **Verification**: 빌드 성공
+- **Exit Criteria**: PostDetailResponse에 isRead가 포함되고 로그인 사용자에 대해 정확한 값 반환
+- **Status**: completed
+
+### Todo 7: PostListReadService의 isRead 소스를 PostReadLog로 전환
+- **Priority**: 2
+- **Dependencies**: Todo 2
+- **Goal**: 게시물 목록의 isRead를 PostViewLog 대신 PostReadLog 기반으로 전환한다
+- **Work**:
+  - `PostListReadService` 생성자에서 `postViewLogRepository` → `postReadLogRepository`로 교체
+  - `getPosts()`에서 `postViewLogRepository.findDistinctPostIdsByUserIdAndPostIdIn()` 호출을 `postReadLogRepository.findByUserIdAndPostIdIn()` 결과의 postId 추출로 변경
+  - `readPostIds` 변수명 유지, 로직만 변경
+  - `convertToResponse()` 호출 부분은 변경 없음
+- **Convention Notes**: 기존 패턴 유지하면서 데이터 소스만 전환
+- **Verification**: 빌드 성공
+- **Exit Criteria**: 목록 조회 시 isRead가 PostReadLog 기반으로 정확하게 반환
+- **Status**: completed
+
+### Todo 8: Spotless 적용 및 최종 검증
+- **Priority**: 3
+- **Dependencies**: Todo 1~7
+- **Goal**: 코드 포맷팅을 적용하고 전체 빌드를 검증한다
+- **Work**:
+  - `cd main-server && ./gradlew spotlessApply && ./gradlew spotlessCheck` 실행
+  - 빌드 오류 발생 시 수정
+- **Convention Notes**: CLAUDE.md Completion Checklist 준수
+- **Verification**: spotlessCheck 통과, 빌드 성공
+- **Exit Criteria**: spotlessCheck 통과 및 빌드 성공
+- **Status**: completed
+
+## Verification Strategy
+- `./gradlew spotlessApply && ./gradlew spotlessCheck` 통과
+- `./gradlew build` 또는 `./gradlew compileKotlin` 통과
+- 새 파일들이 기존 패턴(PostLikeLog 계열)과 일관성 있는지 확인
+
+## Progress Tracking
+- Total Todos: 8
+- Completed: 8
+- Status: Execution complete
+
+## Change Log
+- 2026-02-22: Plan created
+- 2026-02-22: All todos completed, spotlessCheck and compileKotlin passed

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt
@@ -6,6 +6,7 @@ import com.techtaurant.mainserver.post.dto.PostDetailResponse
 import com.techtaurant.mainserver.post.enums.PostStatus
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostLikeLogRepository
+import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -21,6 +22,7 @@ class PostDetailReadService(
     private val postRepository: PostRepository,
     private val postViewLogService: PostViewLogService,
     private val postLikeLogRepository: PostLikeLogRepository,
+    private val postReadLogRepository: PostReadLogRepository,
 ) {
     /**
      * 게시물 상세 정보를 조회합니다.
@@ -68,6 +70,11 @@ class PostDetailReadService(
                 }
             } ?: LikeStatus.NONE
 
-        return PostDetailResponse.from(post, likeStatus)
+        val isRead =
+            userId?.let {
+                postReadLogRepository.existsByPostIdAndUserId(postId, it)
+            } ?: false
+
+        return PostDetailResponse.from(post, likeStatus, isRead)
     }
 }

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -8,8 +8,8 @@ import com.techtaurant.mainserver.post.dto.PostListTagResponse
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
+import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
-import com.techtaurant.mainserver.post.infrastructure.out.PostViewLogRepository
 import com.techtaurant.mainserver.user.entity.User
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.core.context.SecurityContextHolder
@@ -24,7 +24,7 @@ import java.util.UUID
 @Transactional(readOnly = true)
 class PostListReadService(
     private val postRepository: PostRepository,
-    private val postViewLogRepository: PostViewLogRepository,
+    private val postReadLogRepository: PostReadLogRepository,
     @param:Value("\${app.default-post-thumbnail-url}")
     private val defaultThumbnailUrl: String,
 ) {
@@ -75,10 +75,10 @@ class PostListReadService(
         val currentUserId = getCurrentUserId()
         val readPostIds =
             if (currentUserId != null && content.isNotEmpty()) {
-                postViewLogRepository.findDistinctPostIdsByUserIdAndPostIdIn(
+                postReadLogRepository.findByUserIdAndPostIdIn(
                     userId = currentUserId,
                     postIds = content.mapNotNull { it.id },
-                ).toSet()
+                ).map { it.postId }.toSet()
             } else {
                 emptySet()
             }

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostReadLogService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostReadLogService.kt
@@ -1,0 +1,60 @@
+package com.techtaurant.mainserver.post.application
+
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.post.entity.PostReadLog
+import com.techtaurant.mainserver.post.enums.PostStatus
+import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
+import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import com.techtaurant.mainserver.user.enums.UserStatus
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+/**
+ * 게시물 읽음 표시 서비스
+ * 사용자의 게시물 읽음/안읽음 상태를 관리합니다.
+ */
+@Service
+class PostReadLogService(
+    private val postReadLogRepository: PostReadLogRepository,
+    private val postRepository: PostRepository,
+    private val userRepository: UserRepository,
+) {
+    /**
+     * 게시물 읽음 상태를 변경합니다.
+     * 멱등성을 보장하여 이미 동일 상태인 경우 무시합니다.
+     *
+     * @param postId 대상 게시물 ID
+     * @param userId 사용자 ID
+     * @param isRead true: 읽음 표시 (레코드 생성), false: 안읽음 표시 (레코드 삭제)
+     * @throws ApiException 게시물 또는 사용자가 존재하지 않는 경우
+     */
+    @Transactional
+    fun toggleReadStatus(
+        postId: UUID,
+        userId: UUID,
+        isRead: Boolean,
+    ) {
+        if (!postRepository.existsById(postId)) {
+            throw ApiException(PostStatus.POST_NOT_FOUND)
+        }
+
+        val user =
+            userRepository.findById(userId).orElseThrow {
+                ApiException(UserStatus.ID_NOT_FOUND)
+            }
+
+        val existingLog = postReadLogRepository.findByPostIdAndUserId(postId, userId)
+
+        if (isRead) {
+            if (existingLog == null) {
+                postReadLogRepository.save(PostReadLog(postId = postId, user = user))
+            }
+        } else {
+            if (existingLog != null) {
+                postReadLogRepository.delete(existingLog)
+            }
+        }
+    }
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostDetailResponse.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostDetailResponse.kt
@@ -20,6 +20,7 @@ import java.util.UUID
  * @property likeCount 좋아요수
  * @property commentCount 댓글수
  * @property likeStatus 현재 사용자의 좋아요 상태
+ * @property isRead 현재 사용자가 읽음 표시한 게시물인지 여부 (비회원은 항상 false)
  * @property createdAt 작성일
  * @property updatedAt 수정일
  */
@@ -45,6 +46,8 @@ data class PostDetailResponse(
     val commentCount: Long,
     @field:Schema(description = "현재 사용자의 좋아요 상태")
     val likeStatus: LikeStatus,
+    @field:Schema(description = "현재 사용자가 읽음 표시한 게시물인지 여부")
+    val isRead: Boolean,
     @field:Schema(description = "작성일")
     val createdAt: Date,
     @field:Schema(description = "수정일")
@@ -56,11 +59,13 @@ data class PostDetailResponse(
          *
          * @param post 게시물 엔티티
          * @param likeStatus 현재 사용자의 좋아요 상태
+         * @param isRead 현재 사용자가 읽음 표시한 게시물인지 여부
          * @return 게시물 상세 응답 DTO
          */
         fun from(
             post: Post,
             likeStatus: LikeStatus,
+            isRead: Boolean,
         ): PostDetailResponse =
             PostDetailResponse(
                 id = post.id!!,
@@ -73,6 +78,7 @@ data class PostDetailResponse(
                 likeCount = post.likeCount,
                 commentCount = post.commentCount,
                 likeStatus = likeStatus,
+                isRead = isRead,
                 createdAt = post.createdAt,
                 updatedAt = post.updatedAt,
             )

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/dto/RecordPostReadRequest.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/dto/RecordPostReadRequest.kt
@@ -1,0 +1,21 @@
+package com.techtaurant.mainserver.post.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotNull
+
+/**
+ * 읽음 상태 변경 요청 DTO
+ * 사용자가 게시물을 읽음/안읽음으로 표시할 때 사용합니다.
+ *
+ * @property isRead 읽음 상태 (true: 읽음 표시, false: 안읽음 표시)
+ */
+@Schema(description = "읽음 상태 변경 요청")
+data class RecordPostReadRequest(
+    @field:NotNull(message = "읽음 상태는 필수입니다")
+    @field:Schema(
+        description = "읽음 상태 (true: 읽음 표시, false: 안읽음 표시)",
+        example = "true",
+        required = true,
+    )
+    val isRead: Boolean,
+)

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/entity/PostReadLog.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/entity/PostReadLog.kt
@@ -1,0 +1,30 @@
+package com.techtaurant.mainserver.post.entity
+
+import com.techtaurant.mainserver.common.base.EntityBase
+import com.techtaurant.mainserver.user.entity.User
+import jakarta.persistence.*
+import java.util.UUID
+
+/**
+ * 게시물 읽음 표시 기록 엔티티
+ * 사용자가 명시적으로 게시물을 읽었다고 표시한 기록을 저장합니다.
+ * 레코드가 존재하면 읽음, 존재하지 않으면 안읽음 상태입니다.
+ *
+ * @property postId 읽음 표시한 게시물 ID
+ * @property user 읽음 표시한 사용자
+ */
+@Entity
+@Table(
+    name = "post_read_log",
+    uniqueConstraints = [UniqueConstraint(columnNames = ["post_id", "user_id"])],
+    indexes = [
+        Index(name = "idx_post_read_log_user_post", columnList = "user_id,post_id"),
+    ],
+)
+class PostReadLog(
+    @Column(name = "post_id", nullable = false)
+    var postId: UUID,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    var user: User,
+) : EntityBase()

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadController.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadController.kt
@@ -1,0 +1,57 @@
+package com.techtaurant.mainserver.post.infrastructure.`in`
+
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.post.application.PostReadLogService
+import com.techtaurant.mainserver.post.dto.RecordPostReadRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@Tag(name = "Post", description = "게시물 API")
+@RestController
+@RequestMapping("/api/posts")
+@Validated
+class PostReadController(
+    private val postReadLogService: PostReadLogService,
+) {
+    @PostMapping("/{postId}/read")
+    @Operation(summary = "게시물 읽음 상태 변경", description = "게시물에 대한 읽음 상태를 변경합니다. isRead=true: 읽음 표시, isRead=false: 안읽음 표시. 인증된 사용자만 호출 가능합니다.")
+    @ApiResponses(
+        value = [
+            io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "읽음 상태 변경 성공",
+            ),
+            io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "401",
+                description = "인증되지 않은 사용자",
+            ),
+            io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "404",
+                description = "게시물 또는 사용자를 찾을 수 없음",
+            ),
+        ],
+    )
+    fun toggleReadStatus(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable postId: UUID,
+        @Valid @RequestBody request: RecordPostReadRequest,
+    ): ApiResponse<Unit> {
+        postReadLogService.toggleReadStatus(
+            postId = postId,
+            userId = userId,
+            isRead = request.isRead,
+        )
+
+        return ApiResponse.ok(Unit)
+    }
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostReadLogRepository.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostReadLogRepository.kt
@@ -1,0 +1,44 @@
+package com.techtaurant.mainserver.post.infrastructure.out
+
+import com.techtaurant.mainserver.post.entity.PostReadLog
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
+
+interface PostReadLogRepository : JpaRepository<PostReadLog, UUID> {
+    /**
+     * 특정 게시물에 대한 특정 사용자의 읽음 기록을 조회합니다.
+     *
+     * @param postId 게시물 ID
+     * @param userId 사용자 ID
+     * @return 읽음 기록 (없으면 null)
+     */
+    fun findByPostIdAndUserId(
+        postId: UUID,
+        userId: UUID,
+    ): PostReadLog?
+
+    /**
+     * 특정 게시물에 대한 특정 사용자의 읽음 기록 존재 여부를 확인합니다.
+     *
+     * @param postId 게시물 ID
+     * @param userId 사용자 ID
+     * @return 읽음 기록 존재 여부
+     */
+    fun existsByPostIdAndUserId(
+        postId: UUID,
+        userId: UUID,
+    ): Boolean
+
+    /**
+     * 특정 사용자의 여러 게시물에 대한 읽음 기록을 일괄 조회합니다.
+     * 게시물 목록에서 읽음 여부를 확인할 때 사용합니다.
+     *
+     * @param userId 사용자 ID
+     * @param postIds 게시물 ID 목록
+     * @return 읽음 기록 목록
+     */
+    fun findByUserIdAndPostIdIn(
+        userId: UUID,
+        postIds: List<UUID>,
+    ): List<PostReadLog>
+}

--- a/main-server/src/main/resources/db/migration/V15__create_post_read_log.sql
+++ b/main-server/src/main/resources/db/migration/V15__create_post_read_log.sql
@@ -1,0 +1,18 @@
+-- 게시물 읽음 표시 기록 테이블
+-- 사용자가 명시적으로 게시물을 읽었다고 표시한 기록을 저장
+-- 레코드 존재 = 읽음, 레코드 없음 = 안읽음
+CREATE TABLE post_read_log (
+    id UUID PRIMARY KEY,
+    post_id UUID NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(post_id, user_id)
+);
+
+-- 목록 조회 시 사용자별 읽음 여부 일괄 확인용 인덱스
+CREATE INDEX idx_post_read_log_user_post ON post_read_log(user_id, post_id);
+
+COMMENT ON TABLE post_read_log IS '게시물 읽음 표시 기록';
+COMMENT ON COLUMN post_read_log.post_id IS '읽음 표시한 게시물';
+COMMENT ON COLUMN post_read_log.user_id IS '읽음 표시한 사용자';

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostReadLogServiceTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostReadLogServiceTest.kt
@@ -1,0 +1,206 @@
+package com.techtaurant.mainserver.post.application
+
+import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.post.entity.Category
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.entity.PostReadLog
+import com.techtaurant.mainserver.post.enums.PostStatus
+import com.techtaurant.mainserver.post.infrastructure.out.CategoryRepository
+import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
+import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.enums.UserStatus
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+/**
+ * PostReadLogService 통합 테스트
+ *
+ * TestContainers를 활용하여 실제 PostgreSQL 데이터베이스 환경에서
+ * 게시물 읽음/안읽음 토글 로직을 검증합니다.
+ */
+@DisplayName("PostReadLogService 통합 테스트")
+@Transactional
+class PostReadLogServiceTest : IntegrationTest() {
+    @Autowired
+    private lateinit var postReadLogService: PostReadLogService
+
+    @Autowired
+    private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var postReadLogRepository: PostReadLogRepository
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var categoryRepository: CategoryRepository
+
+    private lateinit var testUser: User
+    private lateinit var testPost: Post
+
+    @BeforeEach
+    fun setUpTestData() {
+        // Given - 테스트 사용자 생성
+        testUser =
+            userRepository.save(
+                User(
+                    name = "테스트사용자",
+                    email = "test@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "test-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/profile.jpg",
+                ),
+            )
+
+        // Given - 테스트 카테고리 생성
+        val testCategory =
+            categoryRepository.save(
+                Category(
+                    user = testUser,
+                    name = "테스트카테고리",
+                    path = "테스트카테고리",
+                    depth = 1,
+                ),
+            )
+
+        // Given - 테스트 게시물 생성
+        testPost =
+            postRepository.save(
+                Post(
+                    title = "테스트 게시물",
+                    content = "테스트 게시물 내용입니다",
+                    author = testUser,
+                    category = testCategory,
+                ),
+            )
+    }
+
+    @Test
+    @DisplayName("읽음 표시하면 읽음 기록이 생성된다")
+    fun toggleReadStatus_markAsRead_shouldCreateReadLog() {
+        // Given - 읽음 기록이 없는 상태
+
+        // When - 읽음 표시
+        postReadLogService.toggleReadStatus(testPost.id!!, testUser.id!!, true)
+
+        // Then - 읽음 기록 생성 확인
+        val log = postReadLogRepository.findByPostIdAndUserId(testPost.id!!, testUser.id!!)
+        assertThat(log).isNotNull
+        assertThat(log?.postId).isEqualTo(testPost.id)
+    }
+
+    @Test
+    @DisplayName("안읽음 표시하면 읽음 기록이 삭제된다")
+    fun toggleReadStatus_markAsUnread_shouldDeleteReadLog() {
+        // Given - 이미 읽음 표시한 상태
+        postReadLogRepository.save(PostReadLog(postId = testPost.id!!, user = testUser))
+
+        // When - 안읽음 표시
+        postReadLogService.toggleReadStatus(testPost.id!!, testUser.id!!, false)
+
+        // Then - 읽음 기록 삭제 확인
+        val log = postReadLogRepository.findByPostIdAndUserId(testPost.id!!, testUser.id!!)
+        assertThat(log).isNull()
+    }
+
+    @Test
+    @DisplayName("이미 읽음 상태에서 다시 읽음 표시하면 변화가 없다")
+    fun toggleReadStatus_duplicateRead_shouldBeIdempotent() {
+        // Given - 이미 읽음 표시한 상태
+        val existingLog = postReadLogRepository.save(PostReadLog(postId = testPost.id!!, user = testUser))
+        val existingLogId = existingLog.id!!
+
+        // When - 다시 읽음 표시
+        postReadLogService.toggleReadStatus(testPost.id!!, testUser.id!!, true)
+
+        // Then - 기존 레코드가 유지됨 (새로 생성되지 않음)
+        val log = postReadLogRepository.findByPostIdAndUserId(testPost.id!!, testUser.id!!)
+        assertThat(log).isNotNull
+        assertThat(log?.id).isEqualTo(existingLogId)
+    }
+
+    @Test
+    @DisplayName("이미 안읽음 상태에서 안읽음 표시하면 변화가 없다")
+    fun toggleReadStatus_duplicateUnread_shouldBeIdempotent() {
+        // Given - 읽음 기록이 없는 상태
+
+        // When - 안읽음 표시
+        postReadLogService.toggleReadStatus(testPost.id!!, testUser.id!!, false)
+
+        // Then - 여전히 기록 없음
+        val log = postReadLogRepository.findByPostIdAndUserId(testPost.id!!, testUser.id!!)
+        assertThat(log).isNull()
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시물에 읽음 표시하면 예외가 발생한다")
+    fun toggleReadStatus_withNonExistentPost_shouldThrowException() {
+        // Given - 존재하지 않는 게시물 ID
+        val nonExistentPostId = UUID.randomUUID()
+
+        // When & Then - ApiException 발생
+        assertThatThrownBy {
+            postReadLogService.toggleReadStatus(nonExistentPostId, testUser.id!!, true)
+        }
+            .isInstanceOf(ApiException::class.java)
+            .extracting { (it as ApiException).status }
+            .isEqualTo(PostStatus.POST_NOT_FOUND)
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자가 읽음 표시하면 예외가 발생한다")
+    fun toggleReadStatus_withNonExistentUser_shouldThrowException() {
+        // Given - 존재하지 않는 사용자 ID
+        val nonExistentUserId = UUID.randomUUID()
+
+        // When & Then - ApiException 발생
+        assertThatThrownBy {
+            postReadLogService.toggleReadStatus(testPost.id!!, nonExistentUserId, true)
+        }
+            .isInstanceOf(ApiException::class.java)
+            .extracting { (it as ApiException).status }
+            .isEqualTo(UserStatus.ID_NOT_FOUND)
+    }
+
+    @Test
+    @DisplayName("여러 사용자가 동일 게시물에 읽음 표시하면 각각 독립적으로 처리된다")
+    fun toggleReadStatus_multipleUsers_shouldHandleIndependently() {
+        // Given - 추가 사용자 생성
+        val anotherUser =
+            userRepository.save(
+                User(
+                    name = "다른사용자",
+                    email = "another@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "another-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/another.jpg",
+                ),
+            )
+
+        // When - 첫 번째 사용자가 읽음 표시
+        postReadLogService.toggleReadStatus(testPost.id!!, testUser.id!!, true)
+
+        // When - 두 번째 사용자는 읽음 표시하지 않음
+
+        // Then - 첫 번째 사용자만 읽음 기록 존재
+        val log1 = postReadLogRepository.findByPostIdAndUserId(testPost.id!!, testUser.id!!)
+        assertThat(log1).isNotNull
+
+        val log2 = postReadLogRepository.findByPostIdAndUserId(testPost.id!!, anotherUser.id!!)
+        assertThat(log2).isNull()
+    }
+}

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadControllerTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadControllerTest.kt
@@ -1,0 +1,244 @@
+package com.techtaurant.mainserver.post.infrastructure.`in`
+
+import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.post.dto.RecordPostReadRequest
+import com.techtaurant.mainserver.post.entity.Category
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.entity.PostReadLog
+import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import com.techtaurant.mainserver.post.infrastructure.out.CategoryRepository
+import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
+import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import io.restassured.RestAssured
+import io.restassured.common.mapper.TypeRef
+import io.restassured.http.ContentType
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@DisplayName("게시물 읽음 표시 API")
+class PostReadControllerTest : IntegrationTest() {
+    @Autowired
+    private lateinit var postReadLogRepository: PostReadLogRepository
+
+    @Autowired
+    private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var categoryRepository: CategoryRepository
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    private lateinit var testUser: User
+    private lateinit var testPost: Post
+    private lateinit var accessToken: String
+
+    @BeforeEach
+    fun setup() {
+        // Cleanup in correct order (foreign key constraints)
+        postReadLogRepository.deleteAllInBatch()
+        postRepository.deleteAllInBatch()
+        categoryRepository.deleteAllInBatch()
+        userRepository.deleteAllInBatch()
+
+        // Create test user
+        testUser =
+            userRepository.save(
+                User(
+                    name = "Test User",
+                    email = "test@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "test-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/profile.jpg",
+                ),
+            )
+
+        // Create test category
+        val testCategory =
+            categoryRepository.save(
+                Category(
+                    user = testUser,
+                    name = "테스트 카테고리",
+                    path = "테스트 카테고리",
+                    depth = 1,
+                ),
+            )
+
+        // Create test post
+        testPost =
+            postRepository.save(
+                Post(
+                    title = "테스트 게시물",
+                    content = "테스트 내용",
+                    author = testUser,
+                    category = testCategory,
+                    status = PostStatusEnum.PUBLISHED,
+                ),
+            )
+
+        // Generate JWT token
+        accessToken = jwtTokenProvider.createAccessToken(testUser.id!!, testUser.role)
+    }
+
+    @Test
+    @DisplayName("읽음 표시 성공 - isRead=true로 요청하면 읽음 기록이 생성된다")
+    fun toggleReadStatus_markAsRead_shouldCreateReadLog() {
+        // Given: 읽음 기록이 없는 상태
+        val request = RecordPostReadRequest(isRead = true)
+
+        // When: POST /api/posts/{postId}/read 호출
+        val response =
+            RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer $accessToken")
+                .body(request)
+                .`when`()
+                .post("/api/posts/${testPost.id}/read")
+                .then()
+                .statusCode(200)
+                .extract()
+                .`as`(object : TypeRef<ApiResponse<Unit>>() {})
+
+        // Then: 응답 성공 확인
+        assertNotNull(response)
+        assertEquals(200, response.status)
+
+        // Then: DB에 읽음 기록 생성 확인
+        val readLog = postReadLogRepository.findByPostIdAndUserId(testPost.id!!, testUser.id!!)
+        assertNotNull(readLog, "읽음 기록이 DB에 생성되어야 함")
+    }
+
+    @Test
+    @DisplayName("안읽음 표시 성공 - isRead=false로 요청하면 읽음 기록이 삭제된다")
+    fun toggleReadStatus_markAsUnread_shouldDeleteReadLog() {
+        // Given: 사용자가 게시물을 읽음 표시한 상태
+        val readLog =
+            postReadLogRepository.save(
+                PostReadLog(
+                    postId = testPost.id!!,
+                    user = testUser,
+                ),
+            )
+        val readLogId = readLog.id!!
+        val request = RecordPostReadRequest(isRead = false)
+
+        // When: POST /api/posts/{postId}/read 호출 (isRead=false)
+        val response =
+            RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer $accessToken")
+                .body(request)
+                .`when`()
+                .post("/api/posts/${testPost.id}/read")
+                .then()
+                .statusCode(200)
+                .extract()
+                .`as`(object : TypeRef<ApiResponse<Unit>>() {})
+
+        // Then: 응답 성공 확인
+        assertNotNull(response)
+        assertEquals(200, response.status)
+
+        // Then: DB에서 읽음 기록이 삭제되었는지 확인
+        val deletedLog = postReadLogRepository.findById(readLogId)
+        assertFalse(deletedLog.isPresent, "읽음 기록이 DB에서 삭제되어야 함")
+    }
+
+    @Test
+    @DisplayName("읽음 표시 실패 - 존재하지 않는 게시물 ID로 요청하면 404 반환")
+    fun toggleReadStatus_withNonExistentPost_shouldReturn404() {
+        // Given: 존재하지 않는 게시물 ID
+        val nonExistentPostId = UUID.randomUUID()
+        val request = RecordPostReadRequest(isRead = true)
+
+        // When: POST 요청
+        val response =
+            RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer $accessToken")
+                .body(request)
+                .`when`()
+                .post("/api/posts/$nonExistentPostId/read")
+                .then()
+                .statusCode(404)
+                .extract()
+                .`as`(object : TypeRef<ApiResponse<Unit>>() {})
+
+        // Then: 에러 응답 확인
+        assertNotNull(response)
+        assertEquals(3001, response.status, "POST_NOT_FOUND 에러 코드 (3001)가 반환되어야 함")
+        assertNotNull(response.message)
+    }
+
+    @Test
+    @DisplayName("읽음 표시 실패 - JWT 토큰 없이 요청하면 401 반환")
+    fun toggleReadStatus_withoutAuthentication_shouldReturn401() {
+        // Given: 읽음 요청
+        val request = RecordPostReadRequest(isRead = true)
+
+        // When: 인증 헤더 없이 POST 요청
+        RestAssured
+            .given()
+            .contentType(ContentType.JSON)
+            .body(request)
+            .`when`()
+            .post("/api/posts/${testPost.id}/read")
+            .then()
+            .statusCode(401)
+    }
+
+    @Test
+    @DisplayName("멱등성 보장 - 이미 읽음 상태에서 다시 읽음 요청 시 정상 처리")
+    fun toggleReadStatus_duplicateRead_shouldSucceed() {
+        // Given: 이미 읽음 표시한 상태
+        postReadLogRepository.save(
+            PostReadLog(
+                postId = testPost.id!!,
+                user = testUser,
+            ),
+        )
+        val request = RecordPostReadRequest(isRead = true)
+
+        // When: 다시 읽음 표시 요청
+        val response =
+            RestAssured
+                .given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", "Bearer $accessToken")
+                .body(request)
+                .`when`()
+                .post("/api/posts/${testPost.id}/read")
+                .then()
+                .statusCode(200)
+                .extract()
+                .`as`(object : TypeRef<ApiResponse<Unit>>() {})
+
+        // Then: 정상 응답
+        assertNotNull(response)
+        assertEquals(200, response.status)
+
+        // Then: 읽음 기록은 여전히 1개
+        val exists = postReadLogRepository.existsByPostIdAndUserId(testPost.id!!, testUser.id!!)
+        assertTrue(exists, "읽음 기록이 유지되어야 함")
+    }
+}


### PR DESCRIPTION
## Summary
- 사용자가 게시물을 명시적으로 읽음/안읽음 표시할 수 있는 토글 API 추가 (`POST /api/posts/{postId}/read`)
- `post_read_log` 테이블 및 Flyway 마이그레이션 추가 (레코드 존재 = 읽음, 없음 = 안읽음)
- 게시물 목록/상세 응답에 `isRead` 필드를 `PostReadLog` 기반으로 제공
- 멱등성 보장: 이미 동일 상태인 경우 무시

## Changes
- `PostReadLog` 엔티티, `PostReadLogRepository`, `PostReadLogService` 생성
- `PostReadController` (토글 API) 생성
- `PostDetailResponse`에 `isRead` 필드 추가 및 `PostDetailReadService` 수정
- `PostListReadService`의 읽음 여부 판단을 `PostViewLog` → `PostReadLog` 기반으로 변경
- `V15__create_post_read_log.sql` Flyway 마이그레이션 추가

## Test plan
- [x] `PostReadLogServiceTest` — 읽음/안읽음 토글, 멱등성, 존재하지 않는 게시물/사용자 예외 (7개 테스트)
- [x] `PostReadControllerTest` — API E2E 테스트: 성공, 404, 401, 멱등성 (5개 테스트)
- [x] 12개 테스트 모두 통과 확인