### PR TITLE
ops(cd): ECR 리포지토리 이름 SSM에서 동적 조회, 하드코딩 제거

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,19 +41,3 @@ COOKIE_PATH=/
 # Swagger
 # 개발 환경: http://localhost:8080
 SWAGGER_BASE_URL=http://localhost:8080
-
-# ── GitHub Actions CD 시크릿 ──────────────────────────────────────────────────
-# 로컬 개발에는 불필요. scripts/setup-github-secrets.sh 실행 시에만 사용됨.
-
-# AWS 자격증명 (ECR push, SSM Parameter Store 접근용)
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
-
-# 개발 서버 SSH 접속 정보
-DEV_SSH_HOST=
-DEV_SSH_USER=ec2-user
-DEV_SSH_PORT=22
-
-# SSH 개인키 파일 경로 (PEM 파일 전체 내용을 시크릿으로 등록)
-# 예: ~/.ssh/techtaurant-dev.pem
-DEV_SSH_PRIVATE_KEY_PATH=

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   AWS_REGION: ap-northeast-2
-  ECR_REPOSITORY: techtaurant-dev-server
 
 jobs:
   deploy:
@@ -31,6 +30,14 @@ jobs:
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: Get ECR repository name from SSM
+        run: |
+          ECR_REPO=$(aws ssm get-parameter \
+            --name "/techtaurant/dev/ECR_REPOSITORY_NAME" \
+            --query "Parameter.Value" \
+            --output text)
+          echo "ECR_REPOSITORY_NAME=$ECR_REPO" >> $GITHUB_ENV
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -51,8 +58,8 @@ jobs:
         run: |
           docker buildx build \
             --platform linux/arm64 \
-            -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
-            -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY_NAME:latest \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY_NAME:${{ github.sha }} \
             --cache-from type=gha \
             --cache-to type=gha,mode=max \
             --push \


### PR DESCRIPTION
## Summary

- `cd-dev.yml`에서 `ECR_REPOSITORY: techtaurant-dev-server` 하드코딩 제거
- ECR 로그인 직후 SSM `/techtaurant/dev/ECR_REPOSITORY_NAME` 조회 스텝 추가 (`$GITHUB_ENV` 주입)
- `.env.example`에서 `# GitHub Actions CD 시크릿` 섹션 제거 (스크립트 삭제에 따른 정리)

## 변경된 워크플로우 흐름

```
Configure AWS Credentials
→ Login to Amazon ECR
→ Get ECR repository name from SSM  ← 신규
→ Build and Push ($ECR_REPOSITORY_NAME 사용)
→ Fetch env from SSM
→ Deploy
```

## 연관 PR

- techtaurant-infra: https://github.com/Techtaurant/techtaurant-infra/pull/5