### PR TITLE
fix(test): PostListReadService 테스트 컴파일 에러 수정

### DIFF
--- a/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/main-server/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -25,11 +25,14 @@ class PostListReadServiceTest {
     private val postReadLogRepository: PostReadLogRepository = mockk()
     private val defaultThumbnailUrl = "/static/images/post-thumbnail.png"
 
+    private val baseUrl = "http://localhost:8080"
+
     private val postListReadService =
         PostListReadService(
             postRepository = postRepository,
             postReadLogRepository = postReadLogRepository,
             defaultThumbnailUrl = defaultThumbnailUrl,
+            baseUrl = baseUrl,
         )
 
     private lateinit var testUser: User


### PR DESCRIPTION
## 관련 자료

## 어떤 작업인가요?
- PostListReadService 생성자에 baseUrl 파라미터가 추가되면서 테스트 코드에서 컴파일 에러가 발생한 CI 실패를 수정

## 어떻게 해결했나요?
**테스트 코드 컴파일 에러 수정**
- PostListReadService에 `@Value("\${swagger.base-url}")` baseUrl 파라미터가 추가된 후, 단위 테스트에서 해당 파라미터를 전달하지 않아 컴파일 실패
- 테스트에 baseUrl 값(`http://localhost:8080`)을 추가하여 해결

## 중요한 변경 사항은 무엇인가요?
### PostListReadServiceTest 컴파일 에러 수정

**baseUrl 파라미터 추가**
- **변경 이유**: PostListReadService 생성자 시그니처 변경에 테스트가 맞지 않아 CI 컴파일 실패
- **수정 파일**: `main-server/src/test/kotlin/.../post/application/PostListReadServiceTest.kt`
