### PR TITLE
feat(auth): dev 환경 전용 테스트 사용자 로그인 API

### DIFF
--- a/.claude/plan/auth/2602/24-dev-test-user-auth.plan.md
+++ b/.claude/plan/auth/2602/24-dev-test-user-auth.plan.md
@@ -1,0 +1,199 @@
+# Dev Test User Auth API
+
+## Business Goal
+dev 환경에서 OAuth2 없이 테스트 사용자로 빠르게 인증하여 JWT를 발급받을 수 있는 API를 제공한다.
+프론트엔드 개발자와 백엔드 개발자가 로컬 개발 시 Google OAuth 플로우 없이 즉시 인증된 상태로 API를 테스트할 수 있게 한다.
+Production 환경에서는 절대로 노출되지 않아야 한다.
+
+## Scope
+- **In Scope**: dev 전용 로그인 API, 테스트 사용자 자동 생성, JWT 쿠키 발급, SecurityConfig dev 설정, OAuthProvider DEV_LOCAL 추가, CLAUDE.md 가이드
+- **Out of Scope**: password 해싱, Flyway 마이그레이션, 테스트 코드, dev 프로파일용 application-dev.yml 생성 (이미 env로 관리)
+
+## Codebase Analysis Summary
+- **인증 방식**: OAuth2 (Google) → `OAuth2SuccessHandler`에서 JWT 발급 + 쿠키 설정
+- **JWT**: `JwtTokenProvider.createAccessToken(userId, role)`, `createRefreshToken(userId)` → 쿠키(`accessToken`, `refreshToken`)로 전달
+- **User Entity**: `name`, `email`, `provider(OAuthProvider)`, `identifier`, `role(UserRole)`, `profileImageUrl` + `EntityBase(id, createdAt, updatedAt)`
+- **User 식별**: `identifier + provider` unique constraint
+- **API 구조**: `/open-api/**` (인증 불필요), `/api/**` (인증 필요), Swagger annotations 사용
+- **응답 래퍼**: `ApiResponse<T>` (status, data, message)
+- **에러 처리**: `ApiException(StatusIfs)` 패턴
+- **Security**: `SecurityConfig` → `JwtAuthenticationFilter` + OAuth2 설정
+- **토큰 캐시**: `TokenCachePort` (Caffeine) — refresh token 저장
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `security/enums/OAuthProvider.kt` | OAuth provider enum | Modify — `DEV_LOCAL` 추가 |
+| `security/config/SecurityConfig.kt` | Security filter chain | Modify — dev-api permitAll 추가 |
+| `security/infrastructure/in/DevTestAuthController.kt` | dev 전용 컨트롤러 | Create |
+| `security/service/DevTestAuthService.kt` | dev 전용 인증 서비스 | Create |
+| `security/dto/DevTestLoginRequest.kt` | 로그인 요청 DTO | Create |
+| `security/jwt/JwtTokenProvider.kt` | JWT 토큰 생성 | Reference |
+| `security/helper/CookieHelper.kt` | 쿠키 설정 | Reference |
+| `security/cache/TokenCachePort.kt` | 토큰 캐시 | Reference |
+| `user/infrastructure/out/UserRepository.kt` | 사용자 조회 | Reference |
+| `user/entity/User.kt` | 사용자 엔티티 | Reference |
+| `CLAUDE.md` | 프로젝트 가이드 | Modify — dev 환경 가이드 추가 |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| DTO 네이밍 | BACKEND.md | `~Request`, `~Response` 접미사 |
+| API description | BACKEND.md | Swagger 설명 한국어 |
+| 응답 래퍼 | ApiResponse.kt | `ApiResponse<T>` 사용 |
+| Enum 파일 분리 | BACKEND.md | Inner class 금지, 각각 파일로 분리 |
+| UUID v7 | EntityBase.kt | ID는 `@UuidV7` 사용 |
+| 코드 포맷 | CLAUDE.md | `spotlessApply` + `spotlessCheck` |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 프로파일 제어 | `@Profile("dev")` | Spring 표준, 빈 미등록으로 완전 차단 | `@ConditionalOnProperty` |
+| API prefix | `/dev-api/auth/login` | 기존 `/open-api`, `/api`와 구분 | `/open-api/dev/auth/login` |
+| Password 검증 | 고정 password `dev-password` | dev 전용, 보안 불필요 | BCrypt |
+| Provider 구분 | `OAuthProvider.DEV_LOCAL` | 기존 OAuth 사용자와 구분 | 별도 필드 |
+| Token 발급 | 쿠키 기반 (OAuth2SuccessHandler와 동일) | 프론트엔드 일관성 | Response body |
+| SecurityConfig | 기존 SecurityConfig에 `/dev-api/**` permitAll 추가 | 단순, dev 빈이 없으면 경로 자체가 404 | 별도 SecurityConfig 빈 분리 |
+
+## API Contracts
+
+### POST /dev-api/auth/login
+- Headers: `Content-Type: application/json`
+- Request:
+```json
+{
+  "identifier": "dev-test-user",
+  "password": "dev-password"
+}
+```
+- Response (200 OK):
+```json
+{
+  "status": 200,
+  "data": null,
+  "message": "OK"
+}
+```
+- Cookies Set:
+  - `accessToken`: JWT access token
+  - `refreshToken`: JWT refresh token
+- Note: `password`가 `dev-password`와 일치하지 않으면 401 에러. dev 프로파일에서만 동작.
+
+## Implementation Todos
+
+### Todo 1: OAuthProvider에 DEV_LOCAL 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 테스트 사용자를 기존 OAuth 사용자와 구분하기 위한 provider 값 추가
+- **Work**:
+  - `security/enums/OAuthProvider.kt`에 `DEV_LOCAL("dev-local")` 값 추가
+- **Convention Notes**: 기존 enum 패턴 유지
+- **Verification**: `./gradlew spotlessApply && ./gradlew spotlessCheck`
+- **Exit Criteria**: 빌드 성공, `OAuthProvider.DEV_LOCAL` 사용 가능
+- **Status**: pending
+
+### Todo 2: DevTestLoginRequest DTO 생성
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: dev 로그인 요청 DTO 정의
+- **Work**:
+  - `security/dto/DevTestLoginRequest.kt` 파일 생성
+  - 필드: `identifier: String`, `password: String`
+  - `@Schema` annotation으로 Swagger 설명 추가
+  - `@field:NotBlank` validation 추가
+- **Convention Notes**: BACKEND.md — Request 접미사, Description 필수
+- **Verification**: 빌드 성공
+- **Exit Criteria**: DTO 클래스 컴파일 성공
+- **Status**: pending
+
+### Todo 3: DevTestAuthService 생성
+- **Priority**: 2
+- **Dependencies**: Todo 1, Todo 2
+- **Goal**: 테스트 사용자 조회/생성 및 JWT 발급 로직 구현
+- **Work**:
+  - `security/service/DevTestAuthService.kt` 파일 생성
+  - `@Service`, `@Profile("dev")` annotation
+  - 의존성: `UserRepository`, `JwtTokenProvider`, `JwtProperties`, `CookieHelper`, `TokenCachePort`
+  - `execute(request: DevTestLoginRequest, response: HttpServletResponse)` 메서드:
+    1. password 검증 (`dev-password` 고정값, 불일치 시 `ApiException` throw)
+    2. `userRepository.findByIdentifierAndProvider(request.identifier, OAuthProvider.DEV_LOCAL)` 조회
+    3. 없으면 `User` 생성 (name=identifier, email="{identifier}@dev.local", provider=DEV_LOCAL, identifier=request.identifier, role=USER, profileImageUrl="")
+    4. `jwtTokenProvider.createAccessToken(userId, role)` + `createRefreshToken(userId)`
+    5. `tokenCacheManager.saveRefreshToken(userId, refreshToken)`
+    6. `cookieHelper.addCookie(response, accessToken/refreshToken, ...)`
+- **Convention Notes**: 기존 `OAuth2SuccessHandler`의 토큰 발급 패턴 그대로 따라감
+- **Verification**: 빌드 성공
+- **Exit Criteria**: Service 클래스 컴파일 성공, 기존 코드와 동일한 JWT+쿠키 발급 플로우
+- **Status**: pending
+
+### Todo 4: SecurityConfig에 /dev-api/** permitAll 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: dev-api 경로 인증 없이 접근 허용
+- **Work**:
+  - `SecurityConfig.securityFilterChain`의 `authorizeHttpRequests` 블록에 `.requestMatchers("/dev-api/**").permitAll()` 추가
+  - 기존 permitAll 목록(swagger, oauth2 등) 바로 아래에 추가
+- **Convention Notes**: 기존 SecurityConfig 패턴 유지
+- **Verification**: 빌드 성공
+- **Exit Criteria**: `/dev-api/**` 경로가 인증 없이 접근 가능
+- **Status**: pending
+
+### Todo 5: DevTestAuthController 생성
+- **Priority**: 3
+- **Dependencies**: Todo 2, Todo 3, Todo 4
+- **Goal**: dev 전용 로그인 API 엔드포인트 구현
+- **Work**:
+  - `security/infrastructure/in/DevTestAuthController.kt` 파일 생성
+  - `@RestController`, `@Profile("dev")`, `@RequestMapping("/dev-api/auth")`, `@Tag(name = "Dev Auth", description = "개발 환경 전용 인증 API")`
+  - `POST /login` 엔드포인트:
+    - `@Operation(summary = "개발용 테스트 로그인")` Swagger annotation
+    - `@ApiResponses` — 200 성공, 401 비밀번호 불일치
+    - `@RequestBody @Valid DevTestLoginRequest` + `HttpServletResponse`
+    - `devTestAuthService.execute(request, response)` 호출
+    - `ApiResponse.ok()` 반환
+- **Convention Notes**: 기존 `AuthOpenApiController` 패턴 참고, Swagger 한국어 설명
+- **Verification**: `./gradlew spotlessApply && ./gradlew spotlessCheck`
+- **Exit Criteria**: `/dev-api/auth/login` 엔드포인트가 Swagger에 노출되고, dev 프로파일에서만 빈 등록
+- **Status**: pending
+
+### Todo 6: CLAUDE.md에 dev 환경 가이드 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: dev 환경에서 테스트 사용자 API 사용 방법과 인프라 설정 가이드 작성
+- **Work**:
+  - `CLAUDE.md`에 `## Dev Test User API` 섹션 추가
+  - 내용:
+    - API 사용법 (curl 예시)
+    - `SPRING_PROFILES_ACTIVE=dev` 설정 방법 (환경변수, application.yml, IntelliJ)
+    - dev 프로파일에서만 동작하는 원리 설명 (`@Profile("dev")`)
+    - 보안 주의사항 (production에서 dev 프로파일 사용 금지)
+- **Convention Notes**: 기존 CLAUDE.md 형식 유지
+- **Verification**: 문서 내용 확인
+- **Exit Criteria**: 다른 개발자가 가이드만 보고 dev 환경 설정 및 API 사용 가능
+- **Status**: pending
+
+### Todo 7: 최종 빌드 검증
+- **Priority**: 4
+- **Dependencies**: Todo 1, 2, 3, 4, 5, 6
+- **Goal**: 전체 코드 빌드 및 린트 통과 확인
+- **Work**:
+  - `cd main-server && ./gradlew spotlessApply && ./gradlew spotlessCheck`
+  - `./gradlew build` (전체 빌드)
+- **Convention Notes**: CLAUDE.md completion checklist 준수
+- **Verification**: 빌드 성공, spotless 통과
+- **Exit Criteria**: BUILD SUCCESSFUL
+- **Status**: pending
+
+## Verification Strategy
+- `./gradlew spotlessApply && ./gradlew spotlessCheck` — 코드 포맷 검증
+- `./gradlew build` — 전체 빌드 성공
+- dev 프로파일이 아닌 경우 `DevTestAuthController`, `DevTestAuthService` 빈이 등록되지 않는지 확인 (`@Profile("dev")`)
+
+## Progress Tracking
+- Total Todos: 7
+- Completed: 7
+- Status: Execution complete
+
+## Change Log
+- 2026-02-24: Plan created
+- 2026-02-24: All todos completed, build successful

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,50 @@
 ```bash
 cd main-server && ./gradlew spotlessApply && ./gradlew spotlessCheck
 ```
