### PR TITLE
modify(post): 최신순 정렬 기준을 createdAt에서 updatedAt으로 변경

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -255,6 +255,7 @@ class PostListReadService(
             commentCount = post.commentCount,
             status = post.status,
             createdAt = post.createdAt,
+            updatedAt = post.updatedAt,
         )
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
@@ -9,11 +9,11 @@ import java.util.UUID
  * 게시물 목록 커서
  *
  * 정렬 기준에 따라 다른 커서 값을 사용
- * - LATEST: createdAt, id
+ * - LATEST: updatedAt(최신 수정 시간), id
  * - VIEW/LIKE/COMMENT: sortValue(해당 count), createdAt, id
  *
  * @property sortValue 정렬 기준 값 (조회수, 좋아요수, 댓글수)
- * @property createdAt 게시물 생성 시간
+ * @property createdAt LATEST 정렬 시 updatedAt, 그 외 정렬 시 createdAt을 담는 보조 정렬 시간 필드
  * @property id 게시물 ID
  * @property sortType 정렬 타입
  */
@@ -72,7 +72,9 @@ data class PostCursor(
                     PostSortType.LIKE -> post.likeCount
                     PostSortType.COMMENT -> post.commentCount
                 }
-            return PostCursor(sortValue, post.createdAt, post.id!!, sortType)
+            // LATEST 정렬은 updatedAt 기준이므로 커서에 updatedAt을 저장합니다.
+            val cursorDate = if (sortType == PostSortType.LATEST) post.updatedAt else post.createdAt
+            return PostCursor(sortValue, cursorDate, post.id!!, sortType)
         }
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostListItemResponse.kt
@@ -34,6 +34,8 @@ data class PostListItemResponse(
     val status: PostStatusEnum,
     @field:Schema(description = "작성일")
     val createdAt: Date,
+    @field:Schema(description = "최종 수정일")
+    val updatedAt: Date,
 ) {
     companion object {
         /**
@@ -59,6 +61,7 @@ data class PostListItemResponse(
                 commentCount = post.commentCount,
                 status = post.status,
                 createdAt = post.createdAt,
+                updatedAt = post.updatedAt,
             )
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/entity/PostSortType.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/entity/PostSortType.kt
@@ -6,7 +6,12 @@ package com.techtaurant.mainserver.post.entity
  * @property field 정렬 기준 필드명
  */
 enum class PostSortType(val field: String) {
-    LATEST("createdAt"),
+    /**
+     * 최신순 정렬은 updatedAt 기준으로 동작합니다.
+     * createdAt을 사용하면 한 번 생성된 게시물이 영구히 낮은 순위에 머물 수 있는 문제가 있어
+     * 수정된 게시물도 상단에 노출될 수 있도록 updatedAt을 기준으로 합니다.
+     */
+    LATEST("updatedAt"),
     VIEW("viewCount"),
     LIKE("likeCount"),
     COMMENT("commentCount"),

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -107,7 +107,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
     /**
      * 정렬 타입에 따른 커서 조건 추가
      *
-     * 최신순은 createdAt + id 기준, 그 외(조회/추천/댓글순)는 해당 count + createdAt + id 기준
+     * 최신순은 updatedAt + id 기준, 그 외(조회/추천/댓글순)는 해당 count + createdAt + id 기준
      */
     private fun addCursorCondition(
         cb: CriteriaBuilder,
@@ -129,21 +129,21 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
     /**
      * 최신순 커서 조건 생성
      *
-     * 동일 시간대 게시물 구분을 위해 id를 보조 키로 사용
-     * 조건: (createdAt < cursor) OR (createdAt = cursor AND id < cursorId)
+     * 최신순은 updatedAt 기준으로 정렬되며, 동일 시간대 게시물 구분을 위해 id를 보조 키로 사용합니다.
+     * 조건: (updatedAt < cursor) OR (updatedAt = cursor AND id < cursorId)
      */
     private fun buildLatestCursorCondition(
         cb: CriteriaBuilder,
         root: Root<Post>,
         cursor: PostCursor,
     ): Predicate {
-        val createdAtLess = cb.lessThan(root.get(EntityBase_.createdAt), cursor.createdAt)
-        val createdAtEqualAndIdLess =
+        val updatedAtLess = cb.lessThan(root.get(EntityBase_.updatedAt), cursor.createdAt)
+        val updatedAtEqualAndIdLess =
             cb.and(
-                cb.equal(root.get(EntityBase_.createdAt), cursor.createdAt),
+                cb.equal(root.get(EntityBase_.updatedAt), cursor.createdAt),
                 cb.lessThan(root.get(EntityBase_.id), cursor.id),
             )
-        return cb.or(createdAtLess, createdAtEqualAndIdLess)
+        return cb.or(updatedAtLess, updatedAtEqualAndIdLess)
     }
 
     /**
@@ -184,7 +184,9 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
     /**
      * 정렬 타입에 따른 ORDER BY 절 적용
      *
-     * 모든 정렬은 DESC이며 동점자 처리를 위해 createdAt, id를 보조 정렬 키로 추가
+     * 모든 정렬은 DESC이며 동점자 처리를 위해 createdAt, id를 보조 정렬 키로 추가합니다.
+     * 최신순(LATEST)은 updatedAt 기준입니다. createdAt을 기준으로 하면 한 번 생성된 게시물이
+     * 영구히 낮은 순위에 머물 수 있으므로, 수정된 게시물도 상단에 노출될 수 있도록 updatedAt을 사용합니다.
      */
     private fun applyOrdering(
         cb: CriteriaBuilder,
@@ -196,7 +198,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             when (sortType) {
                 PostSortType.LATEST ->
                     listOf(
-                        cb.desc(root.get(EntityBase_.createdAt)),
+                        cb.desc(root.get(EntityBase_.updatedAt)),
                         cb.desc(root.get(EntityBase_.id)),
                     )
                 PostSortType.VIEW ->


### PR DESCRIPTION
## Summary

- 최신순(LATEST) 정렬 기준을 `createdAt` → `updatedAt`으로 변경
- 커서 페이지네이션(`PostCursor`)도 LATEST 케이스에서 `updatedAt` 사용
- `PostListItemResponse`에 `updatedAt` 필드 추가

## 변경 이유

`createdAt` 기준으로 정렬하면 한 번 생성된 게시물이 수정되어도 영구히 낮은 순위에 머무는 문제가 있습니다. `updatedAt` 기준으로 변경하여 최근 수정된 게시물도 상단에 노출될 수 있도록 합니다.

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `PostSortType.kt` | `LATEST("createdAt")` → `LATEST("updatedAt")` + 이유 주석 |
| `PostCursor.kt` | LATEST 커서에 `post.updatedAt` 저장, 주석 갱신 |
| `PostRepositoryCustomImpl.kt` | LATEST 정렬/커서 조건을 `updatedAt` 기준으로 변경 + 주석 |
| `PostListItemResponse.kt` | `updatedAt: Date` 필드 추가 |
| `PostListReadService.kt` | `convertToResponse()`에 `updatedAt` 전달 |

## Test plan

- [ ] 게시물 목록 최신순 조회 시 최근 수정된 게시물이 상단에 노출되는지 확인
- [ ] 커서 기반 페이지네이션이 updatedAt 기준으로 정상 동작하는지 확인
- [ ] VIEW/LIKE/COMMENT 정렬은 기존과 동일하게 동작하는지 확인
- [ ] `PostListItemResponse`에 `updatedAt` 필드가 포함되는지 확인