### PR TITLE
refactor(post): GET /posts에 authorId 필터 추가 후 사용자 게시물 조회 엔드포인트 통합

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -32,11 +32,16 @@ class PostListReadService(
     /**
      * 게시물 목록을 커서 기반 페이지네이션으로 조회
      *
+     * authorId 지정 시 해당 사용자의 게시물만 조회하며, 본인 조회 시 DRAFT/PRIVATE 포함, 타인 조회 시 PUBLISHED만 반환.
+     * authorId 미지정 시 전체 게시물 조회 (로그인 사용자의 DRAFT/PRIVATE 포함).
+     *
      * @param cursor 이전 응답의 nextCursor (null이면 첫 페이지)
      * @param size 페이지 크기
      * @param period 기간 필터 (WEEK, MONTH, YEAR, ALL)
      * @param sortType 정렬 기준 (LATEST, VIEW, LIKE, COMMENT)
-     * @param userId 현재 사용자 ID (비회원이면 null)
+     * @param currentUserId 현재 로그인 사용자 ID (비회원이면 null)
+     * @param authorId 작성자 필터 (null이면 전체 조회)
+     * @param categoryId 카테고리 필터 (null이면 전체, authorId 지정 시에만 적용)
      * @return 커서 기반 페이지 응답
      */
     fun getPosts(
@@ -44,81 +49,9 @@ class PostListReadService(
         size: Int,
         period: PostPeriod = PostPeriod.ALL,
         sortType: PostSortType = PostSortType.LATEST,
-        userId: UUID? = null,
-    ): CursorPageResponse<PostListItemResponse> {
-        val postCursor = cursor?.let { PostCursor.decode(it) }
-
-        if (cursor != null && postCursor == null) {
-            return CursorPageResponse(
-                content = emptyList(),
-                nextCursor = null,
-                hasNext = false,
-                size = 0,
-            )
-        }
-
-        val posts =
-            postRepository.findPostsWithConditions(
-                cursor = postCursor,
-                size = size + 1,
-                period = period,
-                sortType = sortType,
-                visibleToUserId = userId,
-            )
-
-        val hasNext = posts.size > size
-        val content = posts.take(size)
-
-        val nextCursor =
-            if (hasNext && content.isNotEmpty()) {
-                PostCursor.from(content.last(), sortType).encode()
-            } else {
-                null
-            }
-
-        val readPostIds =
-            if (userId != null && content.isNotEmpty()) {
-                postReadLogRepository.findByUserIdAndPostIdIn(
-                    userId = userId,
-                    postIds = content.mapNotNull { it.id },
-                ).map { it.postId }.toSet()
-            } else {
-                emptySet()
-            }
-
-        return CursorPageResponse(
-            content =
-                content.map { post ->
-                    convertToResponse(post, readPostIds.contains(post.id))
-                },
-            nextCursor = nextCursor,
-            hasNext = hasNext,
-            size = content.size,
-        )
-    }
-
-    /**
-     * 특정 사용자의 게시물 목록을 커서 기반 페이지네이션으로 조회
-     *
-     * 본인 조회 시 모든 상태(DRAFT, PUBLISHED, PRIVATE), 타인 조회 시 PUBLISHED만 반환
-     *
-     * @param userId 조회 대상 사용자 ID
-     * @param cursor 이전 응답의 nextCursor (null이면 첫 페이지)
-     * @param size 페이지 크기
-     * @param period 기간 필터 (WEEK, MONTH, YEAR, ALL)
-     * @param sortType 정렬 기준 (LATEST, VIEW, LIKE, COMMENT)
-     * @param categoryId 카테고리 필터 (null이면 전체)
-     * @param currentUserId 현재 로그인 사용자 ID (본인/타인 분기용, 비회원이면 null)
-     * @return 커서 기반 페이지 응답
-     */
-    fun getPostsByUserId(
-        userId: UUID,
-        cursor: String?,
-        size: Int,
-        period: PostPeriod = PostPeriod.ALL,
-        sortType: PostSortType = PostSortType.LATEST,
-        categoryId: UUID? = null,
         currentUserId: UUID? = null,
+        authorId: UUID? = null,
+        categoryId: UUID? = null,
     ): CursorPageResponse<PostListItemResponse> {
         val postCursor = cursor?.let { PostCursor.decode(it) }
 
@@ -131,23 +64,32 @@ class PostListReadService(
             )
         }
 
-        val statuses =
-            if (currentUserId == userId) {
-                PostStatusEnum.entries
-            } else {
-                listOf(PostStatusEnum.PUBLISHED)
-            }
-
         val posts =
-            postRepository.findPostsWithConditions(
-                cursor = postCursor,
-                size = size + 1,
-                period = period,
-                sortType = sortType,
-                authorId = userId,
-                statuses = statuses,
-                categoryId = categoryId,
-            )
+            if (authorId != null) {
+                val statuses =
+                    if (currentUserId == authorId) {
+                        PostStatusEnum.entries
+                    } else {
+                        listOf(PostStatusEnum.PUBLISHED)
+                    }
+                postRepository.findPostsWithConditions(
+                    cursor = postCursor,
+                    size = size + 1,
+                    period = period,
+                    sortType = sortType,
+                    authorId = authorId,
+                    statuses = statuses,
+                    categoryId = categoryId,
+                )
+            } else {
+                postRepository.findPostsWithConditions(
+                    cursor = postCursor,
+                    size = size + 1,
+                    period = period,
+                    sortType = sortType,
+                    visibleToUserId = currentUserId,
+                )
+            }
 
         val hasNext = posts.size > size
         val content = posts.take(size)

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiController.kt
@@ -95,9 +95,25 @@ class PostReadOpenApiController(
         @Parameter(description = "정렬 기준 (LATEST: 최신순, VIEW: 조회순, LIKE: 추천순, COMMENT: 댓글순)")
         @RequestParam(defaultValue = "LATEST")
         sort: PostSortType,
-        @AuthenticationPrincipal userId: UUID?,
+        @Parameter(description = "작성자 ID 필터 (생략 시 전체 조회, 본인 조회 시 DRAFT/PRIVATE 포함)")
+        @RequestParam(required = false)
+        authorId: UUID?,
+        @Parameter(description = "카테고리 ID 필터 (authorId 지정 시에만 적용, 생략 시 전체)")
+        @RequestParam(required = false)
+        categoryId: UUID?,
+        @AuthenticationPrincipal currentUserId: UUID?,
     ): ApiResponse<CursorPageResponse<PostListItemResponse>> {
-        return ApiResponse.ok(postListReadService.getPosts(cursor, size, period, sort, userId))
+        return ApiResponse.ok(
+            postListReadService.getPosts(
+                cursor = cursor,
+                size = size,
+                period = period,
+                sortType = sort,
+                currentUserId = currentUserId,
+                authorId = authorId,
+                categoryId = categoryId,
+            ),
+        )
     }
 
     @Operation(

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiController.kt
@@ -1,49 +1,23 @@
 package com.techtaurant.mainserver.user.infrastructure.`in`
 
 import com.techtaurant.mainserver.common.dto.ApiResponse
-import com.techtaurant.mainserver.common.dto.CursorPageResponse
-import com.techtaurant.mainserver.post.application.PostListReadService
-import com.techtaurant.mainserver.post.dto.PostListItemResponse
-import com.techtaurant.mainserver.post.entity.PostPeriod
-import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.security.SecurityConstants
 import com.techtaurant.mainserver.user.application.UserReadService
 import com.techtaurant.mainserver.user.dto.UserResponse
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.media.Content
-import io.swagger.v3.oas.annotations.media.ExampleObject
-import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
-import jakarta.validation.constraints.Max
-import jakarta.validation.constraints.Min
-import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
 
 @Tag(name = "User", description = "사용자 Open API")
 @RestController
 @RequestMapping("${SecurityConstants.OPEN_API_PREFIX}/users")
-@Validated
 class UserOpenApiController(
     private val userReadService: UserReadService,
-    private val postListReadService: PostListReadService,
 ) {
-    companion object {
-        private const val VALIDATION_ERROR_EXAMPLE =
-            "{\"status\": 400," +
-                " \"data\": {\"errors\":" +
-                " {\"getPostsByUserId.size\":" +
-                " \"100 이하여야 합니다\"}}," +
-                " \"message\": \"Wrong Request\"}"
-    }
-
     @Operation(summary = "사용자 검색", description = "사용자 이름으로 검색합니다")
     @ApiResponses(
         value = [
@@ -58,70 +32,5 @@ class UserOpenApiController(
         @RequestParam name: String,
     ): ApiResponse<List<UserResponse>> {
         return ApiResponse.ok(userReadService.searchByName(name))
-    }
-
-    @Operation(
-        summary = "사용자 게시물 목록 조회",
-        description = "특정 사용자의 게시물 목록을 커서 기반 페이지네이션으로 조회합니다. 본인 조회 시 DRAFT/PRIVATE 포함, 타인 조회 시 PUBLISHED만 반환됩니다.",
-    )
-    @ApiResponses(
-        value = [
-            io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "200",
-                description = "조회 성공",
-            ),
-            io.swagger.v3.oas.annotations.responses.ApiResponse(
-                responseCode = "400",
-                description = "잘못된 요청 (size 범위 초과 등)",
-                content = [
-                    Content(
-                        mediaType = "application/json",
-                        schema = Schema(implementation = ApiResponse::class),
-                        examples = [
-                            ExampleObject(
-                                name = "Validation 에러",
-                                value = VALIDATION_ERROR_EXAMPLE,
-                            ),
-                        ],
-                    ),
-                ],
-            ),
-        ],
-    )
-    @GetMapping("/{userId}/posts")
-    fun getPostsByUserId(
-        @Parameter(description = "조회 대상 사용자 ID")
-        @PathVariable
-        userId: UUID,
-        @Parameter(description = "이전 응답의 nextCursor (첫 페이지는 생략)")
-        @RequestParam(required = false)
-        cursor: String?,
-        @Parameter(description = "페이지 크기 (1-100, 기본값 20)")
-        @RequestParam(defaultValue = "20")
-        @Min(1)
-        @Max(100)
-        size: Int,
-        @Parameter(description = "기간 필터 (WEEK: 7일, MONTH: 30일, YEAR: 365일, ALL: 전체)")
-        @RequestParam(defaultValue = "ALL")
-        period: PostPeriod,
-        @Parameter(description = "정렬 기준 (LATEST: 최신순, VIEW: 조회순, LIKE: 추천순, COMMENT: 댓글순)")
-        @RequestParam(defaultValue = "LATEST")
-        sort: PostSortType,
-        @Parameter(description = "카테고리 ID 필터 (생략 시 전체)")
-        @RequestParam(required = false)
-        categoryId: UUID?,
-        @AuthenticationPrincipal currentUserId: UUID?,
-    ): ApiResponse<CursorPageResponse<PostListItemResponse>> {
-        return ApiResponse.ok(
-            postListReadService.getPostsByUserId(
-                userId = userId,
-                cursor = cursor,
-                size = size,
-                period = period,
-                sortType = sort,
-                categoryId = categoryId,
-                currentUserId = currentUserId,
-            ),
-        )
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -94,7 +94,7 @@ class PostListReadServiceTest {
             } returns emptyList()
 
             // when
-            postListReadService.getPosts(cursor = null, size = 20, userId = testUser.id!!)
+            postListReadService.getPosts(cursor = null, size = 20, currentUserId = testUser.id!!)
 
             // then
             verify {
@@ -124,7 +124,7 @@ class PostListReadServiceTest {
             } returns posts
 
             // when
-            postListReadService.getPosts(cursor = null, size = 20, userId = null)
+            postListReadService.getPosts(cursor = null, size = 20, currentUserId = null)
 
             // then
             verify {
@@ -140,11 +140,11 @@ class PostListReadServiceTest {
     }
 
     @Nested
-    @DisplayName("getPostsByUserId")
-    inner class GetPostsByUserId {
+    @DisplayName("getPosts (authorId 필터)")
+    inner class GetPostsWithAuthorId {
         @Test
         @DisplayName("본인 조회 시 모든 상태(DRAFT, PUBLISHED, PRIVATE)로 Repository를 호출한다")
-        fun getPostsByUserId_ownPosts_queriesAllStatuses() {
+        fun getPosts_ownPosts_queriesAllStatuses() {
             // given
             val posts = listOf(createPost(testUser))
             every {
@@ -163,11 +163,11 @@ class PostListReadServiceTest {
             } returns emptyList()
 
             // when
-            postListReadService.getPostsByUserId(
-                userId = testUser.id!!,
+            postListReadService.getPosts(
                 cursor = null,
                 size = 20,
                 currentUserId = testUser.id!!,
+                authorId = testUser.id!!,
             )
 
             // then
@@ -186,7 +186,7 @@ class PostListReadServiceTest {
 
         @Test
         @DisplayName("타인 조회 시 PUBLISHED만으로 Repository를 호출한다")
-        fun getPostsByUserId_otherUserPosts_queriesPublishedOnly() {
+        fun getPosts_otherUserPosts_queriesPublishedOnly() {
             // given
             val posts = listOf(createPost(otherUser))
             every {
@@ -205,11 +205,11 @@ class PostListReadServiceTest {
             } returns emptyList()
 
             // when
-            postListReadService.getPostsByUserId(
-                userId = otherUser.id!!,
+            postListReadService.getPosts(
                 cursor = null,
                 size = 20,
                 currentUserId = testUser.id!!,
+                authorId = otherUser.id!!,
             )
 
             // then
@@ -228,7 +228,7 @@ class PostListReadServiceTest {
 
         @Test
         @DisplayName("비로그인 사용자 조회 시 PUBLISHED만으로 Repository를 호출하고 isRead는 항상 false이다")
-        fun getPostsByUserId_anonymousUser_queriesPublishedOnly() {
+        fun getPosts_anonymousUser_queriesPublishedOnly() {
             // given
             val posts = listOf(createPost(otherUser))
             every {
@@ -245,11 +245,11 @@ class PostListReadServiceTest {
 
             // when
             val result =
-                postListReadService.getPostsByUserId(
-                    userId = otherUser.id!!,
+                postListReadService.getPosts(
                     cursor = null,
                     size = 20,
                     currentUserId = null,
+                    authorId = otherUser.id!!,
                 )
 
             // then
@@ -269,14 +269,14 @@ class PostListReadServiceTest {
 
         @Test
         @DisplayName("잘못된 커서 전달 시 빈 응답을 반환한다")
-        fun getPostsByUserId_invalidCursor_returnsEmptyResponse() {
+        fun getPosts_invalidCursor_returnsEmptyResponse() {
             // given & when
             val result =
-                postListReadService.getPostsByUserId(
-                    userId = testUser.id!!,
+                postListReadService.getPosts(
                     cursor = "invalid-cursor-string",
                     size = 20,
                     currentUserId = testUser.id!!,
+                    authorId = testUser.id!!,
                 )
 
             // then
@@ -288,7 +288,7 @@ class PostListReadServiceTest {
 
         @Test
         @DisplayName("다음 페이지가 있으면 hasNext가 true이고 nextCursor가 반환된다")
-        fun getPostsByUserId_hasMorePosts_returnsHasNextTrue() {
+        fun getPosts_hasMorePosts_returnsHasNextTrue() {
             // given
             val posts = (1..3).map { createPost(testUser) }
             every {
@@ -308,11 +308,11 @@ class PostListReadServiceTest {
 
             // when
             val result =
-                postListReadService.getPostsByUserId(
-                    userId = testUser.id!!,
+                postListReadService.getPosts(
                     cursor = null,
                     size = 2,
                     currentUserId = testUser.id!!,
+                    authorId = testUser.id!!,
                 )
 
             // then
@@ -323,7 +323,7 @@ class PostListReadServiceTest {
 
         @Test
         @DisplayName("다음 페이지가 없으면 hasNext가 false이고 nextCursor가 null이다")
-        fun getPostsByUserId_noMorePosts_returnsHasNextFalse() {
+        fun getPosts_noMorePosts_returnsHasNextFalse() {
             // given
             val posts = listOf(createPost(testUser))
             every {
@@ -343,11 +343,11 @@ class PostListReadServiceTest {
 
             // when
             val result =
-                postListReadService.getPostsByUserId(
-                    userId = testUser.id!!,
+                postListReadService.getPosts(
                     cursor = null,
                     size = 20,
                     currentUserId = testUser.id!!,
+                    authorId = testUser.id!!,
                 )
 
             // then
@@ -358,7 +358,7 @@ class PostListReadServiceTest {
 
         @Test
         @DisplayName("로그인 사용자가 조회 시 읽음 기록이 반영된다")
-        fun getPostsByUserId_loggedInUser_appliesReadStatus() {
+        fun getPosts_loggedInUser_appliesReadStatus() {
             // given
             val post1 = createPost(otherUser)
             val post2 = createPost(otherUser)
@@ -382,11 +382,11 @@ class PostListReadServiceTest {
 
             // when
             val result =
-                postListReadService.getPostsByUserId(
-                    userId = otherUser.id!!,
+                postListReadService.getPosts(
                     cursor = null,
                     size = 20,
                     currentUserId = testUser.id!!,
+                    authorId = otherUser.id!!,
                 )
 
             // then


### PR DESCRIPTION
## Summary

- `GET /users/{userId}/posts` 엔드포인트 제거
- `GET /posts`에 `authorId` (optional), `categoryId` (optional) 파라미터 추가
- 두 기능을 단일 엔드포인트로 통합

## 변경 상세

| 파일 | 변경 내용 |
|------|-----------|
| `PostListReadService.kt` | `getPosts`에 `authorId`, `categoryId`, `currentUserId` 통합, `getPostsByUserId` 삭제 |
| `PostReadOpenApiController.kt` | `authorId`, `categoryId` optional param 추가 |
| `UserOpenApiController.kt` | `getPostsByUserId` 메서드 및 `postListReadService` 의존성 제거 |
| `PostListReadServiceTest.kt` | `GetPostsByUserId` → `GetPostsWithAuthorId`로 마이그레이션 |

## API 동작

- `GET /open-api/posts` — 전체 피드 (기존 동일)
- `GET /open-api/posts?authorId=xxx` — 특정 사용자 게시물 (본인이면 DRAFT/PRIVATE 포함, 타인이면 PUBLISHED만)
- `GET /open-api/posts?authorId=xxx&categoryId=yyy` — 카테고리 필터 추가
- `GET /open-api/users/{userId}/posts` — **제거됨**