+
+## Dev Test User API
+
+dev 환경에서 OAuth2 플로우 없이 테스트 사용자로 JWT를 발급받을 수 있는 API.
+
+### 동작 원리
+
+- `@Profile("dev")` 어노테이션으로 dev 프로파일에서만 빈이 등록됨
+- dev가 아닌 환경에서는 컨트롤러/서비스 자체가 존재하지 않아 404 반환
+- 테스트 사용자는 `OAuthProvider.DEV_LOCAL` provider로 구분
+
+### 사용법
+
+```bash
+curl -X POST http://localhost:8080/open-api/dev/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"identifier": "dev-test-user", "password": "dev-password"}' \
+  -c cookies.txt
+```
+
+- `identifier`: 원하는 테스트 사용자명 (없으면 자동 생성, 있으면 기존 사용자 사용)
+- `password`: 고정값 `dev-password`
+- 응답 쿠키에 `accessToken`, `refreshToken`이 설정됨
+
+### dev 프로파일 활성화 방법
+
+**환경변수 (권장)**:
+```bash
+SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun
+```
+
+**IntelliJ Run Configuration**:
+1. Run/Debug Configurations 열기
+2. Active profiles에 `dev` 입력
+
+**application.yml (비권장, 커밋 주의)**:
+```yaml
+spring:
+  profiles:
+    active: dev
+```
+
+### 보안 주의사항
+
+- `SPRING_PROFILES_ACTIVE=dev`는 **로컬 개발 환경에서만** 사용
+- Production/Staging 환경에서는 절대로 `dev` 프로파일을 활성화하지 않아야 함
+- CI/CD 파이프라인에서 dev 프로파일이 포함되지 않도록 확인

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/security/dto/DevTestLoginRequest.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/security/dto/DevTestLoginRequest.kt
@@ -1,0 +1,20 @@
+package com.techtaurant.mainserver.security.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+
+/**
+ * 개발 환경 테스트 로그인 요청 DTO
+ *
+ * @property identifier 테스트 사용자 식별자
+ * @property password 개발 환경 고정 비밀번호 (dev-password)
+ */
+@Schema(description = "개발 환경 테스트 로그인 요청")
+data class DevTestLoginRequest(
+    @field:NotBlank(message = "식별자는 필수입니다")
+    @field:Schema(description = "테스트 사용자 식별자", example = "dev-test-user")
+    val identifier: String,
+    @field:NotBlank(message = "비밀번호는 필수입니다")
+    @field:Schema(description = "개발 환경 비밀번호", example = "dev-password")
+    val password: String,
+)

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/security/enums/OAuthProvider.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/security/enums/OAuthProvider.kt
@@ -4,6 +4,7 @@ enum class OAuthProvider(
     private val registrationId: String,
 ) {
     GOOGLE("google"),
+    DEV_LOCAL("dev-local"),
     ;
 
     fun getRegistrationId(): String {

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/security/infrastructure/in/DevTestAuthController.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/security/infrastructure/in/DevTestAuthController.kt
@@ -1,0 +1,54 @@
+package com.techtaurant.mainserver.security.infrastructure.`in`
+
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.security.SecurityConstants
+import com.techtaurant.mainserver.security.dto.DevTestLoginRequest
+import com.techtaurant.mainserver.security.service.DevTestAuthService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletResponse
+import jakarta.validation.Valid
+import org.springframework.context.annotation.Profile
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 개발 환경 전용 테스트 인증 컨트롤러
+ *
+ * dev 프로파일에서만 활성화되며, 테스트 사용자로 JWT 토큰을 발급받을 수 있다.
+ */
+@RestController
+@Profile("dev")
+@RequestMapping("${SecurityConstants.OPEN_API_PREFIX}/dev/auth")
+@Tag(name = "Dev Auth", description = "개발 환경 전용 인증 API")
+class DevTestAuthController(
+    private val devTestAuthService: DevTestAuthService,
+) {
+    @Operation(
+        summary = "개발용 테스트 로그인",
+        description = "테스트 사용자로 로그인하여 JWT 토큰을 쿠키로 발급받습니다. 사용자가 없으면 자동 생성됩니다.",
+    )
+    @ApiResponses(
+        value = [
+            io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "로그인 성공, 쿠키에 accessToken/refreshToken 설정",
+            ),
+            io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "비밀번호 불일치",
+            ),
+        ],
+    )
+    @PostMapping("/login")
+    fun login(
+        @RequestBody @Valid request: DevTestLoginRequest,
+        response: HttpServletResponse,
+    ): ApiResponse<Nothing> {
+        devTestAuthService.execute(request, response)
+        return ApiResponse.ok()
+    }
+}

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/security/service/DevTestAuthService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/security/service/DevTestAuthService.kt
@@ -1,0 +1,97 @@
+package com.techtaurant.mainserver.security.service
+
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.common.status.DefaultStatus
+import com.techtaurant.mainserver.security.cache.TokenCachePort
+import com.techtaurant.mainserver.security.dto.DevTestLoginRequest
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.security.helper.CookieHelper
+import com.techtaurant.mainserver.security.jwt.JwtConstants
+import com.techtaurant.mainserver.security.jwt.JwtProperties
+import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.context.annotation.Profile
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 개발 환경 전용 테스트 인증 서비스
+ *
+ * 테스트 사용자를 조회하거나 생성하고 JWT 토큰을 쿠키로 발급한다.
+ * dev 프로파일에서만 빈이 등록된다.
+ */
+@Service
+@Profile("dev")
+class DevTestAuthService(
+    private val userRepository: UserRepository,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val jwtProperties: JwtProperties,
+    private val cookieHelper: CookieHelper,
+    private val tokenCacheManager: TokenCachePort,
+) {
+    companion object {
+        private const val DEV_PASSWORD_HASH =
+            "\$2b\$10\$HEy96.lKMAZS.qUQRbkcMOSeqqvR3pcZyIgPNzIT0kZuX/T7BgqLi"
+        private val PASSWORD_ENCODER = BCryptPasswordEncoder()
+    }
+
+    /**
+     * 테스트 사용자 인증 및 JWT 토큰 발급
+     *
+     * @param request 테스트 로그인 요청 (identifier + password)
+     * @param response JWT 토큰 쿠키를 설정할 HTTP 응답
+     * @throws ApiException password가 일치하지 않는 경우
+     */
+    @Transactional
+    fun execute(
+        request: DevTestLoginRequest,
+        response: HttpServletResponse,
+    ) {
+        validatePassword(request.password)
+
+        val user = findOrCreateTestUser(request.identifier)
+        val userId = user.id ?: throw ApiException(DefaultStatus.SERVER_ERROR, "테스트 사용자 ID가 없습니다")
+
+        val accessToken = jwtTokenProvider.createAccessToken(userId, user.role)
+        val refreshToken = jwtTokenProvider.createRefreshToken(userId)
+
+        tokenCacheManager.saveRefreshToken(userId.toString(), refreshToken)
+
+        cookieHelper.addCookie(
+            response,
+            JwtConstants.ACCESS_TOKEN_COOKIE,
+            accessToken,
+            (jwtProperties.accessTokenExpireMs / 1000).toInt(),
+        )
+        cookieHelper.addCookie(
+            response,
+            JwtConstants.REFRESH_TOKEN_COOKIE,
+            refreshToken,
+            (jwtProperties.refreshTokenExpireMs / 1000).toInt(),
+        )
+    }
+
+    private fun validatePassword(password: String) {
+        if (!PASSWORD_ENCODER.matches(password, DEV_PASSWORD_HASH)) {
+            throw ApiException(DefaultStatus.BAD_REQUEST, "개발 환경 비밀번호가 일치하지 않습니다")
+        }
+    }
+
+    private fun findOrCreateTestUser(identifier: String): User {
+        return userRepository.findByIdentifierAndProvider(identifier, OAuthProvider.DEV_LOCAL)
+            ?: userRepository.save(
+                User(
+                    name = identifier,
+                    email = "$identifier@dev.local",
+                    provider = OAuthProvider.DEV_LOCAL,
+                    identifier = identifier,
+                    role = UserRole.USER,
+                    profileImageUrl = "",
+                ),
+            )
+    }
+}


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/auth/2602/24-dev-test-user-auth.plan.md)

