### PR TITLE
fix(user): 사용자 검색 API 빈 문자열 입력 시 전체 사용자 노출 취약점 수정

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiController.kt
@@ -5,8 +5,14 @@ import com.techtaurant.mainserver.security.SecurityConstants
 import com.techtaurant.mainserver.user.application.UserReadService
 import com.techtaurant.mainserver.user.dto.UserResponse
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.NotBlank
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -15,9 +21,19 @@ import org.springframework.web.bind.annotation.RestController
 @Tag(name = "User", description = "사용자 Open API")
 @RestController
 @RequestMapping("${SecurityConstants.OPEN_API_PREFIX}/users")
+@Validated
 class UserOpenApiController(
     private val userReadService: UserReadService,
 ) {
+    companion object {
+        private const val SEARCH_NAME_VALIDATION_ERROR_EXAMPLE =
+            "{\"status\": 400," +
+                " \"data\": {\"errors\":" +
+                " {\"searchByName.name\":" +
+                " \"공백일 수 없습니다\"}}," +
+                " \"message\": \"Wrong Request\"}"
+    }
+
     @Operation(summary = "사용자 검색", description = "사용자 이름으로 검색합니다")
     @ApiResponses(
         value = [
@@ -25,11 +41,30 @@ class UserOpenApiController(
                 responseCode = "200",
                 description = "검색 성공",
             ),
+            io.swagger.v3.oas.annotations.responses.ApiResponse(
+                responseCode = "400",
+                description = "name이 공백인 경우",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ApiResponse::class),
+                        examples = [
+                            ExampleObject(
+                                name = "Validation 에러",
+                                value = SEARCH_NAME_VALIDATION_ERROR_EXAMPLE,
+                            ),
+                        ],
+                    ),
+                ],
+            ),
         ],
     )
     @GetMapping("/search")
     fun searchByName(
-        @RequestParam name: String,
+        @Parameter(description = "검색할 사용자 이름 (1자 이상)")
+        @RequestParam
+        @NotBlank
+        name: String,
     ): ApiResponse<List<UserResponse>> {
         return ApiResponse.ok(userReadService.searchByName(name))
     }

--- a/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiControllerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiControllerTest.kt
@@ -1,0 +1,154 @@
+package com.techtaurant.mainserver.user.infrastructure.`in`
+
+import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.dto.UserResponse
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import io.restassured.RestAssured
+import io.restassured.common.mapper.TypeRef
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@DisplayName("사용자 검색 API")
+class UserOpenApiControllerTest : IntegrationTest() {
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @BeforeEach
+    fun setup() {
+        userRepository.deleteAllInBatch()
+    }
+
+    @Nested
+    @DisplayName("입력값 검증")
+    inner class ValidationTest {
+        @Test
+        @DisplayName("빈 문자열로 검색하면 400을 반환한다")
+        fun whenNameIsEmpty_thenReturn400() {
+            // given
+            // 검색어 없이 빈 문자열 전달
+
+            // when
+            val statusCode =
+                RestAssured
+                    .given()
+                    .queryParam("name", "")
+                    .`when`()
+                    .get("/open-api/users/search")
+                    .then()
+                    .extract()
+                    .statusCode()
+
+            // then
+            assertEquals(400, statusCode, "빈 문자열 검색은 400을 반환해야 한다")
+        }
+
+        @Test
+        @DisplayName("공백만 있는 문자열로 검색하면 400을 반환한다")
+        fun whenNameIsBlank_thenReturn400() {
+            // given
+            // 공백 문자만으로 구성된 검색어 전달
+
+            // when
+            val statusCode =
+                RestAssured
+                    .given()
+                    .queryParam("name", "   ")
+                    .`when`()
+                    .get("/open-api/users/search")
+                    .then()
+                    .extract()
+                    .statusCode()
+
+            // then
+            assertEquals(400, statusCode, "공백만 있는 검색어는 400을 반환해야 한다")
+        }
+    }
+
+    @Nested
+    @DisplayName("정상 검색")
+    inner class SearchTest {
+        @Test
+        @DisplayName("유효한 이름으로 검색하면 매칭되는 사용자 목록을 반환한다")
+        fun whenNameIsValid_thenReturnMatchingUsers() {
+            // given
+            userRepository.save(
+                User(
+                    name = "김테크",
+                    email = "kim@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "google-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/profile.jpg",
+                ),
+            )
+            userRepository.save(
+                User(
+                    name = "이개발",
+                    email = "lee@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "google-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/profile.jpg",
+                ),
+            )
+
+            // when
+            val response =
+                RestAssured
+                    .given()
+                    .queryParam("name", "테크")
+                    .`when`()
+                    .get("/open-api/users/search")
+                    .then()
+                    .statusCode(200)
+                    .extract()
+                    .`as`(object : TypeRef<ApiResponse<List<UserResponse>>>() {})
+
+            // then
+            val users = response.data!!
+            assertEquals(1, users.size, "검색어와 매칭되는 사용자 1명이 반환되어야 한다")
+            assertEquals("김테크", users[0].name)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 이름으로 검색하면 빈 목록을 반환한다")
+        fun whenNameDoesNotMatch_thenReturnEmptyList() {
+            // given
+            userRepository.save(
+                User(
+                    name = "김테크",
+                    email = "kim@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "google-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/profile.jpg",
+                ),
+            )
+
+            // when
+            val response =
+                RestAssured
+                    .given()
+                    .queryParam("name", "존재하지않는이름xyz")
+                    .`when`()
+                    .get("/open-api/users/search")
+                    .then()
+                    .statusCode(200)
+                    .extract()
+                    .`as`(object : TypeRef<ApiResponse<List<UserResponse>>>() {})
+
+            // then
+            assertTrue(response.data!!.isEmpty(), "매칭되는 사용자가 없으면 빈 목록이 반환되어야 한다")
+        }
+    }
+}


### PR DESCRIPTION
## 관련 자료
- 이슈 : #69

## 어떤 작업인가요?
`GET /open-api/users/search?name=` 요청 시 빈 문자열이 전달되면 전체 사용자 목록이 노출되는 보안 취약점을 수정한다.

## 어떻게 해결했나요?
**입력값 검증 추가**
- `name` 파라미터에 `@NotBlank` 어노테이션을 추가하여 빈 문자열 및 공백만 있는 검색어를 400으로 거부
- 컨트롤러 클래스에 `@Validated`가 이미 적용되어 있어 별도 설정 없이 동작

**통합 테스트 추가**
- 빈 문자열, 공백 문자열, 정상 검색, 미매칭 4가지 케이스에 대한 통합 테스트 작성

## 중요한 변경 사항은 무엇인가요?
### 취약점 수정

**@NotBlank 검증 추가**
- **변경 이유**: `findByNameContainingIgnoreCaseOrderByNameAsc("")` 쿼리가 전체 사용자를 반환하는 취약점 차단
- **수정 파일**: `UserOpenApiController.kt`

**Swagger 400 에러 응답 명세 추가**
- **변경 이유**: 추가된 검증 오류를 API 문서에 반영
- **수정 파일**: `UserOpenApiController.kt`

**통합 테스트 신규 작성**
- **변경 이유**: 취약점 수정 동작을 검증하고 회귀를 방지
- **수정 파일**: `UserOpenApiControllerTest.kt` (신규)
