### PR TITLE
fix/refactor(user): 사용자 차단 코드 리뷰 반영

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -12,6 +12,7 @@ import com.techtaurant.mainserver.post.enums.PostStatus
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.entity.UserBan
+import com.techtaurant.mainserver.user.entity.UserBan_
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
 import jakarta.persistence.criteria.CriteriaBuilder
@@ -170,10 +171,10 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
 
         banSubquery.select(cb.literal(1L))
         banSubquery.where(
-            cb.equal(banRoot.get<User>("user").get<UUID>(EntityBase_.id), viewerId),
+            cb.equal(banRoot.get(UserBan_.user).get(EntityBase_.id), viewerId),
             cb.equal(
-                banRoot.get<User>("bannedUser").get<UUID>(EntityBase_.id),
-                root.get<User>(Post_.author).get<UUID>(EntityBase_.id),
+                banRoot.get(UserBan_.bannedUser).get(EntityBase_.id),
+                root.get(Post_.author).get(EntityBase_.id),
             ),
         )
 

--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserBanService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserBanService.kt
@@ -7,6 +7,7 @@ import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.enums.UserStatus
 import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -24,12 +25,10 @@ class UserBanService(
     ): UserBanResponse {
         validateNotSelfBan(userId, targetUserId)
 
-        if (userBanRepository.existsByUserIdAndBannedUserId(userId, targetUserId)) {
-            throw ApiException(UserStatus.USER_ALREADY_BANNED)
-        }
-
         val user =
             userRepository.findById(userId).orElseThrow {
+                // @AuthenticationPrincipal로 주입된 userId는 이미 인증된 사용자이므로
+                // 정상 플로우에서는 도달 불가. 토큰 유효 기간 내 사용자가 탈퇴한 경우에만 발생.
                 ApiException(UserStatus.ID_NOT_FOUND)
             }
         val targetUser =
@@ -37,13 +36,23 @@ class UserBanService(
                 ApiException(UserStatus.USER_NOT_FOUND)
             }
 
+        // 이미 차단한 경우 기존 차단 정보를 그대로 반환 (idempotent)
+        userBanRepository.findByUserIdAndBannedUserId(userId, targetUserId)?.let {
+            return UserBanResponse.from(it)
+        }
+
         val userBan =
-            userBanRepository.save(
-                UserBan(
-                    user = user,
-                    bannedUser = targetUser,
-                ),
-            )
+            try {
+                userBanRepository.save(
+                    UserBan(
+                        user = user,
+                        bannedUser = targetUser,
+                    ),
+                )
+            } catch (e: DataIntegrityViolationException) {
+                // 동시 요청으로 인한 유니크 제약 위반 시 기존 차단 정보를 반환 (idempotent)
+                userBanRepository.findByUserIdAndBannedUserId(userId, targetUserId)!!
+            }
 
         return UserBanResponse.from(userBan)
     }
@@ -58,9 +67,7 @@ class UserBanService(
             return emptySet()
         }
 
-        return userBanRepository.findAllByUserId(userId)
-            .map { it.bannedUser.id!! }
-            .toSet()
+        return userBanRepository.findBannedUserIdsByUserId(userId).toHashSet()
     }
 
     @Transactional

--- a/src/main/kotlin/com/techtaurant/mainserver/user/entity/UserBan.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/entity/UserBan.kt
@@ -21,8 +21,8 @@ import jakarta.persistence.UniqueConstraint
 class UserBan(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
-    var user: User,
+    val user: User,
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "banned_user_id", nullable = false)
-    var bannedUser: User,
+    val bannedUser: User,
 ) : EntityBase()

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt
@@ -1,14 +1,12 @@
 package com.techtaurant.mainserver.user.infrastructure.`in`
 
 import com.techtaurant.mainserver.common.dto.ApiResponse
-import com.techtaurant.mainserver.common.swagger.ApiErrorResponses
 import com.techtaurant.mainserver.security.SecurityConstants
 import com.techtaurant.mainserver.user.application.UserBanService
 import com.techtaurant.mainserver.user.application.UserReadService
 import com.techtaurant.mainserver.user.dto.UserBanListItemResponse
 import com.techtaurant.mainserver.user.dto.UserBanResponse
 import com.techtaurant.mainserver.user.dto.UserResponse