## 어떤 작업인가요?
- dev 환경에서 OAuth2 플로우 없이 테스트 사용자로 JWT를 발급받을 수 있는 API 구현

## 어떻게 해결했나요?
**dev 전용 테스트 로그인 API**
- `@Profile("dev")`로 dev 프로파일에서만 컨트롤러/서비스 빈 등록
- `POST /open-api/dev/auth/login`으로 identifier + password 전송하면 테스트 사용자 자동 생성 및 JWT 쿠키 발급

**기존 인증 플로우 재사용**
- `JwtTokenProvider`, `CookieHelper`, `TokenCachePort` 등 기존 인프라 그대로 활용하여 OAuth2 로그인과 동일한 방식으로 토큰 발급

## 중요한 변경 사항은 무엇인가요?
### dev 전용 인증 API 추가

**OAuthProvider.DEV_LOCAL 추가**
- **변경 이유**: 테스트 사용자를 기존 OAuth 사용자와 구분하기 위함
- **수정 파일**: `security/enums/OAuthProvider.kt`

**DevTestAuthService + DevTestAuthController 신규 생성**
- **변경 이유**: dev 환경에서 OAuth2 없이 즉시 JWT 발급
- **수정 파일**: `security/service/DevTestAuthService.kt`, `security/infrastructure/in/DevTestAuthController.kt`, `security/dto/DevTestLoginRequest.kt`

**password BCrypt 해싱 적용**
- **변경 이유**: dev용이라도 평문 비교 대신 BCrypt 해시 비교로 최소한의 보안 유지
- **수정 파일**: `security/service/DevTestAuthService.kt`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
