### PR TITLE
SSM Parameter Store 기반 CD 파이프라인 마이그레이션

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   AWS_REGION: ap-northeast-2
-  ECR_REPOSITORY: techtaurant-main-server
+  ECR_REPOSITORY: techtaurant-dev-server
 
 jobs:
   deploy:
@@ -57,6 +57,27 @@ jobs:
             --cache-to type=gha,mode=max \
             --push \
             ./main-server
+
+      - name: Fetch env from SSM Parameter Store
+        run: |
+          aws ssm get-parameters-by-path \
+            --path "/techtaurant/dev" \
+            --with-decryption \
+            --query "Parameters[*].[Name,Value]" \
+            --output text | while IFS=$'\t' read -r name value; do
+              key=$(echo "$name" | awk -F'/' '{print $NF}')
+              echo "${key}=${value}" >> .env
+          done
+
+      - name: Deploy .env to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DEV_SSH_HOST }}
+          username: ${{ secrets.DEV_SSH_USER }}
+          key: ${{ secrets.DEV_SSH_PRIVATE_KEY }}
+          port: ${{ secrets.DEV_SSH_PORT }}
+          source: ".env"
+          target: "/home/ec2-user/app"
 
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.2.0


### PR DESCRIPTION
## 관련 자료
- 이슈 : #

## 어떤 작업인가요?
- Terraform 인프라 간소화에 따라 CD 파이프라인을 SSM Parameter Store 기반으로 마이그레이션

## 어떻게 해결했나요?
**CD 파이프라인 환경변수 관리 방식 변경**
- GitHub Secrets 기반 환경변수 관리에서 AWS SSM Parameter Store 기반으로 전환
- CI/CD에서 SSM 파라미터를 조회하여 .env 파일 생성 후 SCP로 EC2에 배포하는 방식으로 변경

## 중요한 변경 사항은 무엇인가요?
### CD 파이프라인 마이그레이션

**ECR 리포지토리명 변경**
- **변경 이유**: 인프라 간소화에 따른 ECR 리포지토리 분리
- **수정 파일**: `.github/workflows/cd-dev.yml`

**SSM Parameter Store에서 환경변수 조회 step 추가**
- **변경 이유**: 앱 환경변수를 GitHub Secrets 대신 SSM Parameter Store에서 관리하여 보안성 및 관리 편의성 향상
- **수정 파일**: `.github/workflows/cd-dev.yml`

**SCP로 .env 파일 EC2 배포 step 추가**
- **변경 이유**: SSM에서 생성한 .env 파일을 서버에 전송하여 docker-compose env_file 방식으로 런타임 환경변수 주입
- **수정 파일**: `.github/workflows/cd-dev.yml`