-import com.techtaurant.mainserver.user.enums.UserStatus
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -26,7 +24,6 @@ class UserController(
     private val userReadService: UserReadService,
     private val userBanService: UserBanService,
 ) : UserControllerDocs {
-    @ApiErrorResponses(users = [UserStatus.ID_NOT_FOUND], includeAuthenticationErrors = true)
     @GetMapping("/me")
     override fun getMe(
         @AuthenticationPrincipal userId: UUID,
@@ -34,10 +31,6 @@ class UserController(
         return ApiResponse.ok(userReadService.getMe(userId))
     }
 
-    @ApiErrorResponses(
-        users = [UserStatus.USER_NOT_FOUND, UserStatus.CANNOT_BAN_SELF, UserStatus.USER_ALREADY_BANNED],
-        includeAuthenticationErrors = true,
-    )
     @PostMapping("/{targetUserId}/ban")
     @ResponseStatus(HttpStatus.CREATED)
     override fun banUser(
@@ -47,7 +40,6 @@ class UserController(
         return ApiResponse.created(userBanService.banUser(userId, targetUserId))
     }
 
-    @ApiErrorResponses(includeAuthenticationErrors = true)
     @GetMapping("/me/bans")
     override fun getMyBannedUsers(
         @AuthenticationPrincipal userId: UUID,
@@ -55,10 +47,6 @@ class UserController(
         return ApiResponse.ok(userBanService.getBannedUsers(userId))
     }
 
-    @ApiErrorResponses(
-        users = [UserStatus.CANNOT_BAN_SELF, UserStatus.USER_BAN_NOT_FOUND],
-        includeAuthenticationErrors = true,
-    )
     @DeleteMapping("/{targetUserId}/ban")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     override fun unbanUser(

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserBanRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserBanRepository.kt
@@ -2,14 +2,11 @@ package com.techtaurant.mainserver.user.infrastructure.out
 
 import com.techtaurant.mainserver.user.entity.UserBan
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.UUID
 
 interface UserBanRepository : JpaRepository<UserBan, UUID> {
-    fun existsByUserIdAndBannedUserId(
-        userId: UUID,
-        bannedUserId: UUID,
-    ): Boolean
-
     fun findByUserIdAndBannedUserId(
         userId: UUID,
         bannedUserId: UUID,
@@ -17,5 +14,8 @@ interface UserBanRepository : JpaRepository<UserBan, UUID> {
 
     fun findAllByUserIdOrderByCreatedAtDesc(userId: UUID): List<UserBan>
 
-    fun findAllByUserId(userId: UUID): List<UserBan>
+    @Query("SELECT ub.bannedUser.id FROM UserBan ub WHERE ub.user.id = :userId")
+    fun findBannedUserIdsByUserId(
+        @Param("userId") userId: UUID,
+    ): List<UUID>
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerBanIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerBanIntegrationTest.kt
@@ -4,6 +4,7 @@ import com.techtaurant.mainserver.base.IntegrationTest
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
 import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.enums.UserRole
 import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
@@ -62,9 +63,9 @@ class UserControllerBanIntegrationTest : IntegrationTest() {
     }
 
     @Test
-    @DisplayName("사용자 차단 후 목록 조회와 차단 해제가 정상 동작한다")
-    fun banListAndUnban_success() {
-        // When - 차단 요청
+    @DisplayName("사용자 차단이 성공한다")
+    fun ban_success() {
+        // When & Then
         given()
             .header("Authorization", "Bearer $accessToken")
             .`when`()
@@ -73,8 +74,15 @@ class UserControllerBanIntegrationTest : IntegrationTest() {
             .statusCode(HttpStatus.CREATED.value())
             .body("data.userId", equalTo(targetUser.id.toString()))
             .body("data.name", equalTo(targetUser.name))
+    }
 
-        // Then - 차단 목록 조회
+    @Test
+    @DisplayName("차단 목록 조회가 성공한다")
+    fun getBannedUsers_success() {
+        // Given
+        userBanRepository.save(UserBan(user = testUser, bannedUser = targetUser))
+
+        // When & Then
         given()
             .header("Authorization", "Bearer $accessToken")
             .`when`()
@@ -83,16 +91,35 @@ class UserControllerBanIntegrationTest : IntegrationTest() {
             .statusCode(HttpStatus.OK.value())
             .body("data", hasSize<Any>(1))
             .body("data[0].userId", equalTo(targetUser.id.toString()))
+    }
 
-        // When - 차단 해제
+    @Test
+    @DisplayName("차단 해제가 성공한다")
+    fun unban_success() {
+        // Given
+        userBanRepository.save(UserBan(user = testUser, bannedUser = targetUser))
+
+        // When & Then
         given()
             .header("Authorization", "Bearer $accessToken")
             .`when`()
             .delete("/api/users/${targetUser.id}/ban")
             .then()
             .statusCode(HttpStatus.NO_CONTENT.value())
+    }
 
-        // Then - 차단 목록 비어 있음
+    @Test
+    @DisplayName("차단 해제 후 목록이 비어있다")
+    fun getBannedUsers_afterUnban_returnsEmpty() {
+        // Given
+        userBanRepository.save(UserBan(user = testUser, bannedUser = targetUser))
+
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .delete("/api/users/${targetUser.id}/ban")
+
+        // When & Then
         given()
             .header("Authorization", "Bearer $accessToken")
             .`when`()


### PR DESCRIPTION
## Summary

- **P1 - TOCTOU 레이스컨디션 수정**: `banUser()` save() 호출을 try-catch로 감싸 `DataIntegrityViolationException` 발생 시 기존 차단 정보를 반환 (idempotent 유지)
- **P2 - 엔티티 불변성 강화**: `UserBan` 필드 `var` → `val` 변경
- **P2 - UUID 직접 조회 최적화**: `findAllByUserId()` 대신 JPQL로 `bannedUserId`만 조회하는 `findBannedUserIdsByUserId()` 추가 (N+1 방지)
- **P2 - JPA 메타모델 적용**: `PostRepositoryCustomImpl`의 문자열 리터럴 `"user"`, `"bannedUser"` → `UserBan_` 메타모델로 교체 (컴파일 타임 오타 방지)
- **P2 - Swagger 중복 제거**: `UserController`의 `@ApiErrorResponses` 제거 (`UserControllerDocs`의 `@ApiErrorCodeResponses`와 중복)
- **P2 - 통합테스트 분리**: 단일 테스트(`banListAndUnban_success`) → 4개 독립 시나리오로 분리

## Test plan

- [ ] `UserControllerBanIntegrationTest` 4개 테스트 모두 통과 확인
- [ ] Swagger UI에서 `/api/users/{targetUserId}/ban` 에러 응답 예시 중복 없음 확인
- [ ] 동시 차단 요청 시 500 에러 미발생, 정상 응답 반환 확인