### PR TITLE
refactor(post): 읽음 상태 API 리팩토링 및 Optional Auth 읽음 상태 버그 수정

### DIFF
--- a/.claude/plan/post/2602/27-fix-optional-auth-read-status.plan.md
+++ b/.claude/plan/post/2602/27-fix-optional-auth-read-status.plan.md
@@ -1,0 +1,48 @@
+# 게시물 목록 조회 Optional Auth 읽음 상태 수정
+
+## Business Goal
+게시물 목록 조회 API에서 로그인한 사용자의 읽음 여부(isRead)가 항상 false로 반환되는 버그를 수정하여,
+Optional Auth 기반으로 정확한 읽음 상태를 표시한다.
+
+## Scope
+- **In Scope**:
+  - `PostReadOpenApiController.getPosts()`에 `@AuthenticationPrincipal userId: UUID?` 추가
+  - `PostListReadService.getPosts()`에 `userId: UUID?` 파라미터 추가
+  - `getCurrentUserId()` 메서드 제거
+  - 테스트 코드 업데이트
+  - spotlessApply
+- **Out of Scope**:
+  - PostDetailReadService 변경 (이미 올바르게 구현됨)
+
+## Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `main-server/.../post/application/PostListReadService.kt` | 게시물 목록 조회 서비스 | Modify |
+| `main-server/.../post/infrastructure/in/PostReadOpenApiController.kt` | Open API 컨트롤러 | Modify |
+
+## Implementation Todos
+
+### Todo 1: PostListReadService.getPosts()에 userId 파라미터 추가 및 getCurrentUserId 제거
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: SecurityContext 의존 제거, 명시적 파라미터 전달 방식으로 전환
+- **Status**: pending
+
+### Todo 2: PostReadOpenApiController.getPosts()에 @AuthenticationPrincipal 추가
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 컨트롤러에서 Optional Auth userId를 서비스로 전달
+- **Status**: pending
+
+### Todo 3: spotlessApply 및 빌드 검증
+- **Priority**: 3
+- **Dependencies**: Todo 2
+- **Status**: pending
+
+## Progress Tracking
+- Total Todos: 3
+- Completed: 0
+- Status: Planning complete
+
+## Change Log
+- 2026-02-27: Plan created

