### PR TITLE
feat(post): 게시물 목록 응답에 authorId 필드 추가

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -235,14 +235,6 @@ class PostListReadService(
         return "${updatedAt.time}_$id"
     }
 
-    /**
-     * Post 엔티티를 PostListItemResponse DTO로 변환합니다.
-     * 썸네일 URL과 읽음 여부를 계산하여 포함합니다.
-     *
-     * @param post 게시물 엔티티
-     * @param isRead 현재 사용자가 읽은 게시물인지 여부
-     * @return 응답 DTO
-     */
     private fun convertToResponse(
         post: Post,
         isRead: Boolean,
@@ -260,6 +252,7 @@ class PostListReadService(
         return PostListItemResponse(
             id = post.id!!,
             title = post.title,
+            authorId = post.author.id!!,
             authorName = post.author.name,
             authorProfileImageUrl = post.author.profileImageUrl,
             thumbnailUrl = thumbnailUrl,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostListItemResponse.kt
@@ -6,28 +6,14 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.util.Date
 import java.util.UUID
 
-/**
- * 게시물 목록 아이템 응답 DTO
- *
- * @property id 게시물 ID
- * @property title 게시물 제목
- * @property authorName 작성자 이름
- * @property authorProfileImageUrl 작성자 프로필 이미지 URL
- * @property thumbnailUrl 게시물 썸네일 이미지 URL
- * @property isRead 로그인한 사용자가 읽은 게시물인지 여부 (비회원은 항상 false)
- * @property tags 태그 목록
- * @property viewCount 조회수
- * @property likeCount 좋아요수
- * @property commentCount 댓글수
- * @property status 게시물 상태 (DRAFT: 임시저장, PUBLISHED: 발행, PRIVATE: 비공개)
- * @property createdAt 작성일
- */
 @Schema(description = "게시물 목록 아이템")
 data class PostListItemResponse(
     @field:Schema(description = "게시물 ID")
     val id: UUID,
     @field:Schema(description = "게시물 제목")
     val title: String,
+    @field:Schema(description = "작성자 ID")
+    val authorId: UUID,
     @field:Schema(description = "작성자 이름")
     val authorName: String,
     @field:Schema(description = "작성자 프로필 이미지 URL")
@@ -62,6 +48,7 @@ data class PostListItemResponse(
             PostListItemResponse(
                 id = post.id!!,
                 title = post.title,
+                authorId = post.author.id!!,
                 authorName = post.author.name,
                 authorProfileImageUrl = post.author.profileImageUrl,
                 thumbnailUrl = "",


### PR DESCRIPTION
## Summary
- `PostListItemResponse`에 `authorId: UUID` 필드 추가
- `PostListReadService.convertToResponse()`에서 `post.author.id` 매핑 추가

## Test plan
- [ ] 게시물 목록 조회 API 응답에 `authorId` 포함 확인
- [ ] 기존 테스트 통과 확인