### PR TITLE
feat(post): 사용자별 게시물 목록 조회 및 본인 DRAFT/PRIVATE 노출

### DIFF
--- a/.claude/plan/post/2602/27-fix-get-current-user-id.plan.md
+++ b/.claude/plan/post/2602/27-fix-get-current-user-id.plan.md
@@ -1,0 +1,65 @@
+# getCurrentUserId() 버그 수정
+
+## Business Goal
+`PostListReadService.getCurrentUserId()`가 JWT principal(UUID)을 `User`로 캐스팅하여 항상 null을 반환하는 버그를 수정한다. 이를 통해 `getPosts()`의 `visibleToUserId`와 `getPostsByUserId()`의 본인/타인 분기가 정상 동작하도록 한다.
+
+## Scope
+- **In Scope**: `getCurrentUserId()` 캐스팅 수정, 테스트 mock 업데이트
+- **Out of Scope**: `getPostDetail()` (이미 `@AuthenticationPrincipal userId: UUID?`로 정상 동작)
+
+## Codebase Analysis Summary
+- `JwtAuthenticationFilter`가 `claims.userId`(UUID)를 principal로 저장
+- `@AuthenticationPrincipal userId: UUID?` 패턴이 프로젝트 전체에서 사용됨
+- `getCurrentUserId()`만 `(principal as? User)?.id` 패턴을 사용하여 불일치
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `post/application/PostListReadService.kt` | `getCurrentUserId()` 메서드 | Modify |
+| `post/application/PostListReadServiceTest.kt` | 테스트 mock 수정 | Modify |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| Principal 타입 | JwtAuthenticationFilter | principal은 UUID (User가 아님) |
+| Given-When-Then | SPRING_BOOT.md | 모든 테스트는 GWT 패턴 |
+| spotless | CLAUDE.md | `spotlessApply && spotlessCheck` 필수 |
+
+## Implementation Todos
+
+### Todo 1: getCurrentUserId() 캐스팅 수정
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: principal을 UUID로 직접 캐스팅하여 로그인 사용자 ID를 정상 반환
+- **Work**:
+  - `PostListReadService.kt`의 `getCurrentUserId()` 메서드에서 `(authentication?.principal as? User)?.id`를 `authentication?.principal as? UUID`로 변경
+  - User import 제거 (더 이상 사용하지 않는 경우)
+- **Convention Notes**: JwtAuthenticationFilter가 UUID를 principal로 저장하는 패턴에 맞춤
+- **Verification**: 컴파일 성공
+- **Exit Criteria**: `getCurrentUserId()`가 UUID principal을 정상 반환
+- **Status**: completed
+
+### Todo 2: 테스트 mock 업데이트
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 테스트의 `setCurrentUser()` 헬퍼가 UUID를 principal로 설정하도록 수정
+- **Work**:
+  - `PostListReadServiceTest.kt`의 `setCurrentUser()` 메서드에서 `authentication.principal`이 `user`가 아닌 `user.id`를 반환하도록 변경
+  - User import는 테스트 데이터 생성에 여전히 필요하므로 유지
+- **Convention Notes**: Given-When-Then, @DisplayName 한국어
+- **Verification**: 모든 테스트 통과
+- **Exit Criteria**: 기존 9개 단위 테스트 모두 통과
+- **Status**: completed
+
+## Verification Strategy
+- `./gradlew spotlessApply && ./gradlew spotlessCheck`
+- `./gradlew test --tests PostListReadServiceTest -x jacocoTestCoverageVerification`
+
+## Progress Tracking
+- Total Todos: 2
+- Completed: 2
+- Status: Execution complete
+
+## Change Log
+- 2026-02-27: Plan created
+- 2026-02-27: All todos completed. 9 tests passed, spotless check passed

--- a/.claude/plan/post/2602/27-post-list-visible-own-drafts.plan.md
+++ b/.claude/plan/post/2602/27-post-list-visible-own-drafts.plan.md
@@ -1,0 +1,94 @@
+# 게시물 전체 목록에서 본인 DRAFT/PRIVATE 게시물 노출
+
+## Business Goal
+게시물 전체 목록 조회 API에서 로그인한 사용자가 자신의 DRAFT/PRIVATE 게시물도 함께 볼 수 있도록 한다. 타인의 DRAFT/PRIVATE은 여전히 비노출.
+
+## Scope
+- **In Scope**: `getPosts()` 서비스 로직 수정, Repository 쿼리 조건 추가, Swagger 에러 응답 명세 보강
+- **Out of Scope**: `getPostsByUserId()` (이미 구현됨), 새로운 API 엔드포인트 추가
+
+## Codebase Analysis Summary
+`PostListReadService.getPosts()`가 `findPostsWithConditions()`를 statuses 파라미터 없이 호출하여 PUBLISHED만 조회됨. Repository는 이미 `statuses`, `authorId` 파라미터를 지원하지만 "PUBLISHED OR 내 게시물" 같은 OR 조건은 불가. 새 파라미터 필요.
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `PostRepositoryCustom.kt` | 커스텀 Repository 인터페이스 | Modify - `visibleToUserId` 파라미터 추가 |
+| `PostRepositoryCustomImpl.kt` | 커스텀 Repository 구현체 | Modify - OR 조건 쿼리 추가 |
+| `PostListReadService.kt` | 게시물 목록 서비스 | Modify - `getPosts()`에서 currentUserId 전달 |
+| `PostReadOpenApiController.kt` | Open API 컨트롤러 | Modify - Swagger 400 에러 응답 스키마 추가 |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| Swagger 에러 응답 | CLAUDE.md | `@Content` + `@Schema` + `@ExampleObject` 필수, const val 분리 |
+| Given-When-Then 테스트 | SPRING_BOOT.md | 모든 테스트는 GWT 패턴 준수 |
+| spotless | CLAUDE.md | 변경 후 `spotlessApply && spotlessCheck` 필수 |
+
+## Implementation Todos
+
+### Todo 1: Repository에 visibleToUserId 파라미터 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: `findPostsWithConditions()`에 `visibleToUserId` 파라미터를 추가하여 `(status = PUBLISHED) OR (author = visibleToUserId)` 조건 지원
+- **Work**:
+  - `PostRepositoryCustom.kt`: `visibleToUserId: UUID? = null` 파라미터 추가
+  - `PostRepositoryCustomImpl.kt`: `visibleToUserId != null`일 때 `cb.or(publishedPredicate, authorPredicate)` 조건 생성. 기존 `statuses`/기본 PUBLISHED 로직보다 우선 적용
+- **Convention Notes**: 기존 `authorId`, `statuses`, `categoryId`와 동일한 nullable 기본값 패턴
+- **Verification**: 컴파일 성공
+- **Exit Criteria**: `findPostsWithConditions(visibleToUserId = someUUID)` 호출 시 PUBLISHED + 해당 사용자의 모든 상태 게시물 반환
+- **Status**: completed
+
+### Todo 2: 서비스 로직 수정
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: `PostListReadService.getPosts()`에서 현재 로그인 사용자 ID를 `visibleToUserId`로 전달
+- **Work**:
+  - `PostListReadService.kt`의 `getPosts()` 메서드에서 `getCurrentUserId()`를 `visibleToUserId` 파라미터로 전달
+- **Convention Notes**: 기존 `getCurrentUserId()` 메서드 재사용
+- **Verification**: 컴파일 성공
+- **Exit Criteria**: 로그인 시 본인 DRAFT/PRIVATE 포함, 비로그인 시 PUBLISHED만 조회
+- **Status**: completed
+
+### Todo 3: Swagger 에러 응답 명세 보강
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: `PostReadOpenApiController`의 400 에러 응답에 실제 응답 포맷 문서화
+- **Work**:
+  - `PostReadOpenApiController.kt`에 `@Content` + `@Schema(implementation = ApiResponse::class)` + `@ExampleObject` 추가
+  - `companion object`에 `VALIDATION_ERROR_EXAMPLE` const val 정의
+  - import alias `import ... as SwaggerApiResponse` 적용
+- **Convention Notes**: CLAUDE.md의 Swagger 에러 응답 명세 규칙 준수
+- **Verification**: 컴파일 성공, spotlessCheck 통과
+- **Exit Criteria**: Swagger UI에서 400 에러 응답 body 스키마와 예시 확인 가능
+- **Status**: completed
+
+### Todo 4: 테스트 추가
+- **Priority**: 2
+- **Dependencies**: Todo 1, Todo 2
+- **Goal**: 변경된 로직에 대한 테스트 커버리지 확보
+- **Work**:
+  - `PostListReadServiceTest.kt`에 `getPosts()` 관련 테스트 추가:
+    - 로그인 사용자: 본인 DRAFT/PRIVATE 포함 + 타인 PUBLISHED만 조회 (visibleToUserId 전달 확인)
+    - 비로그인: visibleToUserId가 null로 전달 확인
+  - `PostRepositoryCustomImplTest.kt`에 `visibleToUserId` 테스트 추가:
+    - visibleToUserId 지정 시 PUBLISHED + 해당 사용자의 DRAFT/PRIVATE 모두 반환
+    - visibleToUserId null 시 PUBLISHED만 반환
+- **Convention Notes**: MockK, Given-When-Then, @DisplayName 한국어
+- **Verification**: 테스트 전체 통과
+- **Exit Criteria**: 모든 분기 커버리지 확보
+- **Status**: completed
+
+## Verification Strategy
+- `./gradlew spotlessApply && ./gradlew spotlessCheck`
+- `./gradlew test --tests PostListReadServiceTest`
+- `./gradlew test --tests PostRepositoryCustomImplTest`
+
+## Progress Tracking
+- Total Todos: 4
+- Completed: 4
+- Status: All completed
+
+## Change Log
+- 2026-02-27: Plan created
+- 2026-02-27: All todos completed. 20 tests passed (9 unit + 11 integration), spotless check passed