--- a/.claude/plan/post/2602/27-refactor-read-log-api.plan.md
+++ b/.claude/plan/post/2602/27-refactor-read-log-api.plan.md
@@ -1,0 +1,126 @@
+# 게시물 읽음 상태 API 리팩토링
+
+## Business Goal
+게시물 읽음 상태 변경 API의 경로를 RESTful 컨벤션에 맞게 `read-logs`로 변경하고,
+Swagger 에러 응답 명세를 구체화하여 프론트엔드 개발자가 에러 핸들링을 정확히 할 수 있도록 한다.
+
+## Scope
+- **In Scope**:
+  - API 경로 `/api/posts/{postId}/read` → `/api/posts/{postId}/read-logs` 변경
+  - `UserStatus`에 `USER_NOT_FOUND(404, 1002)` 추가
+  - `PostReadLogService`에서 `USER_NOT_FOUND` 사용
+  - Swagger `@ApiResponses`에 구체적 에러 코드/메시지 명시
+  - 테스트 코드 경로 및 에러 코드 업데이트
+- **Out of Scope**:
+  - Docs 인터페이스 분리
+  - 기존 `UserStatus.ID_NOT_FOUND` 변경
+  - 다른 컨트롤러의 Swagger 개선
+
+## Codebase Analysis Summary
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `main-server/.../post/infrastructure/in/PostReadController.kt` | 읽음 상태 변경 컨트롤러 | Modify |
+| `main-server/.../post/application/PostReadLogService.kt` | 읽음 상태 토글 서비스 | Modify |
+| `main-server/.../user/enums/UserStatus.kt` | 사용자 에러 상태 enum | Modify |
+| `main-server/.../post/infrastructure/in/PostReadControllerTest.kt` | E2E 테스트 | Modify |
+| `main-server/.../post/application/PostReadLogServiceTest.kt` | 서비스 통합 테스트 | Modify |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| Enum 구조 | `PostStatus`, `UserStatus` | `(httpStatusCode, customStatusCode, description)` + `StatusIfs` 구현 |
+| Swagger 스타일 | 기존 컨트롤러들 | `@ApiResponses` + `io.swagger.v3.oas.annotations.responses.ApiResponse` |
+| 에러 메시지 | BACKEND.md | 한국어 description |
+| 테스트 패턴 | SPRING_BOOT.md | Given-When-Then, `@DisplayName` 한국어 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 사용자 미존재 에러 | `USER_NOT_FOUND(404, 1002)` 신규 추가 | 기존 `ID_NOT_FOUND(500)`과 분리, RESTful 404 | 기존 변경 (다른 참조 영향) |
+| Swagger 상세화 | description에 에러코드/메시지 텍스트 포함 | 프로젝트 기존 패턴 유지 | content+Schema 방식 |
+
+## API Contracts
+
+### POST /api/posts/{postId}/read-logs
+- Headers: `Authorization: Bearer {token}`
+- Request: `{ "isRead": boolean }`
+- Response 200: `{ "status": 200, "data": null, "message": "성공" }`
+- Response 401: Spring Security 처리
+- Response 404 (게시물): `{ "status": 3001, "data": null, "message": "게시물을 찾을 수 없습니다" }`
+- Response 404 (사용자): `{ "status": 1002, "data": null, "message": "사용자를 찾을 수 없습니다" }`
+
+## Implementation Todos
+
+### Todo 1: UserStatus에 USER_NOT_FOUND 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: HTTP 404에 매핑되는 사용자 미존재 에러 코드 추가
+- **Work**:
+  - `UserStatus.kt`에 `USER_NOT_FOUND(404, 1002, "사용자를 찾을 수 없습니다")` enum 값 추가
+- **Convention Notes**: 기존 enum 구조 `(httpStatusCode, customStatusCode, description)` 준수
+- **Verification**: 빌드 성공
+- **Exit Criteria**: `UserStatus.USER_NOT_FOUND` 접근 가능
+- **Status**: pending
+
+### Todo 2: PostReadLogService에서 USER_NOT_FOUND 사용
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 사용자 미존재 시 404 에러 반환
+- **Work**:
+  - `PostReadLogService.toggleReadStatus`에서 `UserStatus.ID_NOT_FOUND` → `UserStatus.USER_NOT_FOUND`로 변경
+- **Convention Notes**: 기존 코드 패턴 유지
+- **Verification**: 빌드 성공
+- **Exit Criteria**: 사용자 미존재 시 HTTP 404 + custom code 1002 반환
+- **Status**: pending
+
+### Todo 3: API 경로 변경 및 Swagger 상세화
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: API 경로를 read-logs로 변경하고 Swagger 에러 응답 명세를 구체화
+- **Work**:
+  - `PostReadController.kt`의 `@PostMapping("/{postId}/read")` → `@PostMapping("/{postId}/read-logs")`
+  - `@ApiResponses`의 각 에러 응답 description에 구체적 에러 코드/메시지 추가:
+    - 200: "읽음 상태 변경 성공"
+    - 401: "인증되지 않은 사용자"
+    - 404: "게시물을 찾을 수 없음 (status: 3001, message: 게시물을 찾을 수 없습니다) / 사용자를 찾을 수 없음 (status: 1002, message: 사용자를 찾을 수 없습니다)"
+- **Convention Notes**: 기존 `@ApiResponses` 스타일 유지
+- **Verification**: 빌드 성공
+- **Exit Criteria**: Swagger UI에서 변경된 경로와 상세 에러 명세 확인 가능
+- **Status**: pending
+
+### Todo 4: 테스트 코드 업데이트
+- **Priority**: 3
+- **Dependencies**: Todo 2, Todo 3
+- **Goal**: 변경된 API 경로와 에러 코드에 맞게 테스트 수정
+- **Work**:
+  - `PostReadControllerTest.kt`: 모든 API 호출 경로 `/api/posts/{postId}/read` → `/api/posts/{postId}/read-logs`
+  - `PostReadLogServiceTest.kt`: `toggleReadStatus_withNonExistentUser_shouldThrowException`에서 `UserStatus.ID_NOT_FOUND` → `UserStatus.USER_NOT_FOUND`
+- **Convention Notes**: Given-When-Then 패턴, `@DisplayName` 한국어
+- **Verification**: 테스트 전체 통과
+- **Exit Criteria**: 모든 관련 테스트 PASS
+- **Status**: pending
+
+### Todo 5: spotlessApply 및 최종 검증
+- **Priority**: 4
+- **Dependencies**: Todo 4
+- **Goal**: 코드 포맷팅 및 빌드 최종 확인
+- **Work**:
+  - `cd main-server && ./gradlew spotlessApply && ./gradlew spotlessCheck`
+- **Convention Notes**: CLAUDE.md Completion Checklist
+- **Verification**: spotlessCheck 통과
+- **Exit Criteria**: spotless 통과 + 빌드 성공
+- **Status**: pending
+
+## Verification Strategy
+- `./gradlew spotlessApply && ./gradlew spotlessCheck`
+- 관련 테스트 실행
+
+## Progress Tracking
+- Total Todos: 5
+- Completed: 0
+- Status: Planning complete
+
+## Change Log
+- 2026-02-27: Plan created

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -10,9 +10,7 @@ import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
-import com.techtaurant.mainserver.user.entity.User
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -35,6 +33,7 @@ class PostListReadService(
      * @param size 페이지 크기
      * @param period 기간 필터 (WEEK, MONTH, YEAR, ALL)
      * @param sortType 정렬 기준 (LATEST, VIEW, LIKE, COMMENT)
+     * @param userId 현재 사용자 ID (비회원이면 null)
      * @return 커서 기반 페이지 응답
      */
     fun getPosts(
@@ -42,6 +41,7 @@ class PostListReadService(
         size: Int,
         period: PostPeriod = PostPeriod.ALL,
         sortType: PostSortType = PostSortType.LATEST,
+        userId: UUID? = null,
     ): CursorPageResponse<PostListItemResponse> {
         val postCursor = cursor?.let { PostCursor.decode(it) }
 
@@ -72,11 +72,10 @@ class PostListReadService(
                 null
             }
 
-        val currentUserId = getCurrentUserId()
         val readPostIds =
-            if (currentUserId != null && content.isNotEmpty()) {
+            if (userId != null && content.isNotEmpty()) {
                 postReadLogRepository.findByUserIdAndPostIdIn(
-                    userId = currentUserId,
+                    userId = userId,
                     postIds = content.mapNotNull { it.id },
                 ).map { it.postId }.toSet()
             } else {
@@ -147,17 +146,6 @@ class PostListReadService(
         id: UUID,
     ): String {
         return "${updatedAt.time}_$id"
-    }
-
-    /**
-     * SecurityContext에서 현재 로그인한 사용자의 ID를 추출합니다.
-     * 인증되지 않은 사용자(비회원)인 경우 null을 반환합니다.
-     *
-     * @return 현재 사용자 ID (비회원이면 null)
-     */
-    private fun getCurrentUserId(): UUID? {
-        val authentication = SecurityContextHolder.getContext().authentication
-        return (authentication?.principal as? User)?.id
     }
 
     /**

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostReadLogService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostReadLogService.kt
@@ -42,7 +42,7 @@ class PostReadLogService(
 
         val user =
             userRepository.findById(userId).orElseThrow {
-                ApiException(UserStatus.ID_NOT_FOUND)
+                ApiException(UserStatus.USER_NOT_FOUND)
             }
 
         val existingLog = postReadLogRepository.findByPostIdAndUserId(postId, userId)

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadController.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadController.kt
@@ -23,7 +23,7 @@ import java.util.UUID
 class PostReadController(
     private val postReadLogService: PostReadLogService,
 ) {
-    @PostMapping("/{postId}/read")
+    @PostMapping("/{postId}/read-logs")
     @Operation(summary = "게시물 읽음 상태 변경", description = "게시물에 대한 읽음 상태를 변경합니다. isRead=true: 읽음 표시, isRead=false: 안읽음 표시. 인증된 사용자만 호출 가능합니다.")
     @ApiResponses(
         value = [
@@ -37,7 +37,9 @@ class PostReadController(
             ),
             io.swagger.v3.oas.annotations.responses.ApiResponse(
                 responseCode = "404",
-                description = "게시물 또는 사용자를 찾을 수 없음",
+                description = """게시물 또는 사용자를 찾을 수 없음
+                    - 게시물 미존재: status=3001, message="게시물을 찾을 수 없습니다"
+                    - 사용자 미존재: status=1002, message="사용자를 찾을 수 없습니다"""",
             ),
         ],
     )

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiController.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiController.kt
@@ -65,8 +65,9 @@ class PostReadOpenApiController(
         @Parameter(description = "정렬 기준 (LATEST: 최신순, VIEW: 조회순, LIKE: 추천순, COMMENT: 댓글순)")
         @RequestParam(defaultValue = "LATEST")
         sort: PostSortType,
+        @AuthenticationPrincipal userId: UUID?,
     ): ApiResponse<CursorPageResponse<PostListItemResponse>> {
-        return ApiResponse.ok(postListReadService.getPosts(cursor, size, period, sort))
+        return ApiResponse.ok(postListReadService.getPosts(cursor, size, period, sort, userId))
     }
 
     @Operation(

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/security/config/SwaggerConfig.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/security/config/SwaggerConfig.kt
@@ -22,7 +22,7 @@ import org.springframework.context.annotation.Configuration
  */
 @Configuration
 class SwaggerConfig(
-    @Value("\${swagger.base-url}")
+    @param:Value("\${swagger.base-url}")
     private val swaggerBaseUrl: String,
 ) {
     companion object {

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/user/enums/UserStatus.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/user/enums/UserStatus.kt
@@ -1,12 +1,14 @@
 package com.techtaurant.mainserver.user.enums
 
 import com.techtaurant.mainserver.common.status.StatusIfs
+import org.springframework.http.HttpStatus
 
 enum class UserStatus(
     private val httpStatusCode: Int,
     private val customStatusCode: Int,
     private val description: String,
 ) : StatusIfs {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 1002, "사용자를 찾을 수 없습니다"),
     ID_NOT_FOUND(500, 1001, "User ID not found"),
     ;
 

--- a/main-server/src/main/resources/application.yml
+++ b/main-server/src/main/resources/application.yml
@@ -1,5 +1,6 @@
 server:
-  forward-headers-strategy: native
+    forward-headers-strategy: native
+    port: ${SERVER_PORT:8080}
 
 spring:
   application:

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostReadLogServiceTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostReadLogServiceTest.kt
@@ -172,7 +172,7 @@ class PostReadLogServiceTest : IntegrationTest() {
         }
             .isInstanceOf(ApiException::class.java)
             .extracting { (it as ApiException).status }
-            .isEqualTo(UserStatus.ID_NOT_FOUND)
+            .isEqualTo(UserStatus.USER_NOT_FOUND)
     }
 
     @Test

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadControllerTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadControllerTest.kt
@@ -103,7 +103,7 @@ class PostReadControllerTest : IntegrationTest() {
         // Given: 읽음 기록이 없는 상태
         val request = RecordPostReadRequest(isRead = true)
 
-        // When: POST /api/posts/{postId}/read 호출
+        // When: POST /api/posts/{postId}/read-logs 호출
         val response =
             RestAssured
                 .given()
@@ -111,7 +111,7 @@ class PostReadControllerTest : IntegrationTest() {
                 .header("Authorization", "Bearer $accessToken")
                 .body(request)
                 .`when`()
-                .post("/api/posts/${testPost.id}/read")
+                .post("/api/posts/${testPost.id}/read-logs")
                 .then()
                 .statusCode(200)
                 .extract()
@@ -140,7 +140,7 @@ class PostReadControllerTest : IntegrationTest() {
         val readLogId = readLog.id!!
         val request = RecordPostReadRequest(isRead = false)
 
-        // When: POST /api/posts/{postId}/read 호출 (isRead=false)
+        // When: POST /api/posts/{postId}/read-logs 호출 (isRead=false)
         val response =
             RestAssured
                 .given()
@@ -148,7 +148,7 @@ class PostReadControllerTest : IntegrationTest() {
                 .header("Authorization", "Bearer $accessToken")
                 .body(request)
                 .`when`()
-                .post("/api/posts/${testPost.id}/read")
+                .post("/api/posts/${testPost.id}/read-logs")
                 .then()
                 .statusCode(200)
                 .extract()
@@ -178,7 +178,7 @@ class PostReadControllerTest : IntegrationTest() {
                 .header("Authorization", "Bearer $accessToken")
                 .body(request)
                 .`when`()
-                .post("/api/posts/$nonExistentPostId/read")
+                .post("/api/posts/$nonExistentPostId/read-logs")
                 .then()
                 .statusCode(404)
                 .extract()
@@ -202,7 +202,7 @@ class PostReadControllerTest : IntegrationTest() {
             .contentType(ContentType.JSON)
             .body(request)
             .`when`()
-            .post("/api/posts/${testPost.id}/read")
+            .post("/api/posts/${testPost.id}/read-logs")
             .then()
             .statusCode(401)
     }
@@ -227,7 +227,7 @@ class PostReadControllerTest : IntegrationTest() {
                 .header("Authorization", "Bearer $accessToken")
                 .body(request)
                 .`when`()
-                .post("/api/posts/${testPost.id}/read")
+                .post("/api/posts/${testPost.id}/read-logs")
                 .then()
                 .statusCode(200)
                 .extract()


### PR DESCRIPTION
## 관련 자료
- [작업 계획 - API 리팩토링](.claude/plan/post/2602/27-refactor-read-log-api.plan.md)
- [작업 계획 - Optional Auth 수정](.claude/plan/post/2602/27-fix-optional-auth-read-status.plan.md)

## 어떤 작업인가요?
- 게시물 읽음 상태 API 경로를 RESTful 컨벤션에 맞게 리팩토링하고, Swagger 에러 응답을 상세화하며, 게시물 목록 조회 시 Optional Auth 기반 읽음 상태가 반영되지 않던 버그를 수정합니다.

## 어떻게 해결했나요?
**읽음 상태 API 경로 변경 및 Swagger 상세화**
- API 경로를 `/api/posts/{postId}/read` → `/api/posts/{postId}/read-logs`로 변경
- `UserStatus.USER_NOT_FOUND(404, 1002)` 추가하여 사용자 미존재 시 적절한 HTTP 404 반환
- Swagger 404 에러 응답에 구체적인 에러 코드/메시지 명시

**게시물 목록 Optional Auth 읽음 상태 버그 수정**
- `getCurrentUserId()`가 JWT principal(UUID)을 `User` 엔티티로 캐스팅하여 항상 `null`을 반환하는 버그 수정
- `PostDetailReadService` 패턴과 동일하게 `@AuthenticationPrincipal`로 userId를 직접 전달하는 방식으로 변경

**Config 수정**
- `SwaggerConfig`의 `@Value` → `@param:Value` 어노테이션 수정
- 서버 포트 환경변수 설정 추가

## 중요한 변경 사항은 무엇인가요?
### 읽음 상태 API 리팩토링

**API 경로 변경**
- **변경 이유**: RESTful 컨벤션에 맞는 리소스 기반 경로로 변경
- **수정 파일**: `PostReadController.kt`, `PostReadControllerTest.kt`

**UserStatus.USER_NOT_FOUND 추가**
- **변경 이유**: 기존 `ID_NOT_FOUND(500)`는 HTTP 의미상 부적절, 별도 404 에러 코드 추가
- **수정 파일**: `UserStatus.kt`, `PostReadLogService.kt`, `PostReadLogServiceTest.kt`

**Swagger 에러 응답 상세화**
- **변경 이유**: 프론트엔드 개발자가 에러 핸들링을 정확히 할 수 있도록 구체적 에러 코드/메시지 명시
- **수정 파일**: `PostReadController.kt`

### Optional Auth 읽음 상태 버그 수정

**getCurrentUserId() 제거 및 파라미터 전달 방식으로 변경**
- **변경 이유**: `authentication.principal`이 `UUID`인데 `User`로 캐스팅하여 항상 null 반환 → isRead가 항상 false
- **수정 파일**: `PostListReadService.kt`, `PostReadOpenApiController.kt`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
