### PR TITLE
fix(swagger): 400 에러 응답 스키마 분리 및 테스트 추가

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/common/swagger/ApiErrorCodeOperationCustomizer.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/common/swagger/ApiErrorCodeOperationCustomizer.kt
@@ -5,9 +5,14 @@ import com.techtaurant.mainserver.common.dto.ValidationErrorResponse
 import com.techtaurant.mainserver.common.status.DefaultStatus
 import com.techtaurant.mainserver.common.status.StatusIfs
 import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.ComposedSchema
 import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.IntegerSchema
+import io.swagger.v3.oas.models.media.MapSchema
 import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.media.ObjectSchema
 import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.media.StringSchema
 import io.swagger.v3.oas.models.responses.ApiResponses
 import org.springdoc.core.customizers.OperationCustomizer
 import org.springframework.core.annotation.AnnotatedElementUtils
@@ -93,13 +98,6 @@ class ApiErrorCodeOperationCustomizer : OperationCustomizer {
         val content = response.content ?: Content()
         val mediaType = content["application/json"] ?: MediaType()
 
-        if (mediaType.schema == null) {
-            mediaType.schema =
-                Schema<Any>().apply {
-                    `$ref` = "#/components/schemas/ApiResponse"
-                }
-        }
-
         statuses.forEach { status ->
             val example =
                 SwaggerExample().apply {
@@ -109,14 +107,55 @@ class ApiErrorCodeOperationCustomizer : OperationCustomizer {
             mediaType.addExamples(resolveExampleName(status), example)
         }
 
-        if (httpStatusCode == "400") {
+        val hasValidationError = httpStatusCode == "400"
+        if (hasValidationError) {
             addValidationErrorExample(mediaType)
+        }
+
+        if (mediaType.schema == null) {
+            mediaType.schema =
+                if (hasValidationError) {
+                    ComposedSchema()
+                        .addOneOfItem(businessErrorSchema())
+                        .addOneOfItem(validationErrorSchema())
+                } else {
+                    businessErrorSchema()
+                }
         }
 
         content.addMediaType("application/json", mediaType)
         response.content = content
         operation.responses.addApiResponse(httpStatusCode, response)
     }
+
+    private fun businessErrorSchema(): Schema<*> =
+        ObjectSchema()
+            .addProperty("status", IntegerSchema().description("커스텀 상태 코드").example(3001))
+            .addProperty(
+                "data",
+                Schema<Any>().apply {
+                    description = "에러 상세 데이터"
+                    nullable = true
+                },
+            )
+            .addProperty("message", StringSchema().description("에러 메시지").example("게시물을 찾을 수 없습니다"))
+
+    private fun validationErrorSchema(): Schema<*> =
+        ObjectSchema()
+            .addProperty("status", IntegerSchema().description("커스텀 상태 코드").example(400))
+            .addProperty(
+                "data",
+                ObjectSchema()
+                    .description("검증 오류 상세 정보")
+                    .addProperty(
+                        "errors",
+                        MapSchema()
+                            .description("필드별 검증 오류")
+                            .additionalProperties(StringSchema())
+                            .example(mapOf("field" to "유효하지 않은 값입니다")),
+                    ),
+            )
+            .addProperty("message", StringSchema().description("에러 메시지").example("Wrong Request"))
 
     private fun buildErrorExampleValue(status: StatusIfs): Map<String, Any?> {
         val errorResponse = ApiResponse.error<Any>(status)

--- a/src/test/kotlin/com/techtaurant/mainserver/common/swagger/ApiErrorCodeOperationCustomizerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/common/swagger/ApiErrorCodeOperationCustomizerTest.kt
@@ -1,0 +1,174 @@
+package com.techtaurant.mainserver.common.swagger
+
+import com.techtaurant.mainserver.common.dto.ValidationErrorResponse
+import com.techtaurant.mainserver.common.status.StatusIfs
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.ComposedSchema
+import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.MapSchema
+import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.media.ObjectSchema
+import io.swagger.v3.oas.models.responses.ApiResponses
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.web.method.HandlerMethod
+
+class ApiErrorCodeOperationCustomizerTest {
+    private val customizer = ApiErrorCodeOperationCustomizer()
+    private val controller = TestController()
+
+    @Test
+    @DisplayName("400 에러 응답에는 비즈니스 에러와 검증 에러 스키마를 함께 설정한다")
+    fun customize_withBadRequestAnnotation_addsComposedSchemaAndValidationExample() {
+        // Given
+        val operation = Operation()
+        val handlerMethod = createHandlerMethod("badRequest")
+
+        // When
+        val customized = customizer.customize(operation, handlerMethod)
+
+        // Then
+        val response = requireNotNull(customized.responses["400"])
+        assertThat(response.description).isEqualTo("입력값 검증 실패 또는 비즈니스 규칙 위반")
+
+        val mediaType = requireNotNull(response.content["application/json"])
+        assertThat(mediaType.examples).containsKeys("잘못된 요청", "중복 요청", "Validation 에러")
+
+        val businessErrorExample = requireNotNull(mediaType.examples["잘못된 요청"])
+        assertThat(businessErrorExample.value).isEqualTo(
+            linkedMapOf(
+                "status" to 1400,
+                "data" to null,
+                "message" to "잘못된 요청",
+            ),
+        )
+
+        val validationExample = requireNotNull(mediaType.examples["Validation 에러"])
+        assertThat(validationExample.value).isEqualTo(
+            linkedMapOf(
+                "status" to 400,
+                "data" to ValidationErrorResponse(mapOf("field" to "에러 메시지")),
+                "message" to "Wrong Request",
+            ),
+        )
+
+        val schema = requireNotNull(mediaType.schema)
+        assertThat(schema).isInstanceOf(ComposedSchema::class.java)
+
+        val composedSchema = schema as ComposedSchema
+        assertThat(composedSchema.oneOf).hasSize(2)
+
+        val businessSchema = composedSchema.oneOf[0] as ObjectSchema
+        assertThat(businessSchema.properties).containsKeys("status", "data", "message")
+
+        val validationSchema = composedSchema.oneOf[1] as ObjectSchema
+        val validationDataSchema = validationSchema.properties["data"] as ObjectSchema
+        val errorsSchema = validationDataSchema.properties["errors"] as MapSchema
+        assertThat(errorsSchema.additionalProperties).isNotNull
+    }
+
+    @Test
+    @DisplayName("일반 에러 응답에는 단일 비즈니스 에러 스키마를 설정한다")
+    fun customize_withNotFoundAnnotation_addsBusinessErrorSchema() {
+        // Given
+        val operation = Operation()
+        val handlerMethod = createHandlerMethod("notFound")
+
+        // When
+        val customized = customizer.customize(operation, handlerMethod)
+
+        // Then
+        val response = requireNotNull(customized.responses["404"])
+        assertThat(response.description).isEqualTo("리소스 미존재")
+
+        val mediaType = requireNotNull(response.content["application/json"])
+        assertThat(mediaType.examples).containsOnlyKeys("리소스 없음")
+        assertThat(mediaType.schema).isInstanceOf(ObjectSchema::class.java)
+        assertThat(mediaType.schema).isNotInstanceOf(ComposedSchema::class.java)
+
+        val schema = requireNotNull(mediaType.schema) as ObjectSchema
+        assertThat(schema.properties).containsKeys("status", "data", "message")
+    }
+
+    @Test
+    @DisplayName("기존 응답 설명과 스키마가 있으면 덮어쓰지 않고 예시만 추가한다")
+    fun customize_withExistingResponse_preservesDescriptionAndSchema() {
+        // Given
+        val existingSchema = ObjectSchema().description("기존 스키마")
+        val existingMediaType = MediaType().schema(existingSchema)
+        val existingResponse =
+            io.swagger.v3.oas.models.responses.ApiResponse()
+                .description("기존 설명")
+                .content(Content().addMediaType("application/json", existingMediaType))
+        val operation =
+            Operation().responses(
+                ApiResponses().addApiResponse("403", existingResponse),
+            )
+        val handlerMethod = createHandlerMethod("forbidden")
+
+        // When
+        val customized = customizer.customize(operation, handlerMethod)
+
+        // Then
+        val response = requireNotNull(customized.responses["403"])
+        assertThat(response.description).isEqualTo("기존 설명")
+
+        val mediaType = requireNotNull(response.content["application/json"])
+        assertThat(mediaType.schema).isSameAs(existingSchema)
+        assertThat(mediaType.examples).containsKey("권한 없음")
+    }
+
+    @Test
+    @DisplayName("에러 코드 어노테이션이 없으면 기존 Operation을 그대로 반환한다")
+    fun customize_withoutAnnotation_returnsOriginalOperation() {
+        // Given
+        val operation = Operation()
+        val handlerMethod = createHandlerMethod("withoutAnnotation")
+
+        // When
+        val customized = customizer.customize(operation, handlerMethod)
+
+        // Then
+        assertThat(customized).isSameAs(operation)
+        assertThat(customized.responses).isNull()
+    }
+
+    private fun createHandlerMethod(methodName: String): HandlerMethod =
+        HandlerMethod(controller, controller::class.java.getMethod(methodName))
+
+    private class TestController {
+        @ApiErrorCodeResponse(statusType = TestStatus::class, values = ["BAD_REQUEST_ONE", "BAD_REQUEST_TWO"])
+        fun badRequest() {
+        }
+
+        @ApiErrorCodeResponse(statusType = TestStatus::class, values = ["NOT_FOUND"])
+        fun notFound() {
+        }
+
+        @ApiErrorCodeResponse(statusType = TestStatus::class, values = ["FORBIDDEN"])
+        fun forbidden() {
+        }
+
+        fun withoutAnnotation() {
+        }
+    }
+
+    private enum class TestStatus(
+        private val httpStatusCode: Int,
+        private val customStatusCode: Int,
+        private val description: String,
+    ) : StatusIfs {
+        BAD_REQUEST_ONE(400, 1400, "잘못된 요청"),
+        BAD_REQUEST_TWO(400, 1401, "중복 요청"),
+        FORBIDDEN(403, 1403, "권한 없음"),
+        NOT_FOUND(404, 1404, "리소스 없음"),
+        ;
+
+        override fun getHttpStatusCode(): Int = httpStatusCode
+
+        override fun getCustomStatusCode(): Int = customStatusCode
+
+        override fun getDescription(): String = description
+    }
+}


### PR DESCRIPTION
## 관련 자료
- 이슈 : #

## 어떤 작업인가요?
- Swagger 400 에러 응답 문서가 단일 `ApiResponse` 스키마로 노출되던 문제를 수정하고, 커스터마이저 동작을 고정하는 단위 테스트를 추가했습니다.

## 어떻게 해결했나요?
**400 에러 응답 스키마 분리**
- 400 응답일 때 비즈니스 에러와 검증 에러를 `oneOf`로 함께 표현하도록 스키마 생성을 변경했습니다.
- 기존 공통 `ApiResponse` 참조 대신 실제 Swagger 문서에 필요한 필드 구조를 직접 정의했습니다.

**단위 테스트 추가**
- `ApiErrorCodeOperationCustomizer`의 400/일반 에러 응답 생성, 기존 응답 보존, 어노테이션 미존재 케이스를 검증하는 unit test를 추가했습니다.

## 중요한 변경 사항은 무엇인가요?
### 400 에러 응답 스키마 분리

**400 응답에서 검증 에러 구조를 함께 문서화**
- **변경 이유**: 검증 오류 응답이 실제 구조와 다르게 Swagger에 표시되던 문제를 해결하기 위해
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/common/swagger/ApiErrorCodeOperationCustomizer.kt`

**일반 에러 응답도 명시적 스키마로 통일**
- **변경 이유**: 상태 코드별 예시와 응답 필드 구조를 Swagger 문서에 일관되게 노출하기 위해
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/common/swagger/ApiErrorCodeOperationCustomizer.kt`

### 단위 테스트 추가

**커스터마이저 분기 로직 회귀 방지**
- **변경 이유**: 400 응답의 `oneOf` 스키마와 기존 응답 보존 동작이 다시 깨지지 않도록 하기 위해
- **수정 파일**: `src/test/kotlin/com/techtaurant/mainserver/common/swagger/ApiErrorCodeOperationCustomizerTest.kt`

## 스크린샷 및 시연 영상 (optional)

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