--- a/.claude/plan/user/2602/27-user-posts-list-api.plan.md
+++ b/.claude/plan/user/2602/27-user-posts-list-api.plan.md
@@ -1,0 +1,117 @@
+# User Posts List API
+
+## Business Goal
+특정 사용자의 게시물 목록을 조회하는 API를 제공한다. 본인의 게시물 조회 시 DRAFT/PRIVATE 포함, 타인 조회 시 PUBLISHED만 반환. categoryId 필터링 지원.
+
+## Scope
+- **In Scope**: PostRepositoryCustom에 authorId/statuses/categoryId 파라미터 추가, PostListReadService에 사용자별 조회 메서드, UserOpenApiController에 엔드포인트, Swagger 문서화
+- **Out of Scope**: 새 DTO 생성 (PostListItemResponse 재사용), 테스트 코드
+
+## Codebase Analysis Summary
+- Post 엔티티는 `author: User` (ManyToOne) 관계
+- `PostRepositoryCustomImpl.findPostsWithConditions`가 Criteria API로 동적 쿼리 수행 (기간, 정렬, 커서)
+- `PostListReadService.getPosts`가 커서 페이지네이션 + 읽음 상태 처리
+- `UserOpenApiController`가 `/open-api/users` 경로의 공개 API 담당
+- `getCurrentUserId()`로 SecurityContext에서 현재 사용자 ID 추출 (비회원이면 null)
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `post/infrastructure/out/PostRepositoryCustom.kt` | 커스텀 쿼리 인터페이스 | Modify |
+| `post/infrastructure/out/PostRepositoryCustomImpl.kt` | 커스텀 쿼리 구현체 | Modify |
+| `post/application/PostListReadService.kt` | 게시물 목록 조회 서비스 | Modify |
+| `user/infrastructure/in/UserOpenApiController.kt` | 사용자 Open API 컨트롤러 | Modify |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| Open API 경로 | `SecurityConstants.OPEN_API_PREFIX` | `/open-api/` prefix 사용 |
+| 응답 래핑 | 기존 컨트롤러 | `ApiResponse.ok()` 사용 |
+| 페이지네이션 | `CursorPageResponse<T>` | 커서 기반 페이지네이션 |
+| Swagger | 기존 컨트롤러 | `@Operation`, `@ApiResponses`, `@Parameter` 어노테이션 |
+| 쿼리 파라미터 | 기존 `getPosts` | `@RequestParam(required = false)` 패턴 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 엔드포인트 위치 | `UserOpenApiController` | User 리소스 하위 경로 | PostReadOpenApiController |
+| 상태 필터 로직 | Service에서 본인 여부 판단 | 비즈니스 로직은 서비스 레이어 | Controller 분기 |
+| 쿼리 변경 | 기존 findPostsWithConditions에 optional 파라미터 추가 | DRY | 별도 메서드 |
+| 응답 DTO | PostListItemResponse 재사용 | 동일 구조 | 새 DTO |
+
+## API Contracts
+
+### GET /open-api/users/{userId}/posts
+- Headers: Authorization (optional, Bearer JWT)
+- Request Query Params:
+  - `cursor`: String? (이전 응답의 nextCursor)
+  - `size`: Int (1-100, 기본값 20)
+  - `period`: PostPeriod (WEEK/MONTH/YEAR/ALL, 기본값 ALL)
+  - `sort`: PostSortType (LATEST/VIEW/LIKE/COMMENT, 기본값 LATEST)
+  - `categoryId`: UUID? (카테고리 필터)
+- Response: `ApiResponse<CursorPageResponse<PostListItemResponse>>`
+- Note: 본인 조회 시 모든 상태, 타인 조회 시 PUBLISHED만
+
+## Implementation Todos
+
+### Todo 1: PostRepositoryCustom/Impl에 authorId, statuses, categoryId 파라미터 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 동적 쿼리에 작성자, 상태 목록, 카테고리 필터 조건 추가
+- **Work**:
+  - `PostRepositoryCustom.findPostsWithConditions`에 `authorId: UUID? = null`, `statuses: List<PostStatusEnum>? = null`, `categoryId: UUID? = null` 파라미터 추가
+  - `PostRepositoryCustomImpl.findPostsWithConditions`에 해당 파라미터 반영
+  - authorId가 non-null이면 `cb.equal(root.get(Post_.AUTHOR).get("id"), authorId)` 조건 추가
+  - statuses가 non-null이면 기존 `cb.equal(root.get(Post_.status), PostStatusEnum.PUBLISHED)` 대신 `root.get(Post_.status).in(statuses)` 사용
+  - statuses가 null이면 기존대로 PUBLISHED만 필터
+  - categoryId가 non-null이면 `cb.equal(root.get(Post_.CATEGORY).get("id"), categoryId)` 조건 추가
+  - 기존 호출부 (`PostListReadService.getPosts`)는 파라미터 기본값으로 영향 없음
+- **Convention Notes**: Criteria API 패턴 유지, 기존 predicate 추가 방식 준수
+- **Verification**: 빌드 성공 (`./gradlew compileKotlin`)
+- **Exit Criteria**: 기존 테스트 통과, 새 파라미터가 optional이어서 기존 호출 영향 없음
+- **Status**: pending
+
+### Todo 2: PostListReadService에 사용자별 게시물 조회 메서드 추가
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 사용자 ID 기반 게시물 목록 조회 + 본인 여부에 따른 상태 필터 로직
+- **Work**:
+  - `PostListReadService`에 `getPostsByUserId(userId: UUID, cursor: String?, size: Int, period: PostPeriod, sortType: PostSortType, categoryId: UUID?)` 메서드 추가
+  - `getCurrentUserId()`로 현재 사용자 확인
+  - `currentUserId == userId`이면 statuses = `listOf(DRAFT, PUBLISHED, PRIVATE)`, 아니면 statuses = `listOf(PUBLISHED)`
+  - `postRepository.findPostsWithConditions(cursor, size+1, period, sortType, authorId=userId, statuses=statuses, categoryId=categoryId)` 호출
+  - 이후 기존 `getPosts`와 동일한 커서/읽음 처리 로직 적용
+  - `getCurrentUserId()` 메서드를 private에서 접근 가능하도록 조정 (이미 같은 클래스 내부이므로 그대로 사용)
+- **Convention Notes**: 기존 `getPosts` 메서드의 패턴 (커서 디코딩 → 쿼리 → hasNext 계산 → 읽음 상태 → 응답 변환) 동일하게 따름
+- **Verification**: 빌드 성공
+- **Exit Criteria**: 메서드가 정상 컴파일, 기존 getPosts 영향 없음
+- **Status**: pending
+
+### Todo 3: UserOpenApiController에 엔드포인트 추가
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: GET /open-api/users/{userId}/posts 엔드포인트 추가 + Swagger 문서화
+- **Work**:
+  - `UserOpenApiController`에 `PostListReadService` 의존성 추가 (생성자 주입)
+  - `getPostsByUserId` 메서드 추가:
+    - `@GetMapping("/{userId}/posts")`
+    - `@PathVariable userId: UUID`
+    - `@RequestParam cursor, size, period, sort, categoryId` (기존 PostReadOpenApiController.getPosts와 동일 패턴)
+    - `@Operation`, `@ApiResponses`, `@Parameter` Swagger 어노테이션
+  - `PostListReadService.getPostsByUserId()` 호출하여 결과 반환
+- **Convention Notes**: 기존 `PostReadOpenApiController.getPosts`의 Swagger 패턴 참고, `@Tag(name = "User")` 유지
+- **Verification**: 빌드 성공 + spotlessCheck 통과
+- **Exit Criteria**: 엔드포인트 정상 등록, Swagger 문서 생성
+- **Status**: pending
+
+## Verification Strategy
+- `cd main-server && ./gradlew spotlessApply && ./gradlew spotlessCheck`
+- `cd main-server && ./gradlew compileKotlin`
+
+## Progress Tracking
+- Total Todos: 3
+- Completed: 0
+- Status: Planning complete
+
+## Change Log
+- 2026-02-27: Plan created

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,83 @@
 cd main-server && ./gradlew spotlessApply && ./gradlew spotlessCheck
 ```
 
+## Swagger 에러 응답 명세 규칙
+
+Swagger `@ApiResponse`에 에러를 문서화할 때, `GlobalExceptionHandler`가 실제로 반환하는 응답 포맷과 일치하도록 `@Content` + `@Schema` + `@ExampleObject`를 반드시 포함한다.
+
+### 에러 응답 유형
+
+**1. Validation 에러 (400)** — `@Valid`, `@Min`, `@Max` 등 검증 실패 시
+
+`GlobalExceptionHandler`가 `ApiResponse<ValidationErrorResponse>`를 반환한다.
+
+```json
+{"status": 400, "data": {"errors": {"필드명": "에러메시지"}}, "message": "Wrong Request"}
+```
+
+**2. 비즈니스 에러 (ApiException)** — 도메인 규칙 위반 시
+
+`GlobalExceptionHandler`가 `ApiResponse<null>`을 반환한다. `status`는 도메인별 `StatusIfs` enum의 `customStatusCode`를 사용한다.
+
+```json
+{"status": 3001, "data": null, "message": "게시물을 찾을 수 없습니다"}
+```
+
+### 작성 패턴
+
+Swagger의 `ApiResponse`와 프로젝트의 `ApiResponse`가 이름 충돌하므로, Swagger 쪽은 `import ... as SwaggerApiResponse` alias를 사용한다.
+
+```kotlin
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+
+// Validation 에러
+SwaggerApiResponse(
+    responseCode = "400",
+    description = "에러 상황 설명",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ApiResponse::class),
+            examples = [
+                ExampleObject(
+                    name = "예시 이름",
+                    value = EXAMPLE_CONSTANT, // companion object const val 사용
+                ),
+            ],
+        ),
+    ],
+)
+
+// 비즈니스 에러
+SwaggerApiResponse(
+    responseCode = "404",
+    description = "에러 상황 설명",
+    content = [
+        Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ApiResponse::class),
+            examples = [
+                ExampleObject(
+                    name = "예시 이름",
+                    value = EXAMPLE_CONSTANT,
+                ),
+            ],
+        ),
+    ],
+)
+```
+
+### 주의사항
+
+- ExampleObject의 `value`는 줄 길이(140자) 제한을 지키기 위해 `companion object`의 `const val`로 분리한다
+- `status` 필드 값은 반드시 해당 도메인의 `StatusIfs` enum에 정의된 `customStatusCode`를 사용한다 (DefaultStatus: 400, PostStatus: 3001~3009 등)
+- `message` 필드 값은 해당 `StatusIfs` enum의 `description`과 일치시킨다
+
 ## Dev Test User API
 
 dev 환경에서 OAuth2 플로우 없이 테스트 사용자로 JWT를 발급받을 수 있는 API.

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -55,12 +55,15 @@ class PostListReadService(
             )
         }
 
+        val currentUserId = getCurrentUserId()
+
         val posts =
             postRepository.findPostsWithConditions(
                 cursor = postCursor,
                 size = size + 1,
                 period = period,
                 sortType = sortType,
+                visibleToUserId = currentUserId,
             )
 
         val hasNext = posts.size > size
@@ -72,8 +75,6 @@ class PostListReadService(
             } else {
                 null
             }
-
-        val currentUserId = getCurrentUserId()
         val readPostIds =
             if (currentUserId != null && content.isNotEmpty()) {
                 postReadLogRepository.findByUserIdAndPostIdIn(

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -11,7 +11,6 @@ import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
-import com.techtaurant.mainserver.user.entity.User
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Service
@@ -235,13 +234,14 @@ class PostListReadService(
 
     /**
      * SecurityContext에서 현재 로그인한 사용자의 ID를 추출합니다.
+     * JwtAuthenticationFilter가 principal에 UUID를 저장하므로 UUID로 캐스팅합니다.
      * 인증되지 않은 사용자(비회원)인 경우 null을 반환합니다.
      *
      * @return 현재 사용자 ID (비회원이면 null)
      */
     private fun getCurrentUserId(): UUID? {
         val authentication = SecurityContextHolder.getContext().authentication
-        return (authentication?.principal as? User)?.id
+        return authentication?.principal as? UUID
     }
 
     /**

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -8,6 +8,7 @@ import com.techtaurant.mainserver.post.dto.PostListTagResponse
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
+import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.user.entity.User
@@ -73,6 +74,88 @@ class PostListReadService(
             }
 
         val currentUserId = getCurrentUserId()
+        val readPostIds =
+            if (currentUserId != null && content.isNotEmpty()) {
+                postReadLogRepository.findByUserIdAndPostIdIn(
+                    userId = currentUserId,
+                    postIds = content.mapNotNull { it.id },
+                ).map { it.postId }.toSet()
+            } else {
+                emptySet()
+            }
+
+        return CursorPageResponse(
+            content =
+                content.map { post ->
+                    convertToResponse(post, readPostIds.contains(post.id))
+                },
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+            size = content.size,
+        )
+    }
+
+    /**
+     * 특정 사용자의 게시물 목록을 커서 기반 페이지네이션으로 조회
+     *
+     * 본인 조회 시 모든 상태(DRAFT, PUBLISHED, PRIVATE), 타인 조회 시 PUBLISHED만 반환
+     *
+     * @param userId 조회 대상 사용자 ID
+     * @param cursor 이전 응답의 nextCursor (null이면 첫 페이지)
+     * @param size 페이지 크기
+     * @param period 기간 필터 (WEEK, MONTH, YEAR, ALL)
+     * @param sortType 정렬 기준 (LATEST, VIEW, LIKE, COMMENT)
+     * @param categoryId 카테고리 필터 (null이면 전체)
+     * @return 커서 기반 페이지 응답
+     */
+    fun getPostsByUserId(
+        userId: UUID,
+        cursor: String?,
+        size: Int,
+        period: PostPeriod = PostPeriod.ALL,
+        sortType: PostSortType = PostSortType.LATEST,
+        categoryId: UUID? = null,
+    ): CursorPageResponse<PostListItemResponse> {
+        val postCursor = cursor?.let { PostCursor.decode(it) }
+
+        if (cursor != null && postCursor == null) {
+            return CursorPageResponse(
+                content = emptyList(),
+                nextCursor = null,
+                hasNext = false,
+                size = 0,
+            )
+        }
+
+        val currentUserId = getCurrentUserId()
+        val statuses =
+            if (currentUserId == userId) {
+                PostStatusEnum.entries
+            } else {
+                listOf(PostStatusEnum.PUBLISHED)
+            }
+
+        val posts =
+            postRepository.findPostsWithConditions(
+                cursor = postCursor,
+                size = size + 1,
+                period = period,
+                sortType = sortType,
+                authorId = userId,
+                statuses = statuses,
+                categoryId = categoryId,
+            )
+
+        val hasNext = posts.size > size
+        val content = posts.take(size)
+
+        val nextCursor =
+            if (hasNext && content.isNotEmpty()) {
+                PostCursor.from(content.last(), sortType).encode()
+            } else {
+                null
+            }
+
         val readPostIds =
             if (currentUserId != null && content.isNotEmpty()) {
                 postReadLogRepository.findByUserIdAndPostIdIn(

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiController.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiController.kt
@@ -11,6 +11,9 @@ import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletRequest
@@ -24,6 +27,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 
 @Tag(name = "Post", description = "게시물 API")
 @RestController
@@ -33,19 +37,45 @@ class PostReadOpenApiController(
     private val postListReadService: PostListReadService,
     private val postDetailReadService: PostDetailReadService,
 ) {
+    companion object {
+        private const val VALIDATION_ERROR_EXAMPLE =
+            "{\"status\": 400," +
+                " \"data\": {\"errors\":" +
+                " {\"getPosts.size\":" +
+                " \"100 이하여야 합니다\"}}," +
+                " \"message\": \"Wrong Request\"}"
+
+        private const val POST_NOT_FOUND_EXAMPLE =
+            "{\"status\": 3001," +
+                " \"data\": null," +
+                " \"message\": \"게시물을 찾을 수 없습니다\"}"
+    }
+
     @Operation(
         summary = "게시물 목록 조회",
-        description = "커서 기반 페이지네이션으로 게시물 목록을 조회합니다. 기간 필터와 정렬 조건을 적용할 수 있습니다. 로그인 시 읽음 여부를 포함하며, 비회원도 조회 가능합니다.",
+        description = "커서 기반 페이지네이션으로 게시물 목록을 조회합니다. 기간 필터와 정렬 조건을 적용할 수 있습니다. 로그인 시 본인의 DRAFT/PRIVATE 게시물도 포함되며, 비회원도 조회 가능합니다.",
     )
     @ApiResponses(
         value = [
-            io.swagger.v3.oas.annotations.responses.ApiResponse(
+            SwaggerApiResponse(
                 responseCode = "200",
                 description = "조회 성공 (작성자 프로필 이미지, 게시물 썸네일, 읽음 여부 포함)",
             ),
-            io.swagger.v3.oas.annotations.responses.ApiResponse(
+            SwaggerApiResponse(
                 responseCode = "400",
                 description = "잘못된 요청 (size 범위 초과 등)",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ApiResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Validation 에러",
+                                value = VALIDATION_ERROR_EXAMPLE,
+                            ),
+                        ],
+                    ),
+                ],
             ),
         ],
     )
@@ -75,13 +105,25 @@ class PostReadOpenApiController(
     )
     @ApiResponses(
         value = [
-            io.swagger.v3.oas.annotations.responses.ApiResponse(
+            SwaggerApiResponse(
                 responseCode = "200",
                 description = "조회 성공",
             ),
-            io.swagger.v3.oas.annotations.responses.ApiResponse(
+            SwaggerApiResponse(
                 responseCode = "404",
                 description = "게시물을 찾을 수 없음",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ApiResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "게시물 미존재",
+                                value = POST_NOT_FOUND_EXAMPLE,
+                            ),
+                        ],
+                    ),
+                ],
             ),
         ],
     )

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
@@ -4,6 +4,8 @@ import com.techtaurant.mainserver.post.dto.PostCursor
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
+import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import java.util.UUID
 
 /**
  * 게시물 동적 쿼리를 위한 커스텀 Repository
@@ -16,6 +18,9 @@ interface PostRepositoryCustom {
      * @param size 페이지 크기
      * @param period 기간 필터
      * @param sortType 정렬 타입
+     * @param authorId 작성자 ID 필터 (null이면 미적용)
+     * @param statuses 게시물 상태 필터 (null이면 PUBLISHED만 조회)
+     * @param categoryId 카테고리 ID 필터 (null이면 미적용)
      * @return 게시물 목록
      */
     fun findPostsWithConditions(
@@ -23,5 +28,8 @@ interface PostRepositoryCustom {
         size: Int,
         period: PostPeriod,
         sortType: PostSortType,
+        authorId: UUID? = null,
+        statuses: List<PostStatusEnum>? = null,
+        categoryId: UUID? = null,
     ): List<Post>
 }

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
@@ -21,6 +21,7 @@ interface PostRepositoryCustom {
      * @param authorId 작성자 ID 필터 (null이면 미적용)
      * @param statuses 게시물 상태 필터 (null이면 PUBLISHED만 조회)
      * @param categoryId 카테고리 ID 필터 (null이면 미적용)
+     * @param visibleToUserId PUBLISHED + 해당 사용자의 모든 상태 게시물 조회 (null이면 미적용, statuses보다 우선)
      * @return 게시물 목록
      */
     fun findPostsWithConditions(
@@ -31,5 +32,6 @@ interface PostRepositoryCustom {
         authorId: UUID? = null,
         statuses: List<PostStatusEnum>? = null,
         categoryId: UUID? = null,
+        visibleToUserId: UUID? = null,
     ): List<Post>
 }

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -21,6 +21,7 @@ import jakarta.persistence.criteria.Predicate
 import jakarta.persistence.criteria.Root
 import org.springframework.stereotype.Repository
 import java.util.Calendar
+import java.util.UUID
 
 /**
  * 게시물 동적 쿼리 구현체
@@ -42,6 +43,9 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         size: Int,
         period: PostPeriod,
         sortType: PostSortType,
+        authorId: UUID?,
+        statuses: List<PostStatusEnum>?,
+        categoryId: UUID?,
     ): List<Post> {
         val cb = entityManager.criteriaBuilder
         val cq = cb.createQuery(Post::class.java)
@@ -53,7 +57,15 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
 
         val predicates = mutableListOf<Predicate>()
 
-        predicates.add(cb.equal(root.get(Post_.status), PostStatusEnum.PUBLISHED))
+        if (statuses != null) {
+            predicates.add(root.get(Post_.status).`in`(statuses))
+        } else {
+            predicates.add(cb.equal(root.get(Post_.status), PostStatusEnum.PUBLISHED))
+        }
+
+        authorId?.let { predicates.add(cb.equal(root.get(Post_.author).get(EntityBase_.id), it)) }
+        categoryId?.let { predicates.add(cb.equal(root.get(Post_.category).get(EntityBase_.id), it)) }
+
         addPeriodCondition(cb, root, period, predicates)
         addCursorCondition(cb, root, cursor, sortType, predicates)
 

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -46,6 +46,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         authorId: UUID?,
         statuses: List<PostStatusEnum>?,
         categoryId: UUID?,
+        visibleToUserId: UUID?,
     ): List<Post> {
         val cb = entityManager.criteriaBuilder
         val cq = cb.createQuery(Post::class.java)
@@ -57,7 +58,11 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
 
         val predicates = mutableListOf<Predicate>()
 
-        if (statuses != null) {
+        if (visibleToUserId != null) {
+            val publishedPredicate = cb.equal(root.get(Post_.status), PostStatusEnum.PUBLISHED)
+            val ownPostPredicate = cb.equal(root.get(Post_.author).get(EntityBase_.id), visibleToUserId)
+            predicates.add(cb.or(publishedPredicate, ownPostPredicate))
+        } else if (statuses != null) {
             predicates.add(root.get(Post_.status).`in`(statuses))
         } else {
             predicates.add(cb.equal(root.get(Post_.status), PostStatusEnum.PUBLISHED))

--- a/main-server/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiController.kt
+++ b/main-server/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiController.kt
@@ -1,23 +1,48 @@
 package com.techtaurant.mainserver.user.infrastructure.`in`
 
 import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.dto.CursorPageResponse
+import com.techtaurant.mainserver.post.application.PostListReadService
+import com.techtaurant.mainserver.post.dto.PostListItemResponse
+import com.techtaurant.mainserver.post.entity.PostPeriod
+import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.security.SecurityConstants
 import com.techtaurant.mainserver.user.application.UserReadService
 import com.techtaurant.mainserver.user.dto.UserResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
 
 @Tag(name = "User", description = "사용자 Open API")
 @RestController
 @RequestMapping("${SecurityConstants.OPEN_API_PREFIX}/users")
+@Validated
 class UserOpenApiController(
     private val userReadService: UserReadService,
+    private val postListReadService: PostListReadService,
 ) {
+    companion object {
+        private const val VALIDATION_ERROR_EXAMPLE =
+            "{\"status\": 400," +
+                " \"data\": {\"errors\":" +
+                " {\"getPostsByUserId.size\":" +
+                " \"100 이하여야 합니다\"}}," +
+                " \"message\": \"Wrong Request\"}"
+    }
+
     @Operation(summary = "사용자 검색", description = "사용자 이름으로 검색합니다")
     @ApiResponses(
         value = [
@@ -32,5 +57,68 @@ class UserOpenApiController(
         @RequestParam name: String,
     ): ApiResponse<List<UserResponse>> {
         return ApiResponse.ok(userReadService.searchByName(name))
+    }
+
+    @Operation(
+        summary = "사용자 게시물 목록 조회",
+        description = "특정 사용자의 게시물 목록을 커서 기반 페이지네이션으로 조회합니다. 본인 조회 시 DRAFT/PRIVATE 포함, 타인 조회 시 PUBLISHED만 반환됩니다.",
+    )
+    @ApiResponses(
+        value = [
+            io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+            ),
+            io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (size 범위 초과 등)",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ApiResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Validation 에러",
+                                value = VALIDATION_ERROR_EXAMPLE,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+    @GetMapping("/{userId}/posts")
+    fun getPostsByUserId(
+        @Parameter(description = "조회 대상 사용자 ID")
+        @PathVariable
+        userId: UUID,
+        @Parameter(description = "이전 응답의 nextCursor (첫 페이지는 생략)")
+        @RequestParam(required = false)
+        cursor: String?,
+        @Parameter(description = "페이지 크기 (1-100, 기본값 20)")
+        @RequestParam(defaultValue = "20")
+        @Min(1)
+        @Max(100)
+        size: Int,
+        @Parameter(description = "기간 필터 (WEEK: 7일, MONTH: 30일, YEAR: 365일, ALL: 전체)")
+        @RequestParam(defaultValue = "ALL")
+        period: PostPeriod,
+        @Parameter(description = "정렬 기준 (LATEST: 최신순, VIEW: 조회순, LIKE: 추천순, COMMENT: 댓글순)")
+        @RequestParam(defaultValue = "LATEST")
+        sort: PostSortType,
+        @Parameter(description = "카테고리 ID 필터 (생략 시 전체)")
+        @RequestParam(required = false)
+        categoryId: UUID?,
+    ): ApiResponse<CursorPageResponse<PostListItemResponse>> {
+        return ApiResponse.ok(
+            postListReadService.getPostsByUserId(
+                userId = userId,
+                cursor = cursor,
+                size = size,
+                period = period,
+                sortType = sort,
+                categoryId = categoryId,
+            ),
+        )
     }
 }

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -1,0 +1,351 @@
+package com.techtaurant.mainserver.post.application
+
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.entity.PostPeriod
+import com.techtaurant.mainserver.post.entity.PostReadLog
+import com.techtaurant.mainserver.post.entity.PostSortType
+import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
+import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import java.util.UUID
+
+class PostListReadServiceTest {
+    private val postRepository: PostRepository = mockk()
+    private val postReadLogRepository: PostReadLogRepository = mockk()
+    private val defaultThumbnailUrl = "/static/images/post-thumbnail.png"
+
+    private val postListReadService =
+        PostListReadService(
+            postRepository = postRepository,
+            postReadLogRepository = postReadLogRepository,
+            defaultThumbnailUrl = defaultThumbnailUrl,
+        )
+
+    private lateinit var testUser: User
+    private lateinit var otherUser: User
+
+    @BeforeEach
+    fun setUp() {
+        testUser =
+            User(
+                name = "테스트 사용자",
+                email = "test@example.com",
+                provider = OAuthProvider.GOOGLE,
+                identifier = "test-id",
+                role = UserRole.USER,
+                profileImageUrl = "https://example.com/profile.jpg",
+            ).apply { id = UUID.randomUUID() }
+
+        otherUser =
+            User(
+                name = "다른 사용자",
+                email = "other@example.com",
+                provider = OAuthProvider.GOOGLE,
+                identifier = "other-id",
+                role = UserRole.USER,
+                profileImageUrl = "https://example.com/other-profile.jpg",
+            ).apply { id = UUID.randomUUID() }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    private fun setCurrentUser(user: User?) {
+        if (user != null) {
+            val authentication = mockk<Authentication>()
+            every { authentication.principal } returns user
+            val securityContext = mockk<SecurityContext>()
+            every { securityContext.authentication } returns authentication
+            SecurityContextHolder.setContext(securityContext)
+        } else {
+            SecurityContextHolder.clearContext()
+        }
+    }
+
+    private fun createPost(
+        author: User,
+        status: PostStatusEnum = PostStatusEnum.PUBLISHED,
+    ): Post =
+        Post(
+            title = "테스트 게시물",
+            content = "테스트 내용",
+            author = author,
+            status = status,
+        ).apply { id = UUID.randomUUID() }
+
+    @Nested
+    @DisplayName("getPostsByUserId")
+    inner class GetPostsByUserId {
+        @Test
+        @DisplayName("본인 조회 시 모든 상태(DRAFT, PUBLISHED, PRIVATE)로 Repository를 호출한다")
+        fun getPostsByUserId_ownPosts_queriesAllStatuses() {
+            // given
+            setCurrentUser(testUser)
+            val posts = listOf(createPost(testUser))
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    authorId = testUser.id!!,
+                    statuses = PostStatusEnum.entries,
+                    categoryId = null,
+                )
+            } returns posts
+            every {
+                postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
+            } returns emptyList()
+
+            // when
+            postListReadService.getPostsByUserId(
+                userId = testUser.id!!,
+                cursor = null,
+                size = 20,
+            )
+
+            // then
+            verify {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    authorId = testUser.id!!,
+                    statuses = PostStatusEnum.entries,
+                    categoryId = null,
+                )
+            }
+        }
+
+        @Test
+        @DisplayName("타인 조회 시 PUBLISHED만으로 Repository를 호출한다")
+        fun getPostsByUserId_otherUserPosts_queriesPublishedOnly() {
+            // given
+            setCurrentUser(testUser)
+            val posts = listOf(createPost(otherUser))
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    authorId = otherUser.id!!,
+                    statuses = listOf(PostStatusEnum.PUBLISHED),
+                    categoryId = null,
+                )
+            } returns posts
+            every {
+                postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
+            } returns emptyList()
+
+            // when
+            postListReadService.getPostsByUserId(
+                userId = otherUser.id!!,
+                cursor = null,
+                size = 20,
+            )
+
+            // then
+            verify {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    authorId = otherUser.id!!,
+                    statuses = listOf(PostStatusEnum.PUBLISHED),
+                    categoryId = null,
+                )
+            }
+        }
+
+        @Test
+        @DisplayName("비로그인 사용자 조회 시 PUBLISHED만으로 Repository를 호출하고 isRead는 항상 false이다")
+        fun getPostsByUserId_anonymousUser_queriesPublishedOnly() {
+            // given
+            setCurrentUser(null)
+            val posts = listOf(createPost(otherUser))
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    authorId = otherUser.id!!,
+                    statuses = listOf(PostStatusEnum.PUBLISHED),
+                    categoryId = null,
+                )
+            } returns posts
+
+            // when
+            val result =
+                postListReadService.getPostsByUserId(
+                    userId = otherUser.id!!,
+                    cursor = null,
+                    size = 20,
+                )
+
+            // then
+            verify {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    authorId = otherUser.id!!,
+                    statuses = listOf(PostStatusEnum.PUBLISHED),
+                    categoryId = null,
+                )
+            }
+            assertThat(result.content).allSatisfy { assertThat(it.isRead).isFalse() }
+        }
+
+        @Test
+        @DisplayName("잘못된 커서 전달 시 빈 응답을 반환한다")
+        fun getPostsByUserId_invalidCursor_returnsEmptyResponse() {
+            // given
+            setCurrentUser(testUser)
+
+            // when
+            val result =
+                postListReadService.getPostsByUserId(
+                    userId = testUser.id!!,
+                    cursor = "invalid-cursor-string",
+                    size = 20,
+                )
+
+            // then
+            assertThat(result.content).isEmpty()
+            assertThat(result.nextCursor).isNull()
+            assertThat(result.hasNext).isFalse()
+            assertThat(result.size).isEqualTo(0)
+        }
+
+        @Test
+        @DisplayName("다음 페이지가 있으면 hasNext가 true이고 nextCursor가 반환된다")
+        fun getPostsByUserId_hasMorePosts_returnsHasNextTrue() {
+            // given
+            setCurrentUser(testUser)
+            val posts = (1..3).map { createPost(testUser) }
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 3,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    authorId = testUser.id!!,
+                    statuses = PostStatusEnum.entries,
+                    categoryId = null,
+                )
+            } returns posts
+            every {
+                postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
+            } returns emptyList()
+
+            // when
+            val result =
+                postListReadService.getPostsByUserId(
+                    userId = testUser.id!!,
+                    cursor = null,
+                    size = 2,
+                )
+
+            // then
+            assertThat(result.hasNext).isTrue()
+            assertThat(result.nextCursor).isNotNull()
+            assertThat(result.content).hasSize(2)
+        }
+
+        @Test
+        @DisplayName("다음 페이지가 없으면 hasNext가 false이고 nextCursor가 null이다")
+        fun getPostsByUserId_noMorePosts_returnsHasNextFalse() {
+            // given
+            setCurrentUser(testUser)
+            val posts = listOf(createPost(testUser))
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    authorId = testUser.id!!,
+                    statuses = PostStatusEnum.entries,
+                    categoryId = null,
+                )
+            } returns posts
+            every {
+                postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
+            } returns emptyList()
+
+            // when
+            val result =
+                postListReadService.getPostsByUserId(
+                    userId = testUser.id!!,
+                    cursor = null,
+                    size = 20,
+                )
+
+            // then
+            assertThat(result.hasNext).isFalse()
+            assertThat(result.nextCursor).isNull()
+            assertThat(result.content).hasSize(1)
+        }
+
+        @Test
+        @DisplayName("로그인 사용자가 조회 시 읽음 기록이 반영된다")
+        fun getPostsByUserId_loggedInUser_appliesReadStatus() {
+            // given
+            setCurrentUser(testUser)
+            val post1 = createPost(otherUser)
+            val post2 = createPost(otherUser)
+            val posts = listOf(post1, post2)
+            val readLog = PostReadLog(postId = post1.id!!, user = testUser)
+
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    authorId = otherUser.id!!,
+                    statuses = listOf(PostStatusEnum.PUBLISHED),
+                    categoryId = null,
+                )
+            } returns posts
+            every {
+                postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
+            } returns listOf(readLog)
+
+            // when
+            val result =
+                postListReadService.getPostsByUserId(
+                    userId = otherUser.id!!,
+                    cursor = null,
+                    size = 20,
+                )
+
+            // then
+            val responseMap = result.content.associateBy { it.id }
+            assertThat(responseMap[post1.id!!]!!.isRead).isTrue()
+            assertThat(responseMap[post2.id!!]!!.isRead).isFalse()
+        }
+    }
+}

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -91,6 +91,75 @@ class PostListReadServiceTest {
         ).apply { id = UUID.randomUUID() }
 
     @Nested
+    @DisplayName("getPosts")
+    inner class GetPosts {
+        @Test
+        @DisplayName("로그인 사용자 조회 시 visibleToUserId에 현재 사용자 ID를 전달한다")
+        fun getPosts_loggedInUser_passesVisibleToUserId() {
+            // given
+            setCurrentUser(testUser)
+            val posts = listOf(createPost(testUser))
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    visibleToUserId = testUser.id!!,
+                )
+            } returns posts
+            every {
+                postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
+            } returns emptyList()
+
+            // when
+            postListReadService.getPosts(cursor = null, size = 20)
+
+            // then
+            verify {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    visibleToUserId = testUser.id!!,
+                )
+            }
+        }
+
+        @Test
+        @DisplayName("비로그인 사용자 조회 시 visibleToUserId에 null을 전달한다")
+        fun getPosts_anonymousUser_passesNullVisibleToUserId() {
+            // given
+            setCurrentUser(null)
+            val posts = listOf(createPost(otherUser))
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    visibleToUserId = null,
+                )
+            } returns posts
+
+            // when
+            postListReadService.getPosts(cursor = null, size = 20)
+
+            // then
+            verify {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    visibleToUserId = null,
+                )
+            }
+        }
+    }
+
+    @Nested
     @DisplayName("getPostsByUserId")
     inner class GetPostsByUserId {
         @Test

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -70,7 +70,7 @@ class PostListReadServiceTest {
     private fun setCurrentUser(user: User?) {
         if (user != null) {
             val authentication = mockk<Authentication>()
-            every { authentication.principal } returns user
+            every { authentication.principal } returns user.id!!
             val securityContext = mockk<SecurityContext>()
             every { securityContext.authentication } returns authentication
             SecurityContextHolder.setContext(securityContext)

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
@@ -1,0 +1,109 @@
+package com.techtaurant.mainserver.post.infrastructure.`in`
+
+import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import io.restassured.RestAssured.given
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.not
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+@DisplayName("PostReadOpenApiController 통합 테스트")
+class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    private lateinit var testUser: User
+    private lateinit var otherUser: User
+    private lateinit var accessToken: String
+
+    @BeforeEach
+    fun setUpTestData() {
+        testUser =
+            userRepository.save(
+                User(
+                    name = "테스트사용자",
+                    email = "test@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "test-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/profile.jpg",
+                ),
+            )
+
+        otherUser =
+            userRepository.save(
+                User(
+                    name = "다른사용자",
+                    email = "other@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "other-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/other-profile.jpg",
+                ),
+            )
+
+        accessToken = jwtTokenProvider.createAccessToken(testUser.id!!, testUser.role)
+    }
+
+    @Test
+    @DisplayName("로그인 사용자가 게시물 목록 조회 시 본인의 PRIVATE 게시물이 포함된다")
+    fun getPosts_loggedInUser_includesOwnPrivatePost() {
+        // given
+        val myPrivatePost =
+            postRepository.save(
+                Post(
+                    title = "내 비공개 게시물",
+                    content = "비공개 내용",
+                    author = testUser,
+                    status = PostStatusEnum.PRIVATE,
+                ),
+            )
+        val myPublishedPost =
+            postRepository.save(
+                Post(
+                    title = "내 공개 게시물",
+                    content = "공개 내용",
+                    author = testUser,
+                    status = PostStatusEnum.PUBLISHED,
+                ),
+            )
+        val otherPrivatePost =
+            postRepository.save(
+                Post(
+                    title = "타인 비공개 게시물",
+                    content = "타인 비공개 내용",
+                    author = otherUser,
+                    status = PostStatusEnum.PRIVATE,
+                ),
+            )
+
+        // when & then
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .get("/open-api/posts")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.content.id", hasItem(myPrivatePost.id.toString()))
+            .body("data.content.id", hasItem(myPublishedPost.id.toString()))
+            .body("data.content.id", not(hasItem(otherPrivatePost.id.toString())))
+    }
+}

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
@@ -280,4 +280,96 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
             assertThat(result[0].id).isEqualTo(target.id)
         }
     }
+
+    @Nested
+    @DisplayName("visibleToUserId 필터링")
+    inner class VisibleToUserIdFilter {
+        @Test
+        @DisplayName("visibleToUserId 지정 시 PUBLISHED + 해당 사용자의 모든 상태 게시물을 반환한다")
+        fun findPostsWithConditions_withVisibleToUserId_returnsPublishedAndOwnPosts() {
+            // given
+            val publishedByA = createPost(userA, PostStatusEnum.PUBLISHED)
+            val draftByA = createPost(userA, PostStatusEnum.DRAFT)
+            val privateByA = createPost(userA, PostStatusEnum.PRIVATE)
+            val publishedByB = createPost(userB, PostStatusEnum.PUBLISHED)
+            createPost(userB, PostStatusEnum.DRAFT)
+            createPost(userB, PostStatusEnum.PRIVATE)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    visibleToUserId = userA.id!!,
+                )
+
+            // then
+            val resultIds = result.map { it.id }.toSet()
+            assertThat(resultIds).containsExactlyInAnyOrder(
+                publishedByA.id,
+                draftByA.id,
+                privateByA.id,
+                publishedByB.id,
+            )
+        }
+
+        @Test
+        @DisplayName("visibleToUserId가 null이면 PUBLISHED만 반환한다")
+        fun findPostsWithConditions_withoutVisibleToUserId_returnsPublishedOnly() {
+            // given
+            val publishedByA = createPost(userA, PostStatusEnum.PUBLISHED)
+            createPost(userA, PostStatusEnum.DRAFT)
+            createPost(userA, PostStatusEnum.PRIVATE)
+            val publishedByB = createPost(userB, PostStatusEnum.PUBLISHED)
+            createPost(userB, PostStatusEnum.DRAFT)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    visibleToUserId = null,
+                )
+
+            // then
+            val resultIds = result.map { it.id }.toSet()
+            assertThat(resultIds).containsExactlyInAnyOrder(
+                publishedByA.id,
+                publishedByB.id,
+            )
+        }
+
+        @Test
+        @DisplayName("visibleToUserId는 statuses보다 우선 적용된다")
+        fun findPostsWithConditions_visibleToUserIdOverridesStatuses() {
+            // given
+            val publishedByA = createPost(userA, PostStatusEnum.PUBLISHED)
+            val draftByA = createPost(userA, PostStatusEnum.DRAFT)
+            val publishedByB = createPost(userB, PostStatusEnum.PUBLISHED)
+            createPost(userB, PostStatusEnum.DRAFT)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    statuses = listOf(PostStatusEnum.PUBLISHED),
+                    visibleToUserId = userA.id!!,
+                )
+
+            // then
+            val resultIds = result.map { it.id }.toSet()
+            assertThat(resultIds).containsExactlyInAnyOrder(
+                publishedByA.id,
+                draftByA.id,
+                publishedByB.id,
+            )
+        }
+    }
 }

--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
@@ -1,0 +1,283 @@
+package com.techtaurant.mainserver.post.infrastructure.out
+
+import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.post.entity.Category
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.entity.PostPeriod
+import com.techtaurant.mainserver.post.entity.PostSortType
+import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Transactional
+@ActiveProfiles("test")
+class PostRepositoryCustomImplTest : IntegrationTest() {
+    @Autowired
+    private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var categoryRepository: CategoryRepository
+
+    private lateinit var userA: User
+    private lateinit var userB: User
+    private lateinit var category: Category
+
+    @BeforeEach
+    fun setUpTestData() {
+        userA =
+            userRepository.save(
+                User(
+                    name = "사용자A",
+                    email = "a@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "user-a-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/a.jpg",
+                ),
+            )
+        userB =
+            userRepository.save(
+                User(
+                    name = "사용자B",
+                    email = "b@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "user-b-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/b.jpg",
+                ),
+            )
+        category =
+            categoryRepository.save(
+                Category(
+                    user = userA,
+                    name = "테스트 카테고리",
+                    path = "테스트카테고리",
+                    depth = 1,
+                ),
+            )
+    }
+
+    private fun createPost(
+        author: User,
+        status: PostStatusEnum = PostStatusEnum.PUBLISHED,
+        postCategory: Category? = null,
+    ): Post =
+        postRepository.save(
+            Post(
+                title = "게시물",
+                content = "내용",
+                author = author,
+                status = status,
+                category = postCategory,
+            ),
+        )
+
+    @Nested
+    @DisplayName("authorId 필터링")
+    inner class AuthorIdFilter {
+        @Test
+        @DisplayName("authorId 지정 시 해당 작성자의 게시물만 반환한다")
+        fun findPostsWithConditions_withAuthorId_returnsOnlyAuthorPosts() {
+            // given
+            val postByA = createPost(userA)
+            createPost(userB)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    authorId = userA.id!!,
+                )
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].id).isEqualTo(postByA.id)
+        }
+
+        @Test
+        @DisplayName("authorId가 null이면 모든 작성자의 게시물을 반환한다")
+        fun findPostsWithConditions_withoutAuthorId_returnsAllPosts() {
+            // given
+            createPost(userA)
+            createPost(userB)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    authorId = null,
+                )
+
+            // then
+            assertThat(result).hasSize(2)
+        }
+    }
+
+    @Nested
+    @DisplayName("statuses 필터링")
+    inner class StatusesFilter {
+        @Test
+        @DisplayName("statuses가 null이면 PUBLISHED만 반환한다")
+        fun findPostsWithConditions_withoutStatuses_returnsPublishedOnly() {
+            // given
+            val published = createPost(userA, PostStatusEnum.PUBLISHED)
+            createPost(userA, PostStatusEnum.DRAFT)
+            createPost(userA, PostStatusEnum.PRIVATE)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    statuses = null,
+                )
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].id).isEqualTo(published.id)
+        }
+
+        @Test
+        @DisplayName("모든 상태를 지정하면 전체 게시물을 반환한다")
+        fun findPostsWithConditions_withAllStatuses_returnsAllPosts() {
+            // given
+            createPost(userA, PostStatusEnum.PUBLISHED)
+            createPost(userA, PostStatusEnum.DRAFT)
+            createPost(userA, PostStatusEnum.PRIVATE)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    statuses = PostStatusEnum.entries,
+                )
+
+            // then
+            assertThat(result).hasSize(3)
+        }
+
+        @Test
+        @DisplayName("PUBLISHED만 지정하면 PUBLISHED 게시물만 반환한다")
+        fun findPostsWithConditions_withPublishedOnly_returnsPublishedPosts() {
+            // given
+            val published = createPost(userA, PostStatusEnum.PUBLISHED)
+            createPost(userA, PostStatusEnum.DRAFT)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    statuses = listOf(PostStatusEnum.PUBLISHED),
+                )
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].id).isEqualTo(published.id)
+        }
+    }
+
+    @Nested
+    @DisplayName("categoryId 필터링")
+    inner class CategoryIdFilter {
+        @Test
+        @DisplayName("categoryId 지정 시 해당 카테고리의 게시물만 반환한다")
+        fun findPostsWithConditions_withCategoryId_returnsOnlyCategoryPosts() {
+            // given
+            val categorizedPost = createPost(userA, postCategory = category)
+            createPost(userA)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    categoryId = category.id!!,
+                )
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].id).isEqualTo(categorizedPost.id)
+        }
+
+        @Test
+        @DisplayName("categoryId가 null이면 모든 카테고리의 게시물을 반환한다")
+        fun findPostsWithConditions_withoutCategoryId_returnsAllPosts() {
+            // given
+            createPost(userA, postCategory = category)
+            createPost(userA)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    categoryId = null,
+                )
+
+            // then
+            assertThat(result).hasSize(2)
+        }
+    }
+
+    @Nested
+    @DisplayName("복합 필터링")
+    inner class CombinedFilter {
+        @Test
+        @DisplayName("authorId + statuses + categoryId를 함께 적용하면 교집합 결과를 반환한다")
+        fun findPostsWithConditions_combinedFilters_returnsIntersection() {
+            // given
+            val target = createPost(userA, PostStatusEnum.PUBLISHED, category)
+            createPost(userA, PostStatusEnum.DRAFT, category)
+            createPost(userB, PostStatusEnum.PUBLISHED, category)
+            createPost(userA, PostStatusEnum.PUBLISHED)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    authorId = userA.id!!,
+                    statuses = listOf(PostStatusEnum.PUBLISHED),
+                    categoryId = category.id!!,
+                )
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].id).isEqualTo(target.id)
+        }
+    }
+}


### PR DESCRIPTION
## 관련 자료
- [작업 계획 - 사용자별 게시물 목록](.claude/plan/user/2602/27-user-posts-list-api.plan.md)
- [작업 계획 - 본인 DRAFT/PRIVATE 노출](.claude/plan/post/2602/27-post-list-visible-own-drafts.plan.md)
- [작업 계획 - getCurrentUserId 버그 수정](.claude/plan/post/2602/27-fix-get-current-user-id.plan.md)

## 어떤 작업인가요?
- 사용자별 게시물 목록 조회 API 추가 및 게시물 전체 목록에서 로그인 사용자의 DRAFT/PRIVATE 게시물이 함께 노출되도록 개선

## 어떻게 해결했나요?
**사용자별 게시물 목록 조회 API**
- `GET /open-api/users/{userId}/posts` 엔드포인트 추가
- 본인 조회 시 모든 상태(DRAFT, PUBLISHED, PRIVATE), 타인 조회 시 PUBLISHED만 반환

**게시물 전체 목록에서 본인 DRAFT/PRIVATE 노출**
- Repository에 `visibleToUserId` 파라미터 추가하여 `(PUBLISHED) OR (본인 게시물)` OR 조건 지원
- `getPosts()`에서 현재 로그인 사용자 ID를 `visibleToUserId`로 전달

**getCurrentUserId() 버그 수정**
- `JwtAuthenticationFilter`가 principal에 UUID를 저장하지만, `getCurrentUserId()`가 `User`로 캐스팅하여 항상 null을 반환하던 버그 수정
- `authentication?.principal as? UUID`로 변경하여 visibleToUserId 및 본인/타인 분기 정상 동작

## 중요한 변경 사항은 무엇인가요?
### 사용자별 게시물 목록 조회 API

**UserOpenApiController 추가**
- **변경 이유**: 특정 사용자의 게시물 목록을 조회하는 API 필요
- **수정 파일**: `UserOpenApiController.kt`

### 게시물 전체 목록 visibleToUserId 필터

**Repository visibleToUserId 파라미터**
- **변경 이유**: PUBLISHED만 조회하던 전체 목록에서 본인의 DRAFT/PRIVATE도 함께 보여야 함
- **수정 파일**: `PostRepositoryCustom.kt`, `PostRepositoryCustomImpl.kt`

**서비스 로직 수정**
- **변경 이유**: 현재 로그인 사용자 ID를 Repository에 전달
- **수정 파일**: `PostListReadService.kt`

### getCurrentUserId() UUID 캐스팅 버그 수정

**principal 타입 불일치 수정**
- **변경 이유**: `(principal as? User)?.id` 패턴이 JWT의 UUID principal과 불일치하여 항상 null 반환
- **수정 파일**: `PostListReadService.kt`, `PostListReadServiceTest.kt`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
