### PR TITLE
사용자 차단 API와 조회 차단 정책 추가

### DIFF
--- a/.claude/plan/user/2603/10-add-user-ban-api.plan.md
+++ b/.claude/plan/user/2603/10-add-user-ban-api.plan.md
@@ -1,0 +1,165 @@
+# 사용자 ban API 및 조회 차단 정책 구현
+
+## Business Goal
+특정 사용자가 원치 않는 다른 사용자를 개인적으로 차단할 수 있게 하고, 차단한 사용자의 게시물은 조회되지 않도록 하며 댓글은 맥락은 유지하되 식별 정보가 노출되지 않도록 처리한다.
+
+## Scope
+- **In Scope**: 사용자 ban/ban 목록/unban API, `user_bans` 저장 구조, 게시물 목록/상세 차단 필터, 댓글 마스킹 및 `isBanned` 응답 필드, 관련 Swagger 및 테스트 추가
+- **Out of Scope**: 관리자 차단 기능, 알림 발송, 기존 데이터 백필 외 별도 운영 도구, 댓글 작성 제한 같은 추가 정책
+
+## Codebase Analysis Summary
+사용자 API는 `user.infrastructure.in` 패키지의 controller/docs와 `user.application` 서비스 조합으로 구성되어 있다. 게시물 목록은 `PostListReadService`와 `PostRepositoryCustomImpl`이 조건별 조회를 담당하며, 게시물 상세는 `PostDetailReadService`에서 접근 제어를 수행한다. 댓글 조회는 `CommentReadService`가 응답 DTO 변환 직전에 현재 사용자별 상태를 붙이는 구조다. 따라서 게시물 차단은 repository/service 레벨에서 필터링하고, 댓글 마스킹은 service의 DTO 매핑 단계에 추가하는 방식이 현재 구조와 가장 잘 맞는다.
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/main/resources/db/migration` | DB 마이그레이션 저장소 | Create |
+| `src/main/kotlin/com/techtaurant/mainserver/user/entity/User.kt` | 사용자 엔티티 | Reference |
+| `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserRepository.kt` | 사용자 조회 리포지토리 | Reference |
+| `src/main/kotlin/com/techtaurant/mainserver/user/application/UserReadService.kt` | 사용자 조회 서비스 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt` | 사용자 인증 API | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerDocs.kt` | 사용자 Swagger 계약 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt` | 게시물 목록 조회 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt` | 게시물 상세 조회 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt` | 게시물 조건 조회 인터페이스 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt` | 게시물 조건 조회 구현 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentReadService.kt` | 댓글 조회 서비스 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentListResponse.kt` | 댓글 응답 DTO | Modify |
+| `src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt` | 게시물 목록 단위 테스트 | Modify |
+| `src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadControllerTest.kt` | 댓글 조회 통합 테스트 | Modify |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| DTO 네이밍과 설명 | `.claude/core/BACKEND.md` | Request/Response 접미사 유지, Swagger description은 한국어 작성 |
+| 코드 단순성 | `.claude/core/CODE_PRINCIPLES.md` | 작은 함수로 분리하고 과도한 추상화 없이 현재 요구만 구현 |
+| 테스트 패턴 | `.claude/framework/SPRING_BOOT.md` | 통합 테스트는 기존 `IntegrationTest` 기반, Given-When-Then 구조 유지 |
+| 상태 코드 관리 | 기존 `UserStatus` enum | 새로운 예외는 enum에 추가하고 controller docs에도 명시 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| Ban 저장 방식 | `user_bans` 별도 테이블 | 사용자 간 N:M 관계를 명확히 표현하고 조회 정책을 독립적으로 확장하기 쉽다 | `users` self relation |
+| 게시물 상세 차단 동작 | `POST_NOT_FOUND`로 숨김 | 기존 비공개 게시물 접근 차단과 같은 UX를 유지한다 | 상세는 노출하되 마스킹 |
+| 댓글 차단 동작 | 댓글 유지 + `isBanned=true` + `banned_<6글자>` 치환 | 스레드 맥락은 유지하면서 식별 정보는 제거할 수 있다 | 댓글 완전 제외 |
+| 해시 규칙 | 결정적 SHA-256 기반 6글자 prefix | 동일 작성자의 댓글이 같은 익명 식별자로 보여 추적 가능성이 낮고 읽기 맥락이 유지된다 | 랜덤 익명값, 고정 문구 |
+
+## API Contracts
+
+### `POST /api/users/{targetUserId}/ban`
+- Headers: 인증 필요
+- Request: 없음
+- Response: `ApiResponse<UserBanResponse>`
+- Note: 자기 자신 차단 및 중복 차단은 예외 처리
+
+### `GET /api/users/me/bans`
+- Headers: 인증 필요
+- Request: 없음
+- Response: `ApiResponse<List<UserBanListItemResponse>>`
+- Note: 현재 사용자가 차단한 사용자 목록을 최신순으로 반환
+
+### `DELETE /api/users/{targetUserId}/ban`
+- Headers: 인증 필요
+- Request: 없음
+- Response: `204 No Content`
+- Note: 존재하지 않는 차단 관계는 예외 처리
+
+## Data Models
+
+### UserBan
+| Field | Type | Constraints |
+|-------|------|-------------|
+| id | UUID | PK |
+| user_id | UUID | FK users.id, not null |
+| banned_user_id | UUID | FK users.id, not null |
+| created_at | timestamp | UTC, not null |
+| updated_at | timestamp | UTC, not null |
+
+## Implementation Todos
+
+### Todo 1: ban 저장 구조와 도메인 모델 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 사용자 차단 관계를 저장하고 조회할 수 있는 최소 도메인 구조를 만든다.
+- **Work**:
+  - `V17__create_user_bans.sql` 마이그레이션 추가
+  - `userban` 도메인 패키지 또는 기존 user 하위에 entity/repository 추가
+  - 중복 차단 방지를 위한 unique constraint 및 조회 메서드 구현
+  - `UserStatus`에 ban 관련 예외 코드 추가
+- **Convention Notes**: 명확한 이름을 사용하고 enum/엔티티는 별도 파일로 분리한다.
+- **Verification**: 관련 코드 컴파일 확인, repository 사용 경로 점검
+- **Exit Criteria**: user ban 엔티티와 repository가 생성되고 예외 상태가 정의된다.
+- **Status**: completed
+
+### Todo 2: 사용자 ban API와 목록 조회 API 구현
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 사용자가 다른 사용자를 차단/해제/목록 조회할 수 있는 인증 API를 제공한다.
+- **Work**:
+  - ban 응답 DTO와 목록 DTO 추가
+  - `UserBanService` 또는 역할이 명확한 서비스 추가
+  - `UserController`/`UserControllerDocs`에 POST, GET, DELETE 엔드포인트 추가
+  - 자기 자신 차단, 대상 사용자 없음, 중복 차단, 차단 관계 없음 검증 추가
+- **Convention Notes**: Swagger description은 한국어로 작성하고 `ApiErrorResponses`/`ApiErrorCodeResponses` 패턴을 따른다.
+- **Verification**: 사용자 API 관련 테스트 추가 또는 실행
+- **Exit Criteria**: 세 API가 동작하고 예외가 문서화된다.
+- **Status**: completed
+
+### Todo 3: 게시물 조회 차단 정책 반영
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 로그인 사용자가 차단한 작성자의 게시물은 목록과 상세에서 보이지 않게 한다.
+- **Work**:
+  - 현재 사용자 기준 ban 대상 ID 조회 로직 추가
+  - `PostRepositoryCustom`/`PostRepositoryCustomImpl`에 제외 author 조건 확장
+  - `PostListReadService`에서 ban 대상 작성자 제외 적용
+  - `PostDetailReadService`에서 차단된 작성자 게시물 상세 접근 시 `POST_NOT_FOUND` 처리
+- **Convention Notes**: 게시물 접근 제어는 service/repository 레이어에서 일관되게 처리한다.
+- **Verification**: `PostListReadServiceTest`와 상세 조회 테스트 실행
+- **Exit Criteria**: 로그인 사용자는 차단 대상 작성자의 게시물을 목록/상세에서 볼 수 없다.
+- **Status**: completed
+
+### Todo 4: 댓글 마스킹 정책 반영
+- **Priority**: 3
+- **Dependencies**: Todo 1
+- **Goal**: 차단한 작성자의 댓글은 조회는 유지하되 익명화된 응답으로 반환한다.
+- **Work**:
+  - `CommentListResponse`에 `isBanned` 필드 추가
+  - `CommentReadService`에서 현재 사용자 ban 목록을 로드해 댓글 응답 매핑 시 마스킹 적용
+  - `banned_<6글자>` 형식의 결정적 해시 유틸 추가
+  - 댓글 내용, 작성자명, 프로필 이미지 URL을 마스킹 규칙으로 치환
+- **Convention Notes**: 마스킹 로직은 재사용 가능한 작은 함수로 분리하고 DTO 변환 책임을 흐리지 않도록 한다.
+- **Verification**: 댓글 조회 통합 테스트 또는 서비스 테스트 실행
+- **Exit Criteria**: 차단된 사용자의 댓글은 `isBanned=true`이며 식별 정보가 노출되지 않는다.
+- **Status**: completed
+
+### Todo 5: 회귀 테스트와 문서 정리
+- **Priority**: 4
+- **Dependencies**: Todo 2, Todo 3, Todo 4
+- **Goal**: 기능이 기존 동작을 깨지 않았는지 검증하고 계획 상태를 마무리한다.
+- **Work**:
+  - 변경된 단위/통합 테스트 실행
+  - 필요한 경우 API 문서 설명 보정
+  - 계획 파일 진행률과 변경 로그 갱신
+- **Convention Notes**: 실패한 테스트를 남기지 않고, 테스트 범위는 변경 영향 파일에 집중한다.
+- **Verification**: `./gradlew test --tests ...` 또는 관련 테스트 묶음 실행
+- **Exit Criteria**: 관련 테스트가 통과하고 계획 파일이 완료 상태로 정리된다.
+- **Status**: completed
+
+## Verification Strategy
+변경 영향이 큰 영역은 사용자 API, 게시물 읽기, 댓글 읽기다. 따라서 ban 서비스/컨트롤러 테스트, 게시물 목록/상세 테스트, 댓글 조회 테스트를 우선 실행하고 마지막에 관련 테스트 묶음 또는 전체 테스트를 가능한 범위에서 재실행한다.
+- `./gradlew test --tests "*User*Ban*" --tests "*PostListReadServiceTest*" --tests "*CommentReadControllerTest*"`
+- 필요 시 `./gradlew test --tests "*Post*"` 처럼 범위를 넓혀 회귀 확인
+
+## Progress Tracking
+- Total Todos: 5
+- Completed: 5
+- Status: Execution complete
+
+## Change Log
+- 2026-03-10: Plan created
+- 2026-03-10: Todo 1 completed — `user_bans` 마이그레이션, 엔티티, 리포지토리, 예외 상태 추가
+- 2026-03-10: Todo 2 completed — 사용자 ban, ban 목록 조회, unban API와 DTO/서비스 추가
+- 2026-03-10: Todo 3 completed — 게시물 목록/상세에서 차단한 작성자 비노출 처리
+- 2026-03-10: Todo 4 completed — 댓글 `isBanned` 및 `banned_<6글자>` 마스킹 정책 반영
+- 2026-03-10: Todo 5 completed — JDK 17로 타깃 테스트 실행 완료, JaCoCo 전역 커버리지 게이트는 별도 관리 이슈로 확인

--- a/.claude/plan/user/2603/11-refactor-comment-ban-and-post-ban-query.plan.md
+++ b/.claude/plan/user/2603/11-refactor-comment-ban-and-post-ban-query.plan.md
@@ -1,0 +1,104 @@
+# 댓글 차단 응답 리팩터링과 게시물 차단 조회 쿼리화
+
+## Business Goal
+댓글 차단 응답 생성 책임을 읽기 서비스에서 분리해 유지보수성을 높이고, 게시물 차단 정책을 조회 쿼리에서 직접 처리해 서비스 레이어의 중간 상태 의존을 줄인다.
+
+## Scope
+- **In Scope**: 댓글 차단 응답 assembler 추가, `CommentListResponse` 생성 방식 단순화, 게시물 목록/상세 차단 조건을 repository query로 이동, 관련 테스트 갱신
+- **Out of Scope**: 차단 API 스펙 변경, 차단 정책 변경, 댓글 조회 전체를 projection 기반으로 재작성
+
+## Codebase Analysis Summary
+댓글 응답은 현재 `CommentReadService`가 좋아요 상태와 차단 마스킹을 모두 조합해 `CommentListResponse.from(...)`에 과도한 optional argument를 넘기는 구조다. 게시물 조회는 `PostListReadService`와 `PostDetailReadService`가 `UserBanService.getBannedUserIds()`를 호출해 application 레이어에서 차단 상태를 미리 계산하고 repository로 전달한다. 기존 테스트는 댓글 통합 테스트와 게시물 서비스/리포지토리/컨트롤러 테스트로 나뉘어 있어 리팩터링 이후에도 같은 레이어 경계에서 검증하는 것이 적절하다.
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentReadService.kt` | 댓글 조회 orchestration | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentListResponse.kt` | 댓글 응답 DTO | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/user/application/BannedUserMaskingService.kt` | 차단 사용자 마스킹 규칙 | Reference |
+| `src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentResponseAssembler.kt` | 댓글 응답 조립 전용 클래스 | Create |
+| `src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt` | 게시물 목록 조회 orchestration | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt` | 게시물 상세 조회 orchestration | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt` | 게시물 동적 조회 인터페이스 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt` | 게시물 동적 조회 구현 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepository.kt` | 게시물 상세 조회 확장 포인트 | Reference |
+| `src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadControllerTest.kt` | 댓글 차단 응답 통합 테스트 | Modify |
+| `src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt` | 게시물 목록 서비스 테스트 | Modify |
+| `src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt` | 게시물 동적 조회 repository 테스트 | Modify |
+| `src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt` | 게시물 목록/상세 차단 통합 테스트 | Modify |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| 완료 체크리스트 | `CLAUDE.md` | 코드 변경 후 `./gradlew spotlessApply && ./gradlew spotlessCheck`를 반드시 통과 |
+| 책임 분리 | 기존 `application` / `infrastructure.out` 구조 | 서비스는 orchestration 위주, 조회 조건은 repository query에서 처리 |
+| DTO 단순성 | 기존 DTO 패턴 | DTO는 optional parameter 남용보다 명시적 팩토리/조립 클래스를 우선 |
+| 테스트 범위 | 기존 테스트 파일 구성 | 서비스, repository, controller 레이어 각각 기존 위치에서 회귀 검증 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 댓글 차단 응답 위치 | `CommentResponseAssembler` 신설 | 좋아요 상태와 차단 마스킹을 한 곳에서 조립 | `CommentReadService` 내부 유지 |
+| 댓글 DTO 생성 방식 | 일반 응답/차단 응답을 분리한 명시적 팩토리 | optional 인자 남용 제거 | 단일 `from(...)` 유지 |
+| 게시물 목록 차단 처리 | repository query에서 `NOT EXISTS user_bans` 조건 적용 | 서비스 선조회 제거, 페이징 조건과 결합 일관성 확보 | `excludedAuthorIds` 유지 |
+| 게시물 상세 차단 처리 | repository 기반 차단 여부 조회 추가 | 상세도 동일한 조회 정책 경로 유지 | `UserBanService.getBannedUserIds()` 유지 |
+
+## Implementation Todos
+
+### Todo 1: 댓글 차단 응답 조립 책임 분리
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 댓글 조회 서비스에서 차단 마스킹 세부 구현을 제거한다.
+- **Work**:
+  - `CommentResponseAssembler`를 추가해 댓글 목록 + 좋아요 상태 + 현재 사용자 ID를 받아 `CommentListResponse` 목록으로 변환
+  - `CommentListResponse`에 일반 응답과 차단 응답용 명시적 생성 경로를 만든다
+  - `CommentReadService`는 repository 호출과 pagination orchestration만 담당하도록 정리한다
+- **Convention Notes**: DTO에 과도한 책임을 넣지 말고, assembler가 마스킹 규칙과 응답 조립을 캡슐화한다.
+- **Verification**: `./gradlew test -x jacocoTestCoverageVerification --tests '*CommentReadControllerTest'`
+- **Exit Criteria**: `CommentReadService`에서 차단 응답 필드 조합 코드가 제거되고 댓글 통합 테스트가 통과한다.
+- **Status**: completed
+
+### Todo 2: 게시물 목록/상세 차단 조건을 query로 이동
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 게시물 조회 시 차단 관계를 서비스 선조회 없이 repository query에서 처리한다.
+- **Work**:
+  - `PostRepositoryCustom.findPostsWithConditions`에서 `excludedAuthorIds` 인자를 제거하고 viewer 기준 차단 조건을 받을 수 있게 시그니처를 정리한다
+  - `PostRepositoryCustomImpl`에 `user_bans`를 기준으로 한 `NOT EXISTS` 또는 동등한 subquery 조건을 추가한다
+  - `PostListReadService`에서 `UserBanService.getBannedUserIds()` 호출을 제거한다
+  - `PostDetailReadService`는 repository 기반 차단 여부 조회 또는 차단 조건 포함 조회로 정리한다
+- **Convention Notes**: 조회 정책은 persistence layer에 두고, application service는 입력 조합과 후처리만 담당한다.
+- **Verification**: `./gradlew test -x jacocoTestCoverageVerification --tests '*PostListReadServiceTest' --tests '*PostRepositoryCustomImplTest' --tests '*PostReadOpenApiControllerIntegrationTest'`
+- **Exit Criteria**: 게시물 목록/상세에서 차단 사용자 비노출이 유지되고 서비스 레이어의 ban ID 선조회가 제거된다.
+- **Status**: completed
+
+### Todo 3: 회귀 검증과 포맷 정리
+- **Priority**: 3
+- **Dependencies**: Todo 2
+- **Goal**: 리팩터링 후 기존 기능 회귀와 포맷 규칙을 확인한다.
+- **Work**:
+  - 변경된 댓글/게시물 관련 테스트를 묶어서 실행한다
+  - `spotlessApply`와 `spotlessCheck`를 실행한다
+  - 필요 시 테스트와 포맷 결과에 맞춰 import/order를 정리한다
+- **Convention Notes**: 변경 영향 범위에 집중해 빠르게 검증하되, `CLAUDE.md` 완료 체크리스트는 반드시 지킨다.
+- **Verification**:
+  - `./gradlew test -x jacocoTestCoverageVerification --tests '*CommentReadControllerTest' --tests '*PostListReadServiceTest' --tests '*PostRepositoryCustomImplTest' --tests '*PostReadOpenApiControllerIntegrationTest'`
+  - `./gradlew spotlessApply && ./gradlew spotlessCheck`
+- **Exit Criteria**: 대상 테스트와 spotless가 모두 통과한다.
+- **Status**: completed
+
+## Verification Strategy
+댓글과 게시물 조회 레이어를 각각 통합/단위 테스트로 검증하고, 마지막에 spotless 규칙까지 통과시킨다.
+- `./gradlew test -x jacocoTestCoverageVerification --tests '*CommentReadControllerTest' --tests '*PostListReadServiceTest' --tests '*PostRepositoryCustomImplTest' --tests '*PostReadOpenApiControllerIntegrationTest'`
+- `./gradlew spotlessApply && ./gradlew spotlessCheck`
+
+## Progress Tracking
+- Total Todos: 3
+- Completed: 3
+- Status: Execution complete
+
+## Change Log
+- 2026-03-11: Plan created
+- 2026-03-11: Todo 1 completed — 댓글 차단 응답 조립을 assembler로 분리하고 DTO 팩토리를 단순화
+- 2026-03-11: Todo 2 completed — 게시물 차단 정책을 repository query 기반으로 이동하고 서비스 ban ID 선조회를 제거
+- 2026-03-11: Todo 3 completed — 댓글/게시물 회귀 테스트와 spotless 검증을 완료

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentReadService.kt
@@ -11,6 +11,8 @@ import com.techtaurant.mainserver.common.enums.LikeStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
+import com.techtaurant.mainserver.user.application.BannedUserMaskingService
+import com.techtaurant.mainserver.user.application.UserBanService
 
 /**
  * 댓글 읽기 서비스
@@ -21,6 +23,8 @@ import java.util.UUID
 class CommentReadService(
     private val commentRepository: CommentRepositoryCustom,
     private val commentLikeLogRepository: CommentLikeLogRepository,
+    private val userBanService: UserBanService,
+    private val bannedUserMaskingService: BannedUserMaskingService,
 ) {
     /**
      * 부모 댓글 목록을 커서 기반 페이지네이션으로 조회합니다.
@@ -139,19 +143,38 @@ class CommentReadService(
         comments: List<Comment>,
         userId: UUID?,
     ): List<CommentListResponse> {
-        if (userId == null || comments.isEmpty()) {
-            return comments.map { CommentListResponse.from(it) }
+        if (comments.isEmpty()) {
+            return emptyList()
         }
 
-        val commentIds = comments.map { it.id!! }
-        val likeLogs = commentLikeLogRepository.findByCommentIdInAndUserId(commentIds, userId)
+        val bannedUserIds = userBanService.getBannedUserIds(userId)
+
         val likeStatusMap =
-            likeLogs.associate { log ->
-                log.comment.id!! to if (log.isLiked) LikeStatus.LIKE else LikeStatus.DISLIKE
+            if (userId == null) {
+                emptyMap()
+            } else {
+                val commentIds = comments.map { it.id!! }
+                commentLikeLogRepository.findByCommentIdInAndUserId(commentIds, userId)
+                    .associate { log ->
+                        log.comment.id!! to if (log.isLiked) LikeStatus.LIKE else LikeStatus.DISLIKE
+                    }
             }
 
         return comments.map { comment ->
-            CommentListResponse.from(comment, likeStatusMap[comment.id!!] ?: LikeStatus.NONE)
+            val isBanned = bannedUserIds.contains(comment.author.id)
+            if (!isBanned) {
+                CommentListResponse.from(comment, likeStatusMap[comment.id!!] ?: LikeStatus.NONE)
+            } else {
+                CommentListResponse.from(
+                    comment = comment,
+                    likeStatus = likeStatusMap[comment.id!!] ?: LikeStatus.NONE,
+                    isBanned = true,
+                    authorId = bannedUserMaskingService.maskAuthorId(comment.author.id!!),
+                    authorName = bannedUserMaskingService.maskAuthorName(comment.author.id!!),
+                    authorProfileImageUrl = null,
+                    content = bannedUserMaskingService.maskCommentContent(comment.id!!),
+                )
+            }
         }
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentReadService.kt
@@ -8,11 +8,11 @@ import com.techtaurant.mainserver.comment.infrastructure.out.CommentLikeLogRepos
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepositoryCustom
 import com.techtaurant.mainserver.common.dto.CursorPageResponse
 import com.techtaurant.mainserver.common.enums.LikeStatus
+import com.techtaurant.mainserver.user.application.BannedUserMaskingService
+import com.techtaurant.mainserver.user.application.UserBanService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
-import com.techtaurant.mainserver.user.application.BannedUserMaskingService
-import com.techtaurant.mainserver.user.application.UserBanService
 
 /**
  * 댓글 읽기 서비스

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentReadService.kt
@@ -8,8 +8,6 @@ import com.techtaurant.mainserver.comment.infrastructure.out.CommentLikeLogRepos
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepositoryCustom
 import com.techtaurant.mainserver.common.dto.CursorPageResponse
 import com.techtaurant.mainserver.common.enums.LikeStatus
-import com.techtaurant.mainserver.user.application.BannedUserMaskingService
-import com.techtaurant.mainserver.user.application.UserBanService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -23,8 +21,7 @@ import java.util.UUID
 class CommentReadService(
     private val commentRepository: CommentRepositoryCustom,
     private val commentLikeLogRepository: CommentLikeLogRepository,
-    private val userBanService: UserBanService,
-    private val bannedUserMaskingService: BannedUserMaskingService,
+    private val commentResponseAssembler: CommentResponseAssembler,
 ) {
     /**
      * 부모 댓글 목록을 커서 기반 페이지네이션으로 조회합니다.
@@ -147,8 +144,6 @@ class CommentReadService(
             return emptyList()
         }
 
-        val bannedUserIds = userBanService.getBannedUserIds(userId)
-
         val likeStatusMap =
             if (userId == null) {
                 emptyMap()
@@ -160,21 +155,6 @@ class CommentReadService(
                     }
             }
 
-        return comments.map { comment ->
-            val isBanned = bannedUserIds.contains(comment.author.id)
-            if (!isBanned) {
-                CommentListResponse.from(comment, likeStatusMap[comment.id!!] ?: LikeStatus.NONE)
-            } else {
-                CommentListResponse.from(
-                    comment = comment,
-                    likeStatus = likeStatusMap[comment.id!!] ?: LikeStatus.NONE,
-                    isBanned = true,
-                    authorId = bannedUserMaskingService.maskAuthorId(comment.author.id!!),
-                    authorName = bannedUserMaskingService.maskAuthorName(comment.author.id!!),
-                    authorProfileImageUrl = null,
-                    content = bannedUserMaskingService.maskCommentContent(comment.id!!),
-                )
-            }
-        }
+        return commentResponseAssembler.assemble(comments, likeStatusMap, userId)
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentResponseAssembler.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentResponseAssembler.kt
@@ -1,0 +1,42 @@
+package com.techtaurant.mainserver.comment.application
+
+import com.techtaurant.mainserver.comment.dto.CommentListResponse
+import com.techtaurant.mainserver.comment.entity.Comment
+import com.techtaurant.mainserver.common.enums.LikeStatus
+import com.techtaurant.mainserver.user.application.BannedUserMaskingService
+import com.techtaurant.mainserver.user.application.UserBanService
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class CommentResponseAssembler(
+    private val userBanService: UserBanService,
+    private val bannedUserMaskingService: BannedUserMaskingService,
+) {
+    fun assemble(
+        comments: List<Comment>,
+        likeStatusMap: Map<UUID, LikeStatus>,
+        userId: UUID?,
+    ): List<CommentListResponse> {
+        if (comments.isEmpty()) {
+            return emptyList()
+        }
+
+        val bannedUserIds = userBanService.getBannedUserIds(userId)
+
+        return comments.map { comment ->
+            val likeStatus = likeStatusMap[comment.id!!] ?: LikeStatus.NONE
+            if (!bannedUserIds.contains(comment.author.id)) {
+                CommentListResponse.from(comment, likeStatus)
+            } else {
+                CommentListResponse.fromMasked(
+                    comment = comment,
+                    likeStatus = likeStatus,
+                    maskedAuthorId = bannedUserMaskingService.maskAuthorId(comment.author.id!!),
+                    maskedAuthorName = bannedUserMaskingService.maskAuthorName(comment.author.id!!),
+                    maskedContent = bannedUserMaskingService.maskCommentContent(comment.id!!),
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentListResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentListResponse.kt
@@ -32,6 +32,8 @@ data class CommentListResponse(
     val replyCount: Long,
     @field:Schema(description = "현재 사용자의 좋아요 상태")
     val likeStatus: LikeStatus,
+    @field:Schema(description = "현재 사용자가 차단한 작성자의 댓글인지 여부")
+    val isBanned: Boolean,
     @field:Schema(description = "생성 시각")
     val createdAt: Date,
     @field:Schema(description = "수정 시각")
@@ -41,19 +43,25 @@ data class CommentListResponse(
         fun from(
             comment: Comment,
             likeStatus: LikeStatus = LikeStatus.NONE,
+            isBanned: Boolean = false,
+            authorId: UUID = comment.author.id!!,
+            authorName: String = comment.author.name,
+            authorProfileImageUrl: String? = comment.author.profileImageUrl,
+            content: String = comment.content,
         ): CommentListResponse {
             return CommentListResponse(
                 id = comment.id!!,
-                content = comment.content,
+                content = content,
                 postId = comment.post.id!!,
-                authorId = comment.author.id!!,
-                authorName = comment.author.name,
-                authorProfileImageUrl = comment.author.profileImageUrl,
+                authorId = authorId,
+                authorName = authorName,
+                authorProfileImageUrl = authorProfileImageUrl,
                 parentId = comment.parent?.id,
                 depth = comment.depth,
                 likeCount = comment.likeCount,
                 replyCount = comment.replyCount,
                 likeStatus = likeStatus,
+                isBanned = isBanned,
                 createdAt = comment.createdAt,
                 updatedAt = comment.updatedAt,
             )

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentListResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentListResponse.kt
@@ -43,25 +43,45 @@ data class CommentListResponse(
         fun from(
             comment: Comment,
             likeStatus: LikeStatus = LikeStatus.NONE,
-            isBanned: Boolean = false,
-            authorId: UUID = comment.author.id!!,
-            authorName: String = comment.author.name,
-            authorProfileImageUrl: String? = comment.author.profileImageUrl,
-            content: String = comment.content,
         ): CommentListResponse {
             return CommentListResponse(
                 id = comment.id!!,
-                content = content,
+                content = comment.content,
                 postId = comment.post.id!!,
-                authorId = authorId,
-                authorName = authorName,
-                authorProfileImageUrl = authorProfileImageUrl,
+                authorId = comment.author.id!!,
+                authorName = comment.author.name,
+                authorProfileImageUrl = comment.author.profileImageUrl,
                 parentId = comment.parent?.id,
                 depth = comment.depth,
                 likeCount = comment.likeCount,
                 replyCount = comment.replyCount,
                 likeStatus = likeStatus,
-                isBanned = isBanned,
+                isBanned = false,
+                createdAt = comment.createdAt,
+                updatedAt = comment.updatedAt,
+            )
+        }
+
+        fun fromMasked(
+            comment: Comment,
+            likeStatus: LikeStatus,
+            maskedAuthorId: UUID,
+            maskedAuthorName: String,
+            maskedContent: String,
+        ): CommentListResponse {
+            return CommentListResponse(
+                id = comment.id!!,
+                content = maskedContent,
+                postId = comment.post.id!!,
+                authorId = maskedAuthorId,
+                authorName = maskedAuthorName,
+                authorProfileImageUrl = null,
+                parentId = comment.parent?.id,
+                depth = comment.depth,
+                likeCount = comment.likeCount,
+                replyCount = comment.replyCount,
+                likeStatus = likeStatus,
+                isBanned = true,
                 createdAt = comment.createdAt,
                 updatedAt = comment.updatedAt,
             )

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt
@@ -10,7 +10,6 @@ import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostLikeLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
-import com.techtaurant.mainserver.user.application.UserBanService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -27,7 +26,6 @@ class PostDetailReadService(
     private val postLikeLogRepository: PostLikeLogRepository,
     private val postReadLogRepository: PostReadLogRepository,
     private val attachmentService: AttachmentService,
-    private val userBanService: UserBanService,
 ) {
     /**
      * 게시물 상세 정보를 조회합니다.
@@ -49,13 +47,8 @@ class PostDetailReadService(
         userAgent: String?,
     ): PostDetailResponse {
         val post =
-            postRepository.findPostDetailById(postId)
+            postRepository.findVisiblePostDetailById(postId, userId)
                 ?: throw ApiException(PostStatus.POST_NOT_FOUND)
-        val bannedUserIds = userBanService.getBannedUserIds(userId)
-
-        if (bannedUserIds.contains(post.author.id)) {
-            throw ApiException(PostStatus.POST_NOT_FOUND)
-        }
 
         if (post.status != PostStatusEnum.PUBLISHED) {
             if (userId == null || post.author.id != userId) {

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt
@@ -10,6 +10,7 @@ import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostLikeLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import com.techtaurant.mainserver.user.application.UserBanService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -26,6 +27,7 @@ class PostDetailReadService(
     private val postLikeLogRepository: PostLikeLogRepository,
     private val postReadLogRepository: PostReadLogRepository,
     private val attachmentService: AttachmentService,
+    private val userBanService: UserBanService,
 ) {
     /**
      * 게시물 상세 정보를 조회합니다.
@@ -49,6 +51,11 @@ class PostDetailReadService(
         val post =
             postRepository.findPostDetailById(postId)
                 ?: throw ApiException(PostStatus.POST_NOT_FOUND)
+        val bannedUserIds = userBanService.getBannedUserIds(userId)
+
+        if (bannedUserIds.contains(post.author.id)) {
+            throw ApiException(PostStatus.POST_NOT_FOUND)
+        }
 
         if (post.status != PostStatusEnum.PUBLISHED) {
             if (userId == null || post.author.id != userId) {

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -14,7 +14,6 @@ import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
-import com.techtaurant.mainserver.user.application.UserBanService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -31,7 +30,6 @@ class PostListReadService(
     private val postRepository: PostRepository,
     private val postReadLogRepository: PostReadLogRepository,
     private val attachmentService: AttachmentService,
-    private val userBanService: UserBanService,
     @param:Value("\${app.default-post-thumbnail-url}")
     private val defaultThumbnailUrl: String,
     @param:Value("\${swagger.base-url}")
@@ -66,7 +64,6 @@ class PostListReadService(
         categoryId: UUID? = null,
     ): CursorPageResponse<PostListItemResponse> {
         val postCursor = cursor?.let { PostCursor.decode(it) }
-        val bannedUserIds = userBanService.getBannedUserIds(currentUserId)
 
         if (cursor != null && postCursor == null) {
             return CursorPageResponse(
@@ -93,7 +90,7 @@ class PostListReadService(
                     authorId = authorId,
                     statuses = statuses,
                     categoryId = categoryId,
-                    excludedAuthorIds = bannedUserIds,
+                    viewerId = currentUserId,
                 )
             } else {
                 postRepository.findPostsWithConditions(
@@ -102,7 +99,7 @@ class PostListReadService(
                     period = period,
                     sortType = sortType,
                     visibleToUserId = currentUserId,
-                    excludedAuthorIds = bannedUserIds,
+                    viewerId = currentUserId,
                 )
             }
 

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -14,6 +14,7 @@ import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import com.techtaurant.mainserver.user.application.UserBanService
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -30,6 +31,7 @@ class PostListReadService(
     private val postRepository: PostRepository,
     private val postReadLogRepository: PostReadLogRepository,
     private val attachmentService: AttachmentService,
+    private val userBanService: UserBanService,
     @param:Value("\${app.default-post-thumbnail-url}")
     private val defaultThumbnailUrl: String,
     @param:Value("\${swagger.base-url}")
@@ -64,6 +66,7 @@ class PostListReadService(
         categoryId: UUID? = null,
     ): CursorPageResponse<PostListItemResponse> {
         val postCursor = cursor?.let { PostCursor.decode(it) }
+        val bannedUserIds = userBanService.getBannedUserIds(currentUserId)
 
         if (cursor != null && postCursor == null) {
             return CursorPageResponse(
@@ -90,6 +93,7 @@ class PostListReadService(
                     authorId = authorId,
                     statuses = statuses,
                     categoryId = categoryId,
+                    excludedAuthorIds = bannedUserIds,
                 )
             } else {
                 postRepository.findPostsWithConditions(
@@ -98,6 +102,7 @@ class PostListReadService(
                     period = period,
                     sortType = sortType,
                     visibleToUserId = currentUserId,
+                    excludedAuthorIds = bannedUserIds,
                 )
             }
 

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
@@ -33,5 +33,6 @@ interface PostRepositoryCustom {
         statuses: List<PostStatusEnum>? = null,
         categoryId: UUID? = null,
         visibleToUserId: UUID? = null,
+        excludedAuthorIds: Set<UUID> = emptySet(),
     ): List<Post>
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
@@ -33,6 +33,11 @@ interface PostRepositoryCustom {
         statuses: List<PostStatusEnum>? = null,
         categoryId: UUID? = null,
         visibleToUserId: UUID? = null,
-        excludedAuthorIds: Set<UUID> = emptySet(),
+        viewerId: UUID? = null,
     ): List<Post>
+
+    fun findVisiblePostDetailById(
+        postId: UUID,
+        viewerId: UUID?,
+    ): Post?
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -12,6 +12,7 @@ import com.techtaurant.mainserver.post.enums.PostStatus
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.entity.UserBan
+import com.techtaurant.mainserver.user.entity.UserBan_
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
 import jakarta.persistence.criteria.CriteriaBuilder
@@ -170,10 +171,10 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
 
         banSubquery.select(cb.literal(1L))
         banSubquery.where(
-            cb.equal(banRoot.get<User>("user").get<UUID>(EntityBase_.id), viewerId),
+            cb.equal(banRoot.get(UserBan_.user).get(EntityBase_.id), viewerId),
             cb.equal(
-                banRoot.get<User>("bannedUser").get<UUID>(EntityBase_.id),
-                root.get<User>(Post_.author).get<UUID>(EntityBase_.id),
+                banRoot.get(UserBan_.bannedUser).get(EntityBase_.id),
+                root.get(Post_.author).get(EntityBase_.id),
             ),
         )
 

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -46,6 +46,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         statuses: List<PostStatusEnum>?,
         categoryId: UUID?,
         visibleToUserId: UUID?,
+        excludedAuthorIds: Set<UUID>,
     ): List<Post> {
         val cb = entityManager.criteriaBuilder
         val cq = cb.createQuery(Post::class.java)
@@ -68,6 +69,9 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
 
         authorId?.let { predicates.add(cb.equal(root.get(Post_.author).get(EntityBase_.id), it)) }
         categoryId?.let { predicates.add(cb.equal(root.get(Post_.category).get(EntityBase_.id), it)) }
+        if (excludedAuthorIds.isNotEmpty()) {
+            predicates.add(cb.not(root.get(Post_.author).get(EntityBase_.id).`in`(excludedAuthorIds)))
+        }
 
         addPeriodCondition(cb, root, period, predicates)
         addCursorCondition(cb, root, cursor, sortType, predicates)

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -11,6 +11,7 @@ import com.techtaurant.mainserver.post.entity.Tag
 import com.techtaurant.mainserver.post.enums.PostStatus
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.entity.UserBan
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
 import jakarta.persistence.criteria.CriteriaBuilder
@@ -46,11 +47,12 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         statuses: List<PostStatusEnum>?,
         categoryId: UUID?,
         visibleToUserId: UUID?,
-        excludedAuthorIds: Set<UUID>,
+        viewerId: UUID?,
     ): List<Post> {
         val cb = entityManager.criteriaBuilder
         val cq = cb.createQuery(Post::class.java)
         val root = cq.from(Post::class.java)
+        cq.distinct(true)
 
         root.fetch<Post, User>(Post_.AUTHOR)
         root.fetch<Post, Tag>(Post_.TAGS, JoinType.LEFT)
@@ -69,9 +71,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
 
         authorId?.let { predicates.add(cb.equal(root.get(Post_.author).get(EntityBase_.id), it)) }
         categoryId?.let { predicates.add(cb.equal(root.get(Post_.category).get(EntityBase_.id), it)) }
-        if (excludedAuthorIds.isNotEmpty()) {
-            predicates.add(cb.not(root.get(Post_.author).get(EntityBase_.id).`in`(excludedAuthorIds)))
-        }
+        addViewerBanCondition(cb, cq, root, viewerId, predicates)
 
         addPeriodCondition(cb, root, period, predicates)
         addCursorCondition(cb, root, cursor, sortType, predicates)
@@ -86,6 +86,30 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             .setMaxResults(size)
             .resultList
             .distinctBy { it.id }
+    }
+
+    override fun findVisiblePostDetailById(
+        postId: UUID,
+        viewerId: UUID?,
+    ): Post? {
+        val cb = entityManager.criteriaBuilder
+        val cq = cb.createQuery(Post::class.java)
+        val root = cq.from(Post::class.java)
+        cq.distinct(true)
+
+        root.fetch<Post, User>(Post_.AUTHOR)
+        root.fetch<Post, Tag>(Post_.TAGS, JoinType.LEFT)
+        root.fetch<Post, Any>(Post_.CATEGORY, JoinType.LEFT)
+
+        val predicates =
+            mutableListOf<Predicate>(
+                cb.equal(root.get(EntityBase_.id), postId),
+            )
+
+        addViewerBanCondition(cb, cq, root, viewerId, predicates)
+        cq.where(*predicates.toTypedArray())
+
+        return entityManager.createQuery(cq).resultList.firstOrNull()
     }
 
     /**
@@ -128,6 +152,32 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
                 else -> buildCountCursorCondition(cb, root, cursor, sortType)
             }
         predicates.add(cursorPredicate)
+    }
+
+    private fun addViewerBanCondition(
+        cb: CriteriaBuilder,
+        cq: CriteriaQuery<Post>,
+        root: Root<Post>,
+        viewerId: UUID?,
+        predicates: MutableList<Predicate>,
+    ) {
+        if (viewerId == null) {
+            return
+        }
+
+        val banSubquery = cq.subquery(Long::class.java)
+        val banRoot = banSubquery.from(UserBan::class.java)
+
+        banSubquery.select(cb.literal(1L))
+        banSubquery.where(
+            cb.equal(banRoot.get<User>("user").get<UUID>(EntityBase_.id), viewerId),
+            cb.equal(
+                banRoot.get<User>("bannedUser").get<UUID>(EntityBase_.id),
+                root.get<User>(Post_.author).get<UUID>(EntityBase_.id),
+            ),
+        )
+
+        predicates.add(cb.not(cb.exists(banSubquery)))
     }
 
     /**

--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/BannedUserMaskingService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/BannedUserMaskingService.kt
@@ -1,0 +1,31 @@
+package com.techtaurant.mainserver.user.application
+
+import org.springframework.stereotype.Service
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.UUID
+
+@Service
+class BannedUserMaskingService {
+    fun maskAuthorId(authorId: UUID): UUID {
+        return UUID.nameUUIDFromBytes("banned:$authorId".toByteArray(StandardCharsets.UTF_8))
+    }
+
+    fun maskAuthorName(authorId: UUID): String {
+        return bannedValue(authorId.toString())
+    }
+
+    fun maskCommentContent(commentId: UUID): String {
+        return bannedValue(commentId.toString())
+    }
+
+    private fun bannedValue(source: String): String {
+        return "banned_${hashPrefix(source)}"
+    }
+
+    private fun hashPrefix(source: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        val bytes = digest.digest(source.toByteArray(StandardCharsets.UTF_8))
+        return bytes.joinToString("") { "%02x".format(it) }.take(6)
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserBanService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserBanService.kt
@@ -1,0 +1,88 @@
+package com.techtaurant.mainserver.user.application
+
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.user.dto.UserBanListItemResponse
+import com.techtaurant.mainserver.user.dto.UserBanResponse
+import com.techtaurant.mainserver.user.entity.UserBan
+import com.techtaurant.mainserver.user.enums.UserStatus
+import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class UserBanService(
+    private val userRepository: UserRepository,
+    private val userBanRepository: UserBanRepository,
+) {
+    @Transactional
+    fun banUser(
+        userId: UUID,
+        targetUserId: UUID,
+    ): UserBanResponse {
+        validateNotSelfBan(userId, targetUserId)
+
+        if (userBanRepository.existsByUser_IdAndBannedUser_Id(userId, targetUserId)) {
+            throw ApiException(UserStatus.USER_ALREADY_BANNED)
+        }
+
+        val user =
+            userRepository.findById(userId).orElseThrow {
+                ApiException(UserStatus.ID_NOT_FOUND)
+            }
+        val targetUser =
+            userRepository.findById(targetUserId).orElseThrow {
+                ApiException(UserStatus.USER_NOT_FOUND)
+            }
+
+        val userBan =
+            userBanRepository.save(
+                UserBan(
+                    user = user,
+                    bannedUser = targetUser,
+                ),
+            )
+
+        return UserBanResponse.from(userBan)
+    }
+
+    fun getBannedUsers(userId: UUID): List<UserBanListItemResponse> {
+        return userBanRepository.findAllByUser_IdOrderByCreatedAtDesc(userId)
+            .map(UserBanListItemResponse::from)
+    }
+
+    fun getBannedUserIds(userId: UUID?): Set<UUID> {
+        if (userId == null) {
+            return emptySet()
+        }
+
+        return userBanRepository.findAllByUser_Id(userId)
+            .map { it.bannedUser.id!! }
+            .toSet()
+    }
+
+    @Transactional
+    fun unbanUser(
+        userId: UUID,
+        targetUserId: UUID,
+    ) {
+        validateNotSelfBan(userId, targetUserId)
+
+        val userBan =
+            userBanRepository.findByUser_IdAndBannedUser_Id(userId, targetUserId)
+                ?: throw ApiException(UserStatus.USER_BAN_NOT_FOUND)
+
+        userBanRepository.delete(userBan)
+    }
+
+    private fun validateNotSelfBan(
+        userId: UUID,
+        targetUserId: UUID,
+    ) {
+        if (userId == targetUserId) {
+            throw ApiException(UserStatus.CANNOT_BAN_SELF)
+        }
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserBanService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserBanService.kt
@@ -24,7 +24,7 @@ class UserBanService(
     ): UserBanResponse {
         validateNotSelfBan(userId, targetUserId)
 
-        if (userBanRepository.existsByUser_IdAndBannedUser_Id(userId, targetUserId)) {
+        if (userBanRepository.existsByUserIdAndBannedUserId(userId, targetUserId)) {
             throw ApiException(UserStatus.USER_ALREADY_BANNED)
         }
 
@@ -49,7 +49,7 @@ class UserBanService(
     }
 
     fun getBannedUsers(userId: UUID): List<UserBanListItemResponse> {
-        return userBanRepository.findAllByUser_IdOrderByCreatedAtDesc(userId)
+        return userBanRepository.findAllByUserIdOrderByCreatedAtDesc(userId)
             .map(UserBanListItemResponse::from)
     }
 
@@ -58,7 +58,7 @@ class UserBanService(
             return emptySet()
         }
 
-        return userBanRepository.findAllByUser_Id(userId)
+        return userBanRepository.findAllByUserId(userId)
             .map { it.bannedUser.id!! }
             .toSet()
     }
@@ -71,7 +71,7 @@ class UserBanService(
         validateNotSelfBan(userId, targetUserId)
 
         val userBan =
-            userBanRepository.findByUser_IdAndBannedUser_Id(userId, targetUserId)
+            userBanRepository.findByUserIdAndBannedUserId(userId, targetUserId)
                 ?: throw ApiException(UserStatus.USER_BAN_NOT_FOUND)
 
         userBanRepository.delete(userBan)

--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserBanService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserBanService.kt
@@ -7,6 +7,7 @@ import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.enums.UserStatus
 import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -24,12 +25,10 @@ class UserBanService(
     ): UserBanResponse {
         validateNotSelfBan(userId, targetUserId)
 
-        if (userBanRepository.existsByUserIdAndBannedUserId(userId, targetUserId)) {
-            throw ApiException(UserStatus.USER_ALREADY_BANNED)
-        }
-
         val user =
             userRepository.findById(userId).orElseThrow {
+                // @AuthenticationPrincipal로 주입된 userId는 이미 인증된 사용자이므로
+                // 정상 플로우에서는 도달 불가. 토큰 유효 기간 내 사용자가 탈퇴한 경우에만 발생.
                 ApiException(UserStatus.ID_NOT_FOUND)
             }
         val targetUser =
@@ -37,13 +36,23 @@ class UserBanService(
                 ApiException(UserStatus.USER_NOT_FOUND)
             }
 
+        // 이미 차단한 경우 기존 차단 정보를 그대로 반환 (idempotent)
+        userBanRepository.findByUserIdAndBannedUserId(userId, targetUserId)?.let {
+            return UserBanResponse.from(it)
+        }
+
         val userBan =
-            userBanRepository.save(
-                UserBan(
-                    user = user,
-                    bannedUser = targetUser,
-                ),
-            )
+            try {
+                userBanRepository.save(
+                    UserBan(
+                        user = user,
+                        bannedUser = targetUser,
+                    ),
+                )
+            } catch (e: DataIntegrityViolationException) {
+                // 동시 요청으로 인한 유니크 제약 위반 시 기존 차단 정보를 반환 (idempotent)
+                userBanRepository.findByUserIdAndBannedUserId(userId, targetUserId)!!
+            }
 
         return UserBanResponse.from(userBan)
     }
@@ -58,9 +67,7 @@ class UserBanService(
             return emptySet()
         }
 
-        return userBanRepository.findAllByUserId(userId)
-            .map { it.bannedUser.id!! }
-            .toSet()
+        return userBanRepository.findBannedUserIdsByUserId(userId).toHashSet()
     }
 
     @Transactional

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserBanListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserBanListItemResponse.kt
@@ -1,0 +1,28 @@
+package com.techtaurant.mainserver.user.dto
+
+import com.techtaurant.mainserver.user.entity.UserBan
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.Date
+import java.util.UUID
+
+@Schema(description = "차단한 사용자 목록 아이템 응답")
+data class UserBanListItemResponse(
+    @field:Schema(description = "차단 대상 사용자 ID")
+    val userId: UUID,
+    @field:Schema(description = "차단 대상 사용자 이름")
+    val name: String,
+    @field:Schema(description = "차단 대상 사용자 프로필 이미지 URL", nullable = true)
+    val profileImageUrl: String?,
+    @field:Schema(description = "차단 시각")
+    val bannedAt: Date,
+) {
+    companion object {
+        fun from(userBan: UserBan): UserBanListItemResponse =
+            UserBanListItemResponse(
+                userId = userBan.bannedUser.id!!,
+                name = userBan.bannedUser.name,
+                profileImageUrl = userBan.bannedUser.profileImageUrl,
+                bannedAt = userBan.createdAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserBanResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserBanResponse.kt
@@ -1,0 +1,25 @@
+package com.techtaurant.mainserver.user.dto
+
+import com.techtaurant.mainserver.user.entity.UserBan
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.Date
+import java.util.UUID
+
+@Schema(description = "사용자 차단 응답")
+data class UserBanResponse(
+    @field:Schema(description = "차단 대상 사용자 ID")
+    val userId: UUID,
+    @field:Schema(description = "차단 대상 사용자 이름")
+    val name: String,
+    @field:Schema(description = "차단 시각")
+    val bannedAt: Date,
+) {
+    companion object {
+        fun from(userBan: UserBan): UserBanResponse =
+            UserBanResponse(
+                userId = userBan.bannedUser.id!!,
+                name = userBan.bannedUser.name,
+                bannedAt = userBan.createdAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/user/entity/UserBan.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/entity/UserBan.kt
@@ -1,0 +1,28 @@
+package com.techtaurant.mainserver.user.entity
+
+import com.techtaurant.mainserver.common.base.EntityBase
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "user_bans",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_user_bans_user_id_banned_user_id",
+            columnNames = ["user_id", "banned_user_id"],
+        ),
+    ],
+)
+class UserBan(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    var user: User,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "banned_user_id", nullable = false)
+    var bannedUser: User,
+) : EntityBase()

--- a/src/main/kotlin/com/techtaurant/mainserver/user/entity/UserBan.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/entity/UserBan.kt
@@ -21,8 +21,8 @@ import jakarta.persistence.UniqueConstraint
 class UserBan(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    var user: User,
+    val user: User,
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "banned_user_id", nullable = false)
-    var bannedUser: User,
+    val bannedUser: User,
 ) : EntityBase()

--- a/src/main/kotlin/com/techtaurant/mainserver/user/enums/UserStatus.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/enums/UserStatus.kt
@@ -10,6 +10,9 @@ enum class UserStatus(
 ) : StatusIfs {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 1002, "사용자를 찾을 수 없습니다"),
     ID_NOT_FOUND(500, 1001, "User ID not found"),
+    CANNOT_BAN_SELF(HttpStatus.BAD_REQUEST.value(), 1003, "자기 자신은 차단할 수 없습니다"),
+    USER_ALREADY_BANNED(HttpStatus.CONFLICT.value(), 1004, "이미 차단한 사용자입니다"),
+    USER_BAN_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 1005, "차단한 사용자 관계를 찾을 수 없습니다"),
     ;
 
     override fun getHttpStatusCode(): Int {

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt
@@ -1,14 +1,12 @@
 package com.techtaurant.mainserver.user.infrastructure.`in`
 
 import com.techtaurant.mainserver.common.dto.ApiResponse
-import com.techtaurant.mainserver.common.swagger.ApiErrorResponses
 import com.techtaurant.mainserver.security.SecurityConstants
 import com.techtaurant.mainserver.user.application.UserBanService
 import com.techtaurant.mainserver.user.application.UserReadService
 import com.techtaurant.mainserver.user.dto.UserBanListItemResponse
 import com.techtaurant.mainserver.user.dto.UserBanResponse
 import com.techtaurant.mainserver.user.dto.UserResponse
-import com.techtaurant.mainserver.user.enums.UserStatus
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -26,7 +24,6 @@ class UserController(
     private val userReadService: UserReadService,
     private val userBanService: UserBanService,
 ) : UserControllerDocs {
-    @ApiErrorResponses(users = [UserStatus.ID_NOT_FOUND], includeAuthenticationErrors = true)
     @GetMapping("/me")
     override fun getMe(
         @AuthenticationPrincipal userId: UUID,
@@ -34,10 +31,6 @@ class UserController(
         return ApiResponse.ok(userReadService.getMe(userId))
     }
 
-    @ApiErrorResponses(
-        users = [UserStatus.USER_NOT_FOUND, UserStatus.CANNOT_BAN_SELF, UserStatus.USER_ALREADY_BANNED],
-        includeAuthenticationErrors = true,
-    )
     @PostMapping("/{targetUserId}/ban")
     @ResponseStatus(HttpStatus.CREATED)
     override fun banUser(
@@ -47,7 +40,6 @@ class UserController(
         return ApiResponse.created(userBanService.banUser(userId, targetUserId))
     }
 
-    @ApiErrorResponses(includeAuthenticationErrors = true)
     @GetMapping("/me/bans")
     override fun getMyBannedUsers(
         @AuthenticationPrincipal userId: UUID,
@@ -55,10 +47,6 @@ class UserController(
         return ApiResponse.ok(userBanService.getBannedUsers(userId))
     }
 
-    @ApiErrorResponses(
-        users = [UserStatus.CANNOT_BAN_SELF, UserStatus.USER_BAN_NOT_FOUND],
-        includeAuthenticationErrors = true,
-    )
     @DeleteMapping("/{targetUserId}/ban")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     override fun unbanUser(

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt
@@ -3,12 +3,20 @@ package com.techtaurant.mainserver.user.infrastructure.`in`
 import com.techtaurant.mainserver.common.dto.ApiResponse
 import com.techtaurant.mainserver.common.swagger.ApiErrorResponses
 import com.techtaurant.mainserver.security.SecurityConstants
+import com.techtaurant.mainserver.user.application.UserBanService
 import com.techtaurant.mainserver.user.application.UserReadService
+import com.techtaurant.mainserver.user.dto.UserBanListItemResponse
+import com.techtaurant.mainserver.user.dto.UserBanResponse
 import com.techtaurant.mainserver.user.dto.UserResponse
 import com.techtaurant.mainserver.user.enums.UserStatus
+import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -16,6 +24,7 @@ import java.util.UUID
 @RequestMapping("${SecurityConstants.API_PREFIX}/users")
 class UserController(
     private val userReadService: UserReadService,
+    private val userBanService: UserBanService,
 ) : UserControllerDocs {
     @ApiErrorResponses(users = [UserStatus.ID_NOT_FOUND], includeAuthenticationErrors = true)
     @GetMapping("/me")
@@ -23,5 +32,39 @@ class UserController(
         @AuthenticationPrincipal userId: UUID,
     ): ApiResponse<UserResponse> {
         return ApiResponse.ok(userReadService.getMe(userId))
+    }
+
+    @ApiErrorResponses(
+        users = [UserStatus.USER_NOT_FOUND, UserStatus.CANNOT_BAN_SELF, UserStatus.USER_ALREADY_BANNED],
+        includeAuthenticationErrors = true,
+    )
+    @PostMapping("/{targetUserId}/ban")
+    @ResponseStatus(HttpStatus.CREATED)
+    override fun banUser(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable targetUserId: UUID,
+    ): ApiResponse<UserBanResponse> {
+        return ApiResponse.created(userBanService.banUser(userId, targetUserId))
+    }
+
+    @ApiErrorResponses(includeAuthenticationErrors = true)
+    @GetMapping("/me/bans")
+    override fun getMyBannedUsers(
+        @AuthenticationPrincipal userId: UUID,
+    ): ApiResponse<List<UserBanListItemResponse>> {
+        return ApiResponse.ok(userBanService.getBannedUsers(userId))
+    }
+
+    @ApiErrorResponses(
+        users = [UserStatus.CANNOT_BAN_SELF, UserStatus.USER_BAN_NOT_FOUND],
+        includeAuthenticationErrors = true,
+    )
+    @DeleteMapping("/{targetUserId}/ban")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    override fun unbanUser(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable targetUserId: UUID,
+    ) {
+        userBanService.unbanUser(userId, targetUserId)
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerDocs.kt
@@ -5,6 +5,8 @@ import com.techtaurant.mainserver.common.status.DefaultStatus
 import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponse
 import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponses
 import com.techtaurant.mainserver.security.jwt.JwtStatus
+import com.techtaurant.mainserver.user.dto.UserBanListItemResponse
+import com.techtaurant.mainserver.user.dto.UserBanResponse
 import com.techtaurant.mainserver.user.dto.UserResponse
 import com.techtaurant.mainserver.user.enums.UserStatus
 import io.swagger.v3.oas.annotations.Operation
@@ -27,4 +29,51 @@ interface UserControllerDocs {
         ],
     )
     fun getMe(userId: UUID): ApiResponse<UserResponse>
+
+    @Operation(summary = "사용자 차단", description = "현재 로그인한 사용자가 특정 사용자를 차단합니다")
+    @SwaggerApiResponse(
+        responseCode = "201",
+        description = "차단 성공",
+    )
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED"]),
+            ApiErrorCodeResponse(UserStatus::class, ["USER_NOT_FOUND", "CANNOT_BAN_SELF", "USER_ALREADY_BANNED"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun banUser(
+        userId: UUID,
+        targetUserId: UUID,
+    ): ApiResponse<UserBanResponse>
+
+    @Operation(summary = "내가 차단한 사용자 목록 조회", description = "현재 로그인한 사용자가 차단한 사용자 목록을 최신순으로 조회합니다")
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+    )
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun getMyBannedUsers(userId: UUID): ApiResponse<List<UserBanListItemResponse>>
+
+    @Operation(summary = "사용자 차단 해제", description = "현재 로그인한 사용자가 특정 사용자 차단을 해제합니다")
+    @SwaggerApiResponse(
+        responseCode = "204",
+        description = "차단 해제 성공",
+    )
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED"]),
+            ApiErrorCodeResponse(UserStatus::class, ["CANNOT_BAN_SELF", "USER_BAN_NOT_FOUND"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun unbanUser(
+        userId: UUID,
+        targetUserId: UUID,
+    )
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserBanRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserBanRepository.kt
@@ -2,14 +2,11 @@ package com.techtaurant.mainserver.user.infrastructure.out
 
 import com.techtaurant.mainserver.user.entity.UserBan
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.UUID
 
 interface UserBanRepository : JpaRepository<UserBan, UUID> {
-    fun existsByUserIdAndBannedUserId(
-        userId: UUID,
-        bannedUserId: UUID,
-    ): Boolean
-
     fun findByUserIdAndBannedUserId(
         userId: UUID,
         bannedUserId: UUID,
@@ -17,5 +14,8 @@ interface UserBanRepository : JpaRepository<UserBan, UUID> {
 
     fun findAllByUserIdOrderByCreatedAtDesc(userId: UUID): List<UserBan>
 
-    fun findAllByUserId(userId: UUID): List<UserBan>
+    @Query("SELECT ub.bannedUser.id FROM UserBan ub WHERE ub.user.id = :userId")
+    fun findBannedUserIdsByUserId(
+        @Param("userId") userId: UUID,
+    ): List<UUID>
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserBanRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserBanRepository.kt
@@ -1,0 +1,21 @@
+package com.techtaurant.mainserver.user.infrastructure.out
+
+import com.techtaurant.mainserver.user.entity.UserBan
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface UserBanRepository : JpaRepository<UserBan, UUID> {
+    fun existsByUser_IdAndBannedUser_Id(
+        userId: UUID,
+        bannedUserId: UUID,
+    ): Boolean
+
+    fun findByUser_IdAndBannedUser_Id(
+        userId: UUID,
+        bannedUserId: UUID,
+    ): UserBan?
+
+    fun findAllByUser_IdOrderByCreatedAtDesc(userId: UUID): List<UserBan>
+
+    fun findAllByUser_Id(userId: UUID): List<UserBan>
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserBanRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserBanRepository.kt
@@ -5,17 +5,17 @@ import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
 interface UserBanRepository : JpaRepository<UserBan, UUID> {
-    fun existsByUser_IdAndBannedUser_Id(
+    fun existsByUserIdAndBannedUserId(
         userId: UUID,
         bannedUserId: UUID,
     ): Boolean
 
-    fun findByUser_IdAndBannedUser_Id(
+    fun findByUserIdAndBannedUserId(
         userId: UUID,
         bannedUserId: UUID,
     ): UserBan?
 
-    fun findAllByUser_IdOrderByCreatedAtDesc(userId: UUID): List<UserBan>
+    fun findAllByUserIdOrderByCreatedAtDesc(userId: UUID): List<UserBan>
 
-    fun findAllByUser_Id(userId: UUID): List<UserBan>
+    fun findAllByUserId(userId: UUID): List<UserBan>
 }

--- a/src/main/resources/db/migration/V17__create_user_bans.sql
+++ b/src/main/resources/db/migration/V17__create_user_bans.sql
@@ -1,0 +1,12 @@
+CREATE TABLE user_bans (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    banned_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_user_bans_user_id_banned_user_id UNIQUE (user_id, banned_user_id),
+    CONSTRAINT chk_user_bans_not_self CHECK (user_id <> banned_user_id)
+);
+
+CREATE INDEX idx_user_bans_user_id ON user_bans(user_id);
+CREATE INDEX idx_user_bans_banned_user_id ON user_bans(banned_user_id);

--- a/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadControllerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadControllerTest.kt
@@ -10,8 +10,8 @@ import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
-import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.enums.UserRole
 import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository

--- a/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadControllerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadControllerTest.kt
@@ -9,8 +9,11 @@ import com.techtaurant.mainserver.common.dto.CursorPageResponse
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
+import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import io.restassured.RestAssured
 import io.restassured.common.mapper.TypeRef
@@ -36,12 +39,21 @@ class CommentReadControllerTest : IntegrationTest() {
     @Autowired
     private lateinit var userRepository: UserRepository
 
+    @Autowired
+    private lateinit var userBanRepository: UserBanRepository
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
     private lateinit var testUser: User
+    private lateinit var blockedUser: User
     private lateinit var testPost: Post
     private lateinit var parentComments: List<Comment>
+    private lateinit var accessToken: String
 
     @BeforeEach
     fun setup() {
+        userBanRepository.deleteAllInBatch()
         testUser =
             userRepository.save(
                 User(
@@ -53,6 +65,18 @@ class CommentReadControllerTest : IntegrationTest() {
                     profileImageUrl = "https://example.com/profile.jpg",
                 ),
             )
+        blockedUser =
+            userRepository.save(
+                User(
+                    name = "Blocked User",
+                    email = "blocked@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "blocked-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/blocked-profile.jpg",
+                ),
+            )
+        accessToken = jwtTokenProvider.createAccessToken(testUser.id!!, testUser.role)
 
         // Given: 테스트 게시물 생성
         testPost =
@@ -306,6 +330,47 @@ class CommentReadControllerTest : IntegrationTest() {
             assertEquals(1, secondPageResponse.data!!.size)
             assertTrue(firstPageCommentId != secondPageCommentId, "다음 페이지의 댓글이 달라야 함")
         }
+    }
+
+    @Test
+    @DisplayName("로그인 사용자가 차단한 작성자의 댓글은 마스킹되고 isBanned=true로 반환된다")
+    fun getParentComments_masksBannedAuthorComment() {
+        // Given
+        val blockedComment =
+            commentRepository.save(
+                Comment(
+                    content = "차단된 댓글 내용",
+                    post = testPost,
+                    author = blockedUser,
+                    parent = null,
+                    depth = 0,
+                ),
+            )
+        userBanRepository.save(UserBan(user = testUser, bannedUser = blockedUser))
+
+        // When
+        val response =
+            RestAssured
+                .given()
+                .header("Authorization", "Bearer $accessToken")
+                .queryParam("sort", "LATEST")
+                .queryParam("size", 10)
+                .`when`()
+                .get("/open-api/comments/posts/${testPost.id}")
+                .then()
+                .statusCode(200)
+                .extract()
+                .`as`(object : TypeRef<ApiResponse<CursorPageResponse<CommentListResponse>>>() {})
+
+        // Then
+        val maskedComment = response.data!!.content.first { it.id == blockedComment.id }
+        assertTrue(maskedComment.isBanned)
+        assertTrue(maskedComment.authorName.startsWith("banned_"))
+        assertEquals(13, maskedComment.authorName.length)
+        assertTrue(maskedComment.content.startsWith("banned_"))
+        assertEquals(13, maskedComment.content.length)
+        assertEquals(null, maskedComment.authorProfileImageUrl)
+        assertTrue(maskedComment.authorId != blockedUser.id)
     }
 
     @Nested

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -10,6 +10,7 @@ import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.application.UserBanService
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.enums.UserRole
 import io.mockk.every
@@ -26,6 +27,7 @@ class PostListReadServiceTest {
     private val postRepository: PostRepository = mockk()
     private val postReadLogRepository: PostReadLogRepository = mockk()
     private val attachmentService: AttachmentService = mockk()
+    private val userBanService: UserBanService = mockk()
     private val defaultThumbnailUrl = "/static/images/post-thumbnail.png"
     private val baseUrl = "http://localhost:8080"
 
@@ -34,6 +36,7 @@ class PostListReadServiceTest {
             postRepository = postRepository,
             postReadLogRepository = postReadLogRepository,
             attachmentService = attachmentService,
+            userBanService = userBanService,
             defaultThumbnailUrl = defaultThumbnailUrl,
             baseUrl = baseUrl,
         )
@@ -43,6 +46,8 @@ class PostListReadServiceTest {
 
     @BeforeEach
     fun setUp() {
+        every { userBanService.getBannedUserIds(any()) } returns emptySet()
+
         testUser =
             User(
                 name = "테스트 사용자",
@@ -97,6 +102,7 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     visibleToUserId = testUser.id!!,
+                    excludedAuthorIds = emptySet(),
                 )
             } returns posts
             every {
@@ -114,6 +120,7 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     visibleToUserId = testUser.id!!,
+                    excludedAuthorIds = emptySet(),
                 )
             }
         }
@@ -130,6 +137,7 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     visibleToUserId = null,
+                    excludedAuthorIds = emptySet(),
                 )
             } returns posts
 
@@ -144,6 +152,7 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     visibleToUserId = null,
+                    excludedAuthorIds = emptySet(),
                 )
             }
         }
@@ -173,6 +182,7 @@ class PostListReadServiceTest {
                     authorId = testUser.id!!,
                     statuses = PostStatusEnum.entries,
                     categoryId = null,
+                    excludedAuthorIds = emptySet(),
                 )
             } returns posts
             every {
@@ -197,6 +207,7 @@ class PostListReadServiceTest {
                     authorId = testUser.id!!,
                     statuses = PostStatusEnum.entries,
                     categoryId = null,
+                    excludedAuthorIds = emptySet(),
                 )
             }
         }
@@ -215,6 +226,7 @@ class PostListReadServiceTest {
                     authorId = otherUser.id!!,
                     statuses = listOf(PostStatusEnum.PUBLISHED),
                     categoryId = null,
+                    excludedAuthorIds = emptySet(),
                 )
             } returns posts
             every {
@@ -239,6 +251,7 @@ class PostListReadServiceTest {
                     authorId = otherUser.id!!,
                     statuses = listOf(PostStatusEnum.PUBLISHED),
                     categoryId = null,
+                    excludedAuthorIds = emptySet(),
                 )
             }
         }
@@ -257,6 +270,7 @@ class PostListReadServiceTest {
                     authorId = otherUser.id!!,
                     statuses = listOf(PostStatusEnum.PUBLISHED),
                     categoryId = null,
+                    excludedAuthorIds = emptySet(),
                 )
             } returns posts
 
@@ -279,6 +293,7 @@ class PostListReadServiceTest {
                     authorId = otherUser.id!!,
                     statuses = listOf(PostStatusEnum.PUBLISHED),
                     categoryId = null,
+                    excludedAuthorIds = emptySet(),
                 )
             }
             assertThat(result.content).allSatisfy { assertThat(it.isRead).isFalse() }
@@ -317,6 +332,7 @@ class PostListReadServiceTest {
                     authorId = testUser.id!!,
                     statuses = PostStatusEnum.entries,
                     categoryId = null,
+                    excludedAuthorIds = emptySet(),
                 )
             } returns posts
             every {
@@ -352,6 +368,7 @@ class PostListReadServiceTest {
                     authorId = testUser.id!!,
                     statuses = PostStatusEnum.entries,
                     categoryId = null,
+                    excludedAuthorIds = emptySet(),
                 )
             } returns posts
             every {
@@ -391,6 +408,7 @@ class PostListReadServiceTest {
                     authorId = otherUser.id!!,
                     statuses = listOf(PostStatusEnum.PUBLISHED),
                     categoryId = null,
+                    excludedAuthorIds = emptySet(),
                 )
             } returns posts
             every {

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -10,7 +10,6 @@ import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
-import com.techtaurant.mainserver.user.application.UserBanService
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.enums.UserRole
 import io.mockk.every
@@ -27,7 +26,6 @@ class PostListReadServiceTest {
     private val postRepository: PostRepository = mockk()
     private val postReadLogRepository: PostReadLogRepository = mockk()
     private val attachmentService: AttachmentService = mockk()
-    private val userBanService: UserBanService = mockk()
     private val defaultThumbnailUrl = "/static/images/post-thumbnail.png"
     private val baseUrl = "http://localhost:8080"
 
@@ -36,7 +34,6 @@ class PostListReadServiceTest {
             postRepository = postRepository,
             postReadLogRepository = postReadLogRepository,
             attachmentService = attachmentService,
-            userBanService = userBanService,
             defaultThumbnailUrl = defaultThumbnailUrl,
             baseUrl = baseUrl,
         )
@@ -46,8 +43,6 @@ class PostListReadServiceTest {
 
     @BeforeEach
     fun setUp() {
-        every { userBanService.getBannedUserIds(any()) } returns emptySet()
-
         testUser =
             User(
                 name = "테스트 사용자",
@@ -102,7 +97,7 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     visibleToUserId = testUser.id!!,
-                    excludedAuthorIds = emptySet(),
+                    viewerId = testUser.id!!,
                 )
             } returns posts
             every {
@@ -120,7 +115,7 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     visibleToUserId = testUser.id!!,
-                    excludedAuthorIds = emptySet(),
+                    viewerId = testUser.id!!,
                 )
             }
         }
@@ -137,7 +132,7 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     visibleToUserId = null,
-                    excludedAuthorIds = emptySet(),
+                    viewerId = null,
                 )
             } returns posts
 
@@ -152,7 +147,7 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     visibleToUserId = null,
-                    excludedAuthorIds = emptySet(),
+                    viewerId = null,
                 )
             }
         }
@@ -182,7 +177,7 @@ class PostListReadServiceTest {
                     authorId = testUser.id!!,
                     statuses = PostStatusEnum.entries,
                     categoryId = null,
-                    excludedAuthorIds = emptySet(),
+                    viewerId = testUser.id!!,
                 )
             } returns posts
             every {
@@ -207,7 +202,7 @@ class PostListReadServiceTest {
                     authorId = testUser.id!!,
                     statuses = PostStatusEnum.entries,
                     categoryId = null,
-                    excludedAuthorIds = emptySet(),
+                    viewerId = testUser.id!!,
                 )
             }
         }
@@ -226,7 +221,7 @@ class PostListReadServiceTest {
                     authorId = otherUser.id!!,
                     statuses = listOf(PostStatusEnum.PUBLISHED),
                     categoryId = null,
-                    excludedAuthorIds = emptySet(),
+                    viewerId = testUser.id!!,
                 )
             } returns posts
             every {
@@ -251,7 +246,7 @@ class PostListReadServiceTest {
                     authorId = otherUser.id!!,
                     statuses = listOf(PostStatusEnum.PUBLISHED),
                     categoryId = null,
-                    excludedAuthorIds = emptySet(),
+                    viewerId = testUser.id!!,
                 )
             }
         }
@@ -270,7 +265,7 @@ class PostListReadServiceTest {
                     authorId = otherUser.id!!,
                     statuses = listOf(PostStatusEnum.PUBLISHED),
                     categoryId = null,
-                    excludedAuthorIds = emptySet(),
+                    viewerId = null,
                 )
             } returns posts
 
@@ -293,7 +288,7 @@ class PostListReadServiceTest {
                     authorId = otherUser.id!!,
                     statuses = listOf(PostStatusEnum.PUBLISHED),
                     categoryId = null,
-                    excludedAuthorIds = emptySet(),
+                    viewerId = null,
                 )
             }
             assertThat(result.content).allSatisfy { assertThat(it.isRead).isFalse() }
@@ -332,7 +327,7 @@ class PostListReadServiceTest {
                     authorId = testUser.id!!,
                     statuses = PostStatusEnum.entries,
                     categoryId = null,
-                    excludedAuthorIds = emptySet(),
+                    viewerId = testUser.id!!,
                 )
             } returns posts
             every {
@@ -368,7 +363,7 @@ class PostListReadServiceTest {
                     authorId = testUser.id!!,
                     statuses = PostStatusEnum.entries,
                     categoryId = null,
-                    excludedAuthorIds = emptySet(),
+                    viewerId = testUser.id!!,
                 )
             } returns posts
             every {
@@ -408,7 +403,7 @@ class PostListReadServiceTest {
                     authorId = otherUser.id!!,
                     statuses = listOf(PostStatusEnum.PUBLISHED),
                     categoryId = null,
-                    excludedAuthorIds = emptySet(),
+                    viewerId = testUser.id!!,
                 )
             } returns posts
             every {

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
@@ -6,8 +6,8 @@ import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
-import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.enums.UserRole
 import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
@@ -6,8 +6,10 @@ import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
+import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import io.restassured.RestAssured.given
 import org.hamcrest.Matchers.hasItem
@@ -30,12 +32,16 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
     @Autowired
     private lateinit var jwtTokenProvider: JwtTokenProvider
 
+    @Autowired
+    private lateinit var userBanRepository: UserBanRepository
+
     private lateinit var testUser: User
     private lateinit var otherUser: User
     private lateinit var accessToken: String
 
     @BeforeEach
     fun setUpTestData() {
+        userBanRepository.deleteAllInBatch()
         postRepository.deleteAllInBatch()
         userRepository.deleteAllInBatch()
         testUser =
@@ -107,5 +113,64 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
             .body("data.content.id", hasItem(myPrivatePost.id.toString()))
             .body("data.content.id", hasItem(myPublishedPost.id.toString()))
             .body("data.content.id", not(hasItem(otherPrivatePost.id.toString())))
+    }
+
+    @Test
+    @DisplayName("로그인 사용자가 차단한 작성자의 게시물은 목록에서 제외된다")
+    fun getPosts_excludesBannedAuthorPosts() {
+        // given
+        val visiblePost =
+            postRepository.save(
+                Post(
+                    title = "보이는 게시물",
+                    content = "보이는 내용",
+                    author = testUser,
+                    status = PostStatusEnum.PUBLISHED,
+                ),
+            )
+        val bannedPost =
+            postRepository.save(
+                Post(
+                    title = "숨겨질 게시물",
+                    content = "숨겨질 내용",
+                    author = otherUser,
+                    status = PostStatusEnum.PUBLISHED,
+                ),
+            )
+        userBanRepository.save(UserBan(user = testUser, bannedUser = otherUser))
+
+        // when & then
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .get("/open-api/posts")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.content.id", hasItem(visiblePost.id.toString()))
+            .body("data.content.id", not(hasItem(bannedPost.id.toString())))
+    }
+
+    @Test
+    @DisplayName("로그인 사용자가 차단한 작성자의 게시물 상세 조회 시 404를 반환한다")
+    fun getPostDetail_bannedAuthor_returnsNotFound() {
+        // given
+        val bannedPost =
+            postRepository.save(
+                Post(
+                    title = "차단된 사용자의 게시물",
+                    content = "숨겨질 내용",
+                    author = otherUser,
+                    status = PostStatusEnum.PUBLISHED,
+                ),
+            )
+        userBanRepository.save(UserBan(user = testUser, bannedUser = otherUser))
+
+        // when & then
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .get("/open-api/posts/${bannedPost.id}")
+            .then()
+            .statusCode(HttpStatus.NOT_FOUND.value())
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
@@ -8,7 +8,9 @@ import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -30,6 +32,9 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
     private lateinit var userRepository: UserRepository
 
     @Autowired
+    private lateinit var userBanRepository: UserBanRepository
+
+    @Autowired
     private lateinit var categoryRepository: CategoryRepository
 
     private lateinit var userA: User
@@ -39,6 +44,7 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
     @BeforeEach
     fun setUpTestData() {
         postRepository.deleteAll()
+        userBanRepository.deleteAllInBatch()
 
         userA =
             userRepository.save(
@@ -372,6 +378,29 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
                 draftByA.id,
                 publishedByB.id,
             )
+        }
+
+        @Test
+        @DisplayName("viewerId 지정 시 차단한 작성자의 게시물은 제외한다")
+        fun findPostsWithConditions_withViewerId_excludesBannedAuthorPosts() {
+            // given
+            val visiblePost = createPost(userA, PostStatusEnum.PUBLISHED)
+            createPost(userB, PostStatusEnum.PUBLISHED)
+            userBanRepository.save(UserBan(user = userA, bannedUser = userB))
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    visibleToUserId = userA.id!!,
+                    viewerId = userA.id!!,
+                )
+
+            // then
+            assertThat(result).extracting("id").containsExactly(visiblePost.id)
         }
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerBanIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerBanIntegrationTest.kt
@@ -4,6 +4,7 @@ import com.techtaurant.mainserver.base.IntegrationTest
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
 import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.enums.UserRole
 import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
@@ -62,9 +63,9 @@ class UserControllerBanIntegrationTest : IntegrationTest() {
     }
 
     @Test
-    @DisplayName("사용자 차단 후 목록 조회와 차단 해제가 정상 동작한다")
-    fun banListAndUnban_success() {
-        // When - 차단 요청
+    @DisplayName("사용자 차단이 성공한다")
+    fun ban_success() {
+        // When & Then
         given()
             .header("Authorization", "Bearer $accessToken")
             .`when`()
@@ -73,8 +74,15 @@ class UserControllerBanIntegrationTest : IntegrationTest() {
             .statusCode(HttpStatus.CREATED.value())
             .body("data.userId", equalTo(targetUser.id.toString()))
             .body("data.name", equalTo(targetUser.name))
+    }
 
-        // Then - 차단 목록 조회
+    @Test
+    @DisplayName("차단 목록 조회가 성공한다")
+    fun getBannedUsers_success() {
+        // Given
+        userBanRepository.save(UserBan(user = testUser, bannedUser = targetUser))
+
+        // When & Then
         given()
             .header("Authorization", "Bearer $accessToken")
             .`when`()
@@ -83,16 +91,35 @@ class UserControllerBanIntegrationTest : IntegrationTest() {
             .statusCode(HttpStatus.OK.value())
             .body("data", hasSize<Any>(1))
             .body("data[0].userId", equalTo(targetUser.id.toString()))
+    }
 
-        // When - 차단 해제
+    @Test
+    @DisplayName("차단 해제가 성공한다")
+    fun unban_success() {
+        // Given
+        userBanRepository.save(UserBan(user = testUser, bannedUser = targetUser))
+
+        // When & Then
         given()
             .header("Authorization", "Bearer $accessToken")
             .`when`()
             .delete("/api/users/${targetUser.id}/ban")
             .then()
             .statusCode(HttpStatus.NO_CONTENT.value())
+    }
 
-        // Then - 차단 목록 비어 있음
+    @Test
+    @DisplayName("차단 해제 후 목록이 비어있다")
+    fun getBannedUsers_afterUnban_returnsEmpty() {
+        // Given
+        userBanRepository.save(UserBan(user = testUser, bannedUser = targetUser))
+
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .delete("/api/users/${targetUser.id}/ban")
+
+        // When & Then
         given()
             .header("Authorization", "Bearer $accessToken")
             .`when`()

--- a/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerBanIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerBanIntegrationTest.kt
@@ -1,0 +1,104 @@
+package com.techtaurant.mainserver.user.infrastructure.`in`
+
+import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import com.techtaurant.mainserver.user.enums.UserRole
+import io.restassured.RestAssured.given
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+@DisplayName("UserController ban 통합 테스트")
+class UserControllerBanIntegrationTest : IntegrationTest() {
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var userBanRepository: UserBanRepository
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    private lateinit var testUser: User
+    private lateinit var targetUser: User
+    private lateinit var accessToken: String
+
+    @BeforeEach
+    fun setUpTestData() {
+        userBanRepository.deleteAllInBatch()
+
+        testUser =
+            userRepository.save(
+                User(
+                    name = "테스트사용자",
+                    email = "test@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "test-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/profile.jpg",
+                ),
+            )
+        targetUser =
+            userRepository.save(
+                User(
+                    name = "차단대상",
+                    email = "target@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "target-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/target.jpg",
+                ),
+            )
+        accessToken = jwtTokenProvider.createAccessToken(testUser.id!!, testUser.role)
+    }
+
+    @Test
+    @DisplayName("사용자 차단 후 목록 조회와 차단 해제가 정상 동작한다")
+    fun banListAndUnban_success() {
+        // When - 차단 요청
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .post("/api/users/${targetUser.id}/ban")
+            .then()
+            .statusCode(HttpStatus.CREATED.value())
+            .body("data.userId", equalTo(targetUser.id.toString()))
+            .body("data.name", equalTo(targetUser.name))
+
+        // Then - 차단 목록 조회
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .get("/api/users/me/bans")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data", hasSize<Any>(1))
+            .body("data[0].userId", equalTo(targetUser.id.toString()))
+
+        // When - 차단 해제
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .delete("/api/users/${targetUser.id}/ban")
+            .then()
+            .statusCode(HttpStatus.NO_CONTENT.value())
+
+        // Then - 차단 목록 비어 있음
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .get("/api/users/me/bans")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data", hasSize<Any>(0))
+    }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerBanIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerBanIntegrationTest.kt
@@ -4,9 +4,9 @@ import com.techtaurant.mainserver.base.IntegrationTest
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
 import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
 import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
-import com.techtaurant.mainserver.user.enums.UserRole
 import io.restassured.RestAssured.given
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasSize


### PR DESCRIPTION
## 어떤 작업인가요?
- 사용자가 특정 사용자를 차단하고, 차단한 사용자의 게시물과 댓글 노출을 조회 정책에 맞게 제어하는 기능을 추가하고 관련 조회 구조를 리팩터링합니다.

## 어떻게 해결했나요?
**사용자 차단 API 추가**
- `user_bans` 테이블과 엔티티, 리포지토리를 추가해 사용자 간 차단 관계를 저장하도록 구현했습니다.
- 사용자 차단, 차단 목록 조회, 차단 해제 API와 Swagger 문서를 추가했습니다.

**조회 차단 정책 반영**
- 로그인 사용자가 차단한 작성자의 게시물이 목록과 상세에서 보이지 않도록 처리했습니다.
- 댓글 응답에 `isBanned` 필드를 추가하고, 차단한 사용자의 댓글은 식별 정보와 내용을 마스킹하도록 구현했습니다.

**조회 구조 리팩터링**
- 댓글 차단 응답 조립을 `CommentResponseAssembler`로 분리해 `CommentReadService`와 DTO 책임을 단순화했습니다.
- 게시물 차단 필터는 서비스에서 차단 사용자 ID를 선조회하지 않고 repository query의 차단 subquery로 처리하도록 정리했습니다.

## 중요한 변경 사항은 무엇인가요?
### 사용자 차단 도메인 추가

**차단 관계 저장 구조와 서비스 추가**
- **변경 이유**: 사용자별 차단 상태를 영속화하고 API에서 재사용하기 위해
- **수정 파일**: `src/main/resources/db/migration/V17__create_user_bans.sql`, `src/main/kotlin/com/techtaurant/mainserver/user/entity/UserBan.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserBanRepository.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/application/UserBanService.kt`

**차단/차단 해제/목록 API 공개**
- **변경 이유**: 클라이언트에서 사용자 차단 기능을 직접 사용할 수 있어야 해서
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerDocs.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/dto/UserBanResponse.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/dto/UserBanListItemResponse.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/enums/UserStatus.kt`

### 조회 차단 정책 반영

**게시물 목록/상세에서 차단 사용자 비노출 처리**
- **변경 이유**: 차단한 사용자의 게시물을 조회 결과에서 제외해야 해서
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt`, `src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt`

**댓글 마스킹 응답 구조 정리**
- **변경 이유**: 댓글 맥락은 유지하면서 차단 응답 조립 책임을 서비스와 DTO에서 분리해야 해서
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentReadService.kt`, `src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentResponseAssembler.kt`, `src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentListResponse.kt`

## 스크린샷 및 시연 영상 (optional)

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
