### PR TITLE
feat(user): 사용자 팔로우 API 추가

### DIFF
--- a/.claude/plan/user/2603/15-add-user-follow-api.plan.md
+++ b/.claude/plan/user/2603/15-add-user-follow-api.plan.md
@@ -1,0 +1,163 @@
+# 사용자 팔로우 API 추가
+
+## Business Goal
+사용자가 다른 사용자를 팔로우하거나 팔로우를 취소할 수 있게 하고, 특정 사용자의 팔로워 수와 팔로우 수 및 팔로워/팔로잉 목록을 조회할 수 있도록 하여 사용자 간 관계 기능을 제공한다. 또한 차단 시 기존 팔로우 관계를 즉시 정리해 관계 데이터 정합성을 유지한다.
+
+## Scope
+- **In Scope**: 사용자 팔로우/팔로우 취소 API, 특정 사용자 팔로워 수/팔로우 수 조회 API, 특정 사용자 팔로워 목록/팔로잉 목록 조회 API, 차단 시 양방향 팔로우 관계 자동 해제, Swagger 문서화, 통합 테스트
+- **Out of Scope**: 팔로우 추천, 알림, isFollowing 상태 조회, 페이지네이션, 사용자 상세 프로필 API 신설
+
+## Codebase Analysis Summary
+현재 사용자 도메인은 `UserController`에서 인증이 필요한 내 정보/차단 쓰기 API를, `UserOpenApiController`에서 공개 조회 API를 담당한다. 차단 기능은 `UserBan`, `UserBanRepository`, `UserBanService` 구조로 구현되어 있으며 생성은 멱등적으로 처리되고 Swagger는 별도 Docs interface에 선언된다. 사용자 목록 조회 테스트는 RestAssured 기반 `IntegrationTest` 패턴을 따른다.
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/main/kotlin/com/techtaurant/mainserver/user/entity/UserFollow.kt` | 사용자 팔로우 관계 엔티티 | Create |
+| `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserFollowRepository.kt` | 팔로우 관계 조회/삭제 repository | Create |
+| `src/main/kotlin/com/techtaurant/mainserver/user/application/UserFollowService.kt` | 팔로우/언팔로우/카운트/목록 비즈니스 로직 | Create |
+| `src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowResponse.kt` | 팔로우 생성 응답 DTO | Create |
+| `src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowCountResponse.kt` | 팔로워/팔로우 수 응답 DTO | Create |
+| `src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowListItemResponse.kt` | 팔로워/팔로잉 목록 항목 DTO | Create |
+| `src/main/kotlin/com/techtaurant/mainserver/user/enums/UserStatus.kt` | 팔로우 관련 에러 코드 추가 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/user/application/UserBanService.kt` | 차단 시 팔로우 관계 자동 해제 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt` | 팔로우/언팔로우 엔드포인트 추가 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerDocs.kt` | 팔로우/언팔로우 Swagger 명세 추가 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiController.kt` | 카운트/목록 조회 엔드포인트 추가 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiControllerDocs.kt` | 카운트/목록 Swagger 명세 추가 | Modify |
+| `src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerFollowIntegrationTest.kt` | 팔로우 API 통합 테스트 | Create |
+| `src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerBanIntegrationTest.kt` | 차단 시 언팔로우 연동 테스트 보강 | Modify |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| Swagger 분리 | `CLAUDE.md`, `UserControllerDocs.kt` | Controller 구현체에는 Swagger 어노테이션을 두지 않고 `*ControllerDocs`에만 선언 |
+| API 설명 한국어 | `.claude/core/BACKEND.md`, `CLAUDE.md` | summary, description, DTO 필드 설명을 모두 한국어로 작성 |
+| 에러 코드 선언 | `CLAUDE.md`, `UserControllerDocs.kt` | 가능한 예외를 `ApiErrorCodeResponses`로 빠짐없이 선언 |
+| 서비스 구조 | `UserBanService.kt`, `UserReadService.kt` | 사용자 도메인 비즈니스 로직은 application service에서 처리 |
+| 테스트 스타일 | `integration-test-guide`, `UserControllerBanIntegrationTest.kt` | RestAssured 기반 통합 테스트, Given-When-Then 구분, 명시적 테스트 데이터 정리 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 팔로우 모델 | `UserFollow` 엔티티 별도 생성 | `UserBan`과 동일한 관계 모델로 정합성과 확장성을 확보 | 사용자 테이블에 카운트 컬럼 저장 |
+| 팔로우 읽기/쓰기 서비스 | `UserFollowService` 단일 서비스 | 현재 `UserBanService`도 읽기/쓰기를 함께 담당해 구조 일관성이 높음 | Read/Write 서비스 분리 |
+| 카운트/목록 API 위치 | `UserOpenApiController` | 공개 조회 API를 open-api에 두는 기존 패턴 준수 | `UserController`에 포함 |
+| 차단 연동 방식 | `UserBanService`에서 팔로우 관계 삭제 | 차단 트랜잭션 내에서 정합성 있게 처리 가능 | DB cascade, 도메인 이벤트 |
+| 차단 시 삭제 범위 | 양방향 팔로우 관계 모두 삭제 | 두 사용자 관계 단절이라는 요구를 가장 직접적으로 만족 | 한 방향만 삭제 |
+
+## API Contracts
+
+### POST /api/users/{targetUserId}/follow
+- Headers: `Authorization: Bearer {accessToken}`
+- Request: `없음`
+- Response: `ApiResponse<UserFollowResponse>`
+- Note: 본인 팔로우는 불가하며 대상 사용자가 없으면 에러를 반환한다.
+
+### DELETE /api/users/{targetUserId}/follow
+- Headers: `Authorization: Bearer {accessToken}`
+- Request: `없음`
+- Response: `204 No Content`
+- Note: 팔로우 관계가 없으면 에러를 반환한다.
+
+### GET /open-api/users/{userId}/follow-counts
+- Headers: `없음`
+- Request: `없음`
+- Response: `ApiResponse<UserFollowCountResponse>`
+- Note: 존재하지 않는 사용자는 에러를 반환한다.
+
+### GET /open-api/users/{userId}/followings
+- Headers: `없음`
+- Request: `없음`
+- Response: `ApiResponse<List<UserFollowListItemResponse>>`
+- Note: 특정 사용자가 팔로우한 사용자 목록을 최신순으로 반환한다.
+
+### GET /open-api/users/{userId}/followers
+- Headers: `없음`
+- Request: `없음`
+- Response: `ApiResponse<List<UserFollowListItemResponse>>`
+- Note: 특정 사용자를 팔로우하는 사용자 목록을 최신순으로 반환한다.
+
+## Data Models
+
+### UserFollow
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `id` | `UUID` | PK |
+| `follower` | `User` | FK, not null |
+| `following` | `User` | FK, not null |
+| `createdAt` | `Date` | 생성 시각 |
+| `(follower_id, following_id)` | `unique` | 중복 팔로우 방지 |
+
+## Implementation Todos
+
+### Todo 1: 팔로우 도메인 모델과 서비스 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 팔로우 관계 저장과 조회를 처리할 수 있는 엔티티, repository, service, DTO, 에러 코드를 준비한다.
+- **Work**:
+  - `UserFollow` 엔티티와 `UserFollowRepository`를 추가한다.
+  - `UserFollowService`에 팔로우, 언팔로우, 카운트 조회, 팔로워/팔로잉 목록 조회 로직을 구현한다.
+  - `UserFollowResponse`, `UserFollowCountResponse`, `UserFollowListItemResponse` DTO를 추가한다.
+  - `UserStatus`에 팔로우 관련 에러 코드를 추가한다.
+- **Convention Notes**: `UserBan`과 유사한 관계형 엔티티 패턴을 따르고, DTO description은 한국어로 작성한다.
+- **Verification**: 관련 코드 컴파일 확인, 서비스 로직에서 필요한 에러 케이스 점검
+- **Exit Criteria**: 서비스 레벨에서 팔로우 관계 생성/삭제/카운트/목록 반환이 가능하다.
+- **Status**: completed
+
+### Todo 2: 컨트롤러와 Swagger 문서 추가
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 팔로우 쓰기 API와 공개 조회 API를 노출하고 Swagger 문서를 일치시킨다.
+- **Work**:
+  - `UserController`, `UserControllerDocs`에 팔로우/언팔로우 엔드포인트를 추가한다.
+  - `UserOpenApiController`, `UserOpenApiControllerDocs`에 카운트/팔로워/팔로잉 조회 엔드포인트를 추가한다.
+  - Swagger 응답 코드와 실제 HTTP status, 에러 코드 목록을 일치시킨다.
+- **Convention Notes**: Controller와 Docs interface 시그니처를 동일하게 유지하고, 성공 응답은 content 없이 선언한다.
+- **Verification**: 컨트롤러 시그니처와 Docs interface 일치 여부 확인
+- **Exit Criteria**: 필요한 5개 API가 코드상 노출되고 Swagger 명세가 추가된다.
+- **Status**: completed
+
+### Todo 3: 차단 시 자동 언팔로우 연동 및 통합 테스트 작성
+- **Priority**: 3
+- **Dependencies**: Todo 1, Todo 2
+- **Goal**: 차단 시 팔로우 관계가 자동 정리되고 API 동작이 통합 테스트로 보장되게 한다.
+- **Work**:
+  - `UserBanService`에서 차단 시 두 사용자 간 양방향 팔로우 관계를 삭제하도록 수정한다.
+  - `UserControllerFollowIntegrationTest`를 추가해 팔로우/언팔로우/카운트/팔로워/팔로잉 조회를 검증한다.
+  - `UserControllerBanIntegrationTest`에 차단 후 팔로우 관계 제거 검증을 추가한다.
+- **Convention Notes**: RestAssured 통합 테스트 패턴과 명시적 데이터 정리 순서를 따른다.
+- **Verification**: 사용자 follow/ban 관련 통합 테스트 실행
+- **Exit Criteria**: 차단 연동과 신규 API가 테스트로 검증된다.
+- **Status**: completed
+
+### Todo 4: 포맷/검증 실행 및 마무리
+- **Priority**: 4
+- **Dependencies**: Todo 3
+- **Goal**: 프로젝트 규칙에 맞게 포맷과 정적 검증을 완료하고 최종 상태를 정리한다.
+- **Work**:
+  - `./gradlew spotlessApply && ./gradlew spotlessCheck`를 실행한다.
+  - 필요 시 실패 원인을 수정하고 재검증한다.
+  - 계획 파일 진행 상태와 변경 로그를 완료 상태로 갱신한다.
+- **Convention Notes**: `CLAUDE.md`의 완료 체크리스트를 그대로 따른다.
+- **Verification**: `./gradlew spotlessApply && ./gradlew spotlessCheck`
+- **Exit Criteria**: 포맷/검증 명령이 성공하고 계획 파일 상태가 최신이다.
+- **Status**: completed
+
+## Verification Strategy
+전체 구현 후 팔로우/차단 관련 통합 테스트와 포맷 검증을 통해 동작과 코드 스타일을 함께 확인한다.
+- `./gradlew test --tests "*UserControllerFollowIntegrationTest" --tests "*UserControllerBanIntegrationTest"`
+- `./gradlew spotlessApply && ./gradlew spotlessCheck`
+
+## Progress Tracking
+- Total Todos: 4
+- Completed: 4
+- Status: Execution complete
+
+## Change Log
+- 2026-03-15: Plan created
+- 2026-03-15: Todo 1 completed — 팔로우 도메인 모델, DTO, 서비스, 에러 코드 추가
+- 2026-03-15: Todo 2 completed — 팔로우 컨트롤러와 Open API 및 Swagger 문서 추가
+- 2026-03-15: Todo 3 completed — 차단 시 상호 팔로우 해제 연동과 팔로우 통합 테스트 추가
+- 2026-03-15: Todo 4 completed — Spotless 포맷/검증 실행
+- 2026-03-15: Execution complete

--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserBanService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserBanService.kt
@@ -17,6 +17,7 @@ import java.util.UUID
 class UserBanService(
     private val userRepository: UserRepository,
     private val userBanRepository: UserBanRepository,
+    private val userFollowService: UserFollowService,
 ) {
     @Transactional
     fun banUser(
@@ -38,6 +39,7 @@ class UserBanService(
 
         // 이미 차단한 경우 기존 차단 정보를 그대로 반환 (idempotent)
         userBanRepository.findByUserIdAndBannedUserId(userId, targetUserId)?.let {
+            userFollowService.deleteMutualFollows(userId, targetUserId)
             return UserBanResponse.from(it)
         }
 
@@ -53,6 +55,8 @@ class UserBanService(
                 // 동시 요청으로 인한 유니크 제약 위반 시 기존 차단 정보를 반환 (idempotent)
                 userBanRepository.findByUserIdAndBannedUserId(userId, targetUserId)!!
             }
+
+        userFollowService.deleteMutualFollows(userId, targetUserId)
 
         return UserBanResponse.from(userBan)
     }

--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserFollowService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserFollowService.kt
@@ -1,0 +1,122 @@
+package com.techtaurant.mainserver.user.application
+
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.user.dto.UserFollowCountResponse
+import com.techtaurant.mainserver.user.dto.UserFollowListItemResponse
+import com.techtaurant.mainserver.user.dto.UserFollowResponse
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.entity.UserFollow
+import com.techtaurant.mainserver.user.enums.UserStatus
+import com.techtaurant.mainserver.user.infrastructure.out.UserFollowRepository
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class UserFollowService(
+    private val userRepository: UserRepository,
+    private val userFollowRepository: UserFollowRepository,
+) {
+    @Transactional
+    fun follow(
+        followerId: UUID,
+        targetUserId: UUID,
+    ): UserFollowResponse {
+        validateNotSelfFollow(followerId, targetUserId)
+
+        val follower = getUser(followerId, UserStatus.ID_NOT_FOUND)
+        val following = getUser(targetUserId, UserStatus.USER_NOT_FOUND)
+
+        userFollowRepository.findByFollowerIdAndFollowingId(followerId, targetUserId)?.let {
+            return UserFollowResponse.from(it)
+        }
+
+        val userFollow =
+            try {
+                userFollowRepository.save(
+                    UserFollow(
+                        follower = follower,
+                        following = following,
+                    ),
+                )
+            } catch (e: DataIntegrityViolationException) {
+                userFollowRepository.findByFollowerIdAndFollowingId(followerId, targetUserId)!!
+            }
+
+        return UserFollowResponse.from(userFollow)
+    }
+
+    @Transactional
+    fun unfollow(
+        followerId: UUID,
+        targetUserId: UUID,
+    ) {
+        validateNotSelfFollow(followerId, targetUserId)
+
+        val userFollow =
+            userFollowRepository.findByFollowerIdAndFollowingId(followerId, targetUserId)
+                ?: throw ApiException(UserStatus.USER_FOLLOW_NOT_FOUND)
+
+        userFollowRepository.delete(userFollow)
+    }
+
+    @Transactional(readOnly = true)
+    fun getFollowCounts(userId: UUID): UserFollowCountResponse {
+        getUser(userId, UserStatus.USER_NOT_FOUND)
+
+        return UserFollowCountResponse(
+            followerCount = userFollowRepository.countByFollowingId(userId),
+            followingCount = userFollowRepository.countByFollowerId(userId),
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getFollowings(userId: UUID): List<UserFollowListItemResponse> {
+        getUser(userId, UserStatus.USER_NOT_FOUND)
+
+        return userFollowRepository.findAllByFollowerIdOrderByCreatedAtDesc(userId).map {
+            UserFollowListItemResponse.fromFollowing(it)
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun getFollowers(userId: UUID): List<UserFollowListItemResponse> {
+        getUser(userId, UserStatus.USER_NOT_FOUND)
+
+        return userFollowRepository.findAllByFollowingIdOrderByCreatedAtDesc(userId).map {
+            UserFollowListItemResponse.fromFollower(it)
+        }
+    }
+
+    @Transactional
+    fun deleteMutualFollows(
+        firstUserId: UUID,
+        secondUserId: UUID,
+    ) {
+        if (firstUserId == secondUserId) {
+            return
+        }
+
+        userFollowRepository.deleteMutualFollows(firstUserId, secondUserId)
+    }
+
+    private fun getUser(
+        userId: UUID,
+        status: UserStatus,
+    ): User {
+        return userRepository.findById(userId).orElseThrow {
+            ApiException(status)
+        }
+    }
+
+    private fun validateNotSelfFollow(
+        followerId: UUID,
+        targetUserId: UUID,
+    ) {
+        if (followerId == targetUserId) {
+            throw ApiException(UserStatus.CANNOT_FOLLOW_SELF)
+        }
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowCountResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowCountResponse.kt
@@ -1,0 +1,11 @@
+package com.techtaurant.mainserver.user.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사용자 팔로워 수/팔로우 수 응답")
+data class UserFollowCountResponse(
+    @field:Schema(description = "팔로워 수", example = "12")
+    val followerCount: Long,
+    @field:Schema(description = "팔로우 수", example = "7")
+    val followingCount: Long,
+)

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowListItemResponse.kt
@@ -1,0 +1,36 @@
+package com.techtaurant.mainserver.user.dto
+
+import com.techtaurant.mainserver.user.entity.UserFollow
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.Date
+import java.util.UUID
+
+@Schema(description = "사용자 팔로워/팔로잉 목록 아이템 응답")
+data class UserFollowListItemResponse(
+    @field:Schema(description = "사용자 ID")
+    val userId: UUID,
+    @field:Schema(description = "사용자 이름")
+    val name: String,
+    @field:Schema(description = "사용자 프로필 이미지 URL")
+    val profileImageUrl: String,
+    @field:Schema(description = "팔로우 생성 시각")
+    val followedAt: Date,
+) {
+    companion object {
+        fun fromFollowing(userFollow: UserFollow): UserFollowListItemResponse =
+            UserFollowListItemResponse(
+                userId = userFollow.following.id!!,
+                name = userFollow.following.name,
+                profileImageUrl = userFollow.following.profileImageUrl,
+                followedAt = userFollow.createdAt,
+            )
+
+        fun fromFollower(userFollow: UserFollow): UserFollowListItemResponse =
+            UserFollowListItemResponse(
+                userId = userFollow.follower.id!!,
+                name = userFollow.follower.name,
+                profileImageUrl = userFollow.follower.profileImageUrl,
+                followedAt = userFollow.createdAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowResponse.kt
@@ -1,0 +1,25 @@
+package com.techtaurant.mainserver.user.dto
+
+import com.techtaurant.mainserver.user.entity.UserFollow
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.Date
+import java.util.UUID
+
+@Schema(description = "사용자 팔로우 응답")
+data class UserFollowResponse(
+    @field:Schema(description = "팔로우한 사용자 ID")
+    val userId: UUID,
+    @field:Schema(description = "팔로우한 사용자 이름")
+    val name: String,
+    @field:Schema(description = "팔로우 시각")
+    val followedAt: Date,
+) {
+    companion object {
+        fun from(userFollow: UserFollow): UserFollowResponse =
+            UserFollowResponse(
+                userId = userFollow.following.id!!,
+                name = userFollow.following.name,
+                followedAt = userFollow.createdAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/user/entity/UserFollow.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/entity/UserFollow.kt
@@ -1,0 +1,28 @@
+package com.techtaurant.mainserver.user.entity
+
+import com.techtaurant.mainserver.common.base.EntityBase
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+
+@Entity
+@Table(
+    name = "user_follows",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_user_follows_follower_id_following_id",
+            columnNames = ["follower_id", "following_id"],
+        ),
+    ],
+)
+class UserFollow(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id", nullable = false)
+    val follower: User,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "following_id", nullable = false)
+    val following: User,
+) : EntityBase()

--- a/src/main/kotlin/com/techtaurant/mainserver/user/enums/UserStatus.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/enums/UserStatus.kt
@@ -13,6 +13,9 @@ enum class UserStatus(
     CANNOT_BAN_SELF(HttpStatus.BAD_REQUEST.value(), 1003, "자기 자신은 차단할 수 없습니다"),
     USER_ALREADY_BANNED(HttpStatus.CONFLICT.value(), 1004, "이미 차단한 사용자입니다"),
     USER_BAN_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 1005, "차단한 사용자 관계를 찾을 수 없습니다"),
+    CANNOT_FOLLOW_SELF(HttpStatus.BAD_REQUEST.value(), 1006, "자기 자신은 팔로우할 수 없습니다"),
+    USER_ALREADY_FOLLOWED(HttpStatus.CONFLICT.value(), 1007, "이미 팔로우한 사용자입니다"),
+    USER_FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 1008, "팔로우 관계를 찾을 수 없습니다"),
     ;
 
     override fun getHttpStatusCode(): Int {

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt
@@ -3,9 +3,11 @@ package com.techtaurant.mainserver.user.infrastructure.`in`
 import com.techtaurant.mainserver.common.dto.ApiResponse
 import com.techtaurant.mainserver.security.SecurityConstants
 import com.techtaurant.mainserver.user.application.UserBanService
+import com.techtaurant.mainserver.user.application.UserFollowService
 import com.techtaurant.mainserver.user.application.UserReadService
 import com.techtaurant.mainserver.user.dto.UserBanListItemResponse
 import com.techtaurant.mainserver.user.dto.UserBanResponse
+import com.techtaurant.mainserver.user.dto.UserFollowResponse
 import com.techtaurant.mainserver.user.dto.UserResponse
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -23,6 +25,7 @@ import java.util.UUID
 class UserController(
     private val userReadService: UserReadService,
     private val userBanService: UserBanService,
+    private val userFollowService: UserFollowService,
 ) : UserControllerDocs {
     @GetMapping("/me")
     override fun getMe(
@@ -40,6 +43,15 @@ class UserController(
         return ApiResponse.created(userBanService.banUser(userId, targetUserId))
     }
 
+    @PostMapping("/{targetUserId}/follow")
+    @ResponseStatus(HttpStatus.CREATED)
+    override fun followUser(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable targetUserId: UUID,
+    ): ApiResponse<UserFollowResponse> {
+        return ApiResponse.created(userFollowService.follow(userId, targetUserId))
+    }
+
     @GetMapping("/me/bans")
     override fun getMyBannedUsers(
         @AuthenticationPrincipal userId: UUID,
@@ -54,5 +66,14 @@ class UserController(
         @PathVariable targetUserId: UUID,
     ) {
         userBanService.unbanUser(userId, targetUserId)
+    }
+
+    @DeleteMapping("/{targetUserId}/follow")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    override fun unfollowUser(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable targetUserId: UUID,
+    ) {
+        userFollowService.unfollow(userId, targetUserId)
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerDocs.kt
@@ -7,6 +7,7 @@ import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponses
 import com.techtaurant.mainserver.security.jwt.JwtStatus
 import com.techtaurant.mainserver.user.dto.UserBanListItemResponse
 import com.techtaurant.mainserver.user.dto.UserBanResponse
+import com.techtaurant.mainserver.user.dto.UserFollowResponse
 import com.techtaurant.mainserver.user.dto.UserResponse
 import com.techtaurant.mainserver.user.enums.UserStatus
 import io.swagger.v3.oas.annotations.Operation
@@ -47,6 +48,23 @@ interface UserControllerDocs {
         targetUserId: UUID,
     ): ApiResponse<UserBanResponse>
 
+    @Operation(summary = "사용자 팔로우", description = "현재 로그인한 사용자가 특정 사용자를 팔로우합니다")
+    @SwaggerApiResponse(
+        responseCode = "201",
+        description = "팔로우 성공",
+    )
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED"]),
+            ApiErrorCodeResponse(UserStatus::class, ["USER_NOT_FOUND", "CANNOT_FOLLOW_SELF"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun followUser(
+        userId: UUID,
+        targetUserId: UUID,
+    ): ApiResponse<UserFollowResponse>
+
     @Operation(summary = "내가 차단한 사용자 목록 조회", description = "현재 로그인한 사용자가 차단한 사용자 목록을 최신순으로 조회합니다")
     @SwaggerApiResponse(
         responseCode = "200",
@@ -73,6 +91,23 @@ interface UserControllerDocs {
         ],
     )
     fun unbanUser(
+        userId: UUID,
+        targetUserId: UUID,
+    )
+
+    @Operation(summary = "사용자 팔로우 취소", description = "현재 로그인한 사용자가 특정 사용자 팔로우를 취소합니다")
+    @SwaggerApiResponse(
+        responseCode = "204",
+        description = "팔로우 취소 성공",
+    )
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED"]),
+            ApiErrorCodeResponse(UserStatus::class, ["CANNOT_FOLLOW_SELF", "USER_FOLLOW_NOT_FOUND"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun unfollowUser(
         userId: UUID,
         targetUserId: UUID,
     )

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiController.kt
@@ -8,7 +8,10 @@ import com.techtaurant.mainserver.post.dto.PostListItemResponse
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.security.SecurityConstants
+import com.techtaurant.mainserver.user.application.UserFollowService
 import com.techtaurant.mainserver.user.application.UserReadService
+import com.techtaurant.mainserver.user.dto.UserFollowCountResponse
+import com.techtaurant.mainserver.user.dto.UserFollowListItemResponse
 import com.techtaurant.mainserver.user.dto.UserResponse
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
@@ -27,6 +30,7 @@ import java.util.UUID
 @Validated
 class UserOpenApiController(
     private val userReadService: UserReadService,
+    private val userFollowService: UserFollowService,
     private val postListReadService: PostListReadService,
 ) : UserOpenApiControllerDocs {
     @ApiErrorResponses(includeValidationError = true)
@@ -36,6 +40,27 @@ class UserOpenApiController(
         @RequestParam name: String,
     ): ApiResponse<List<UserResponse>> {
         return ApiResponse.ok(userReadService.searchByName(name))
+    }
+
+    @GetMapping("/{userId}/follow-counts")
+    override fun getFollowCounts(
+        @PathVariable userId: UUID,
+    ): ApiResponse<UserFollowCountResponse> {
+        return ApiResponse.ok(userFollowService.getFollowCounts(userId))
+    }
+
+    @GetMapping("/{userId}/followings")
+    override fun getFollowings(
+        @PathVariable userId: UUID,
+    ): ApiResponse<List<UserFollowListItemResponse>> {
+        return ApiResponse.ok(userFollowService.getFollowings(userId))
+    }
+
+    @GetMapping("/{userId}/followers")
+    override fun getFollowers(
+        @PathVariable userId: UUID,
+    ): ApiResponse<List<UserFollowListItemResponse>> {
+        return ApiResponse.ok(userFollowService.getFollowers(userId))
     }
 
     @GetMapping("/{userId}/posts")

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiControllerDocs.kt
@@ -9,7 +9,10 @@ import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponses
 import com.techtaurant.mainserver.post.dto.PostListItemResponse
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
+import com.techtaurant.mainserver.user.dto.UserFollowCountResponse
+import com.techtaurant.mainserver.user.dto.UserFollowListItemResponse
 import com.techtaurant.mainserver.user.dto.UserResponse
+import com.techtaurant.mainserver.user.enums.UserStatus
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -37,6 +40,51 @@ interface UserOpenApiControllerDocs {
         @NotBlank
         name: String,
     ): ApiResponse<List<UserResponse>>
+
+    @Operation(summary = "사용자 팔로워 수/팔로우 수 조회", description = "특정 사용자의 팔로워 수와 팔로우 수를 조회합니다")
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+    )
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(UserStatus::class, ["USER_NOT_FOUND"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun getFollowCounts(
+        @Parameter(description = "조회 대상 사용자 ID") userId: UUID,
+    ): ApiResponse<UserFollowCountResponse>
+
+    @Operation(summary = "사용자 팔로잉 목록 조회", description = "특정 사용자가 팔로우한 사용자 목록을 최신순으로 조회합니다")
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+    )
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(UserStatus::class, ["USER_NOT_FOUND"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun getFollowings(
+        @Parameter(description = "조회 대상 사용자 ID") userId: UUID,
+    ): ApiResponse<List<UserFollowListItemResponse>>
+
+    @Operation(summary = "사용자 팔로워 목록 조회", description = "특정 사용자를 팔로우하는 사용자 목록을 최신순으로 조회합니다")
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+    )
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(UserStatus::class, ["USER_NOT_FOUND"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun getFollowers(
+        @Parameter(description = "조회 대상 사용자 ID") userId: UUID,
+    ): ApiResponse<List<UserFollowListItemResponse>>
 
     @Operation(
         summary = "사용자 게시물 목록 조회",

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserFollowRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserFollowRepository.kt
@@ -1,0 +1,38 @@
+package com.techtaurant.mainserver.user.infrastructure.out
+
+import com.techtaurant.mainserver.user.entity.UserFollow
+import jakarta.transaction.Transactional
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.UUID
+
+interface UserFollowRepository : JpaRepository<UserFollow, UUID> {
+    fun findByFollowerIdAndFollowingId(
+        followerId: UUID,
+        followingId: UUID,
+    ): UserFollow?
+
+    fun countByFollowerId(followerId: UUID): Long
+
+    fun countByFollowingId(followingId: UUID): Long
+
+    fun findAllByFollowerIdOrderByCreatedAtDesc(followerId: UUID): List<UserFollow>
+
+    fun findAllByFollowingIdOrderByCreatedAtDesc(followingId: UUID): List<UserFollow>
+
+    @Modifying
+    @Transactional
+    @Query(
+        """
+        DELETE FROM UserFollow uf
+        WHERE (uf.follower.id = :firstUserId AND uf.following.id = :secondUserId)
+           OR (uf.follower.id = :secondUserId AND uf.following.id = :firstUserId)
+        """,
+    )
+    fun deleteMutualFollows(
+        @Param("firstUserId") firstUserId: UUID,
+        @Param("secondUserId") secondUserId: UUID,
+    ): Int
+}

--- a/src/main/resources/db/migration/V19__create_user_follows.sql
+++ b/src/main/resources/db/migration/V19__create_user_follows.sql
@@ -1,0 +1,12 @@
+CREATE TABLE user_follows (
+    id UUID PRIMARY KEY,
+    follower_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    following_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_user_follows_follower_id_following_id UNIQUE (follower_id, following_id),
+    CONSTRAINT chk_user_follows_not_self CHECK (follower_id <> following_id)
+);
+
+CREATE INDEX idx_user_follows_follower_id ON user_follows(follower_id);
+CREATE INDEX idx_user_follows_following_id ON user_follows(following_id);

--- a/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerBanIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerBanIntegrationTest.kt
@@ -5,8 +5,10 @@ import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.entity.UserBan
+import com.techtaurant.mainserver.user.entity.UserFollow
 import com.techtaurant.mainserver.user.enums.UserRole
 import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
+import com.techtaurant.mainserver.user.infrastructure.out.UserFollowRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import io.restassured.RestAssured.given
 import org.hamcrest.Matchers.equalTo
@@ -27,6 +29,9 @@ class UserControllerBanIntegrationTest : IntegrationTest() {
     private lateinit var userBanRepository: UserBanRepository
 
     @Autowired
+    private lateinit var userFollowRepository: UserFollowRepository
+
+    @Autowired
     private lateinit var jwtTokenProvider: JwtTokenProvider
 
     private lateinit var testUser: User
@@ -36,6 +41,7 @@ class UserControllerBanIntegrationTest : IntegrationTest() {
     @BeforeEach
     fun setUpTestData() {
         userBanRepository.deleteAllInBatch()
+        userFollowRepository.deleteAllInBatch()
 
         testUser =
             userRepository.save(
@@ -127,5 +133,22 @@ class UserControllerBanIntegrationTest : IntegrationTest() {
             .then()
             .statusCode(HttpStatus.OK.value())
             .body("data", hasSize<Any>(0))
+    }
+
+    @Test
+    @DisplayName("사용자 차단 시 양방향 팔로우 관계가 자동으로 해제된다")
+    fun ban_removesMutualFollows() {
+        userFollowRepository.save(UserFollow(follower = testUser, following = targetUser))
+        userFollowRepository.save(UserFollow(follower = targetUser, following = testUser))
+
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .post("/api/users/${targetUser.id}/ban")
+            .then()
+            .statusCode(HttpStatus.CREATED.value())
+
+        kotlin.test.assertNull(userFollowRepository.findByFollowerIdAndFollowingId(testUser.id!!, targetUser.id!!))
+        kotlin.test.assertNull(userFollowRepository.findByFollowerIdAndFollowingId(targetUser.id!!, testUser.id!!))
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerFollowIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerFollowIntegrationTest.kt
@@ -1,0 +1,145 @@
+package com.techtaurant.mainserver.user.infrastructure.`in`
+
+import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.entity.UserFollow
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserFollowRepository
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import io.restassured.RestAssured.given
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItems
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+@DisplayName("UserController follow 통합 테스트")
+class UserControllerFollowIntegrationTest : IntegrationTest() {
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var userFollowRepository: UserFollowRepository
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    private lateinit var testUser: User
+    private lateinit var firstTargetUser: User
+    private lateinit var secondTargetUser: User
+    private lateinit var followerUser: User
+    private lateinit var accessToken: String
+
+    @BeforeEach
+    fun setUpTestData() {
+        userFollowRepository.deleteAllInBatch()
+
+        testUser = createUser(name = "테스트사용자", emailPrefix = "test")
+        firstTargetUser = createUser(name = "첫번째대상", emailPrefix = "target1")
+        secondTargetUser = createUser(name = "두번째대상", emailPrefix = "target2")
+        followerUser = createUser(name = "팔로워사용자", emailPrefix = "follower")
+        accessToken = jwtTokenProvider.createAccessToken(testUser.id!!, testUser.role)
+    }
+
+    @Test
+    @DisplayName("사용자 팔로우가 성공한다")
+    fun follow_success() {
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .post("/api/users/${firstTargetUser.id}/follow")
+            .then()
+            .statusCode(HttpStatus.CREATED.value())
+            .body("data.userId", equalTo(firstTargetUser.id.toString()))
+            .body("data.name", equalTo(firstTargetUser.name))
+    }
+
+    @Test
+    @DisplayName("팔로워 수와 팔로우 수 조회가 성공한다")
+    fun getFollowCounts_success() {
+        userFollowRepository.save(UserFollow(follower = testUser, following = firstTargetUser))
+        userFollowRepository.save(UserFollow(follower = firstTargetUser, following = secondTargetUser))
+        userFollowRepository.save(UserFollow(follower = followerUser, following = firstTargetUser))
+
+        given()
+            .`when`()
+            .get("/open-api/users/${firstTargetUser.id}/follow-counts")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.followerCount", equalTo(2))
+            .body("data.followingCount", equalTo(1))
+    }
+
+    @Test
+    @DisplayName("팔로잉 목록 조회가 성공한다")
+    fun getFollowings_success() {
+        userFollowRepository.save(UserFollow(follower = testUser, following = firstTargetUser))
+        userFollowRepository.save(UserFollow(follower = testUser, following = secondTargetUser))
+
+        given()
+            .`when`()
+            .get("/open-api/users/${testUser.id}/followings")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data", hasSize<Any>(2))
+            .body("data.userId", hasItems(firstTargetUser.id.toString(), secondTargetUser.id.toString()))
+    }
+
+    @Test
+    @DisplayName("팔로워 목록 조회가 성공한다")
+    fun getFollowers_success() {
+        userFollowRepository.save(UserFollow(follower = testUser, following = firstTargetUser))
+        userFollowRepository.save(UserFollow(follower = followerUser, following = firstTargetUser))
+
+        given()
+            .`when`()
+            .get("/open-api/users/${firstTargetUser.id}/followers")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data", hasSize<Any>(2))
+            .body("data.userId", hasItems(testUser.id.toString(), followerUser.id.toString()))
+    }
+
+    @Test
+    @DisplayName("팔로우 취소가 성공한다")
+    fun unfollow_success() {
+        userFollowRepository.save(UserFollow(follower = testUser, following = firstTargetUser))
+
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .delete("/api/users/${firstTargetUser.id}/follow")
+            .then()
+            .statusCode(HttpStatus.NO_CONTENT.value())
+
+        given()
+            .`when`()
+            .get("/open-api/users/${testUser.id}/follow-counts")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.followerCount", equalTo(0))
+            .body("data.followingCount", equalTo(0))
+    }
+
+    private fun createUser(
+        name: String,
+        emailPrefix: String,
+    ): User {
+        return userRepository.save(
+            User(
+                name = name,
+                email = "$emailPrefix-${UUID.randomUUID()}@example.com",
+                provider = OAuthProvider.GOOGLE,
+                identifier = "$emailPrefix-id-${UUID.randomUUID()}",
+                role = UserRole.USER,
+                profileImageUrl = "https://example.com/$emailPrefix.jpg",
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/user/2603/15-add-user-follow-api.plan.md)
- [프론트 연동 이슈](https://github.com/Techtaurant/fe/issues/100)

## 어떤 작업인가요?
- 사용자 간 팔로우 관계를 생성/해제하고, 특정 사용자의 팔로워 수와 팔로워/팔로잉 목록을 조회할 수 있도록 API를 추가합니다.

## 어떻게 해결했나요?
**팔로우 도메인 모델 추가**
- 사용자 팔로우 관계를 저장하는 엔티티, 리포지토리, 서비스와 응답 DTO를 추가했습니다.
- 팔로우 생성/취소와 카운트/목록 조회 로직을 사용자 도메인 서비스에서 처리하도록 구성했습니다.

**API 및 문서화 확장**
- 인증 API에 팔로우/언팔로우 엔드포인트를 추가했습니다.
- Open API에 팔로워 수, 팔로워 목록, 팔로잉 목록 조회 엔드포인트를 추가하고 Swagger 문서를 함께 반영했습니다.

**차단 연동 및 검증 보강**
- 사용자 차단 시 두 사용자 사이의 상호 팔로우 관계가 자동으로 정리되도록 연동했습니다.
- 팔로우 API와 차단 연동 시나리오를 통합 테스트로 검증했습니다.

## 중요한 변경 사항은 무엇인가요?
### 팔로우 도메인 및 조회 API 추가

**팔로우 관계 모델과 서비스 구현**
- **변경 이유**: 사용자 간 구독 관계를 저장하고 재사용 가능한 비즈니스 로직 계층을 만들기 위해
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/user/entity/UserFollow.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserFollowRepository.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/application/UserFollowService.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowResponse.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowCountResponse.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowListItemResponse.kt`, `src/main/resources/db/migration/V19__create_user_follows.sql`

**팔로우 관련 API와 Swagger 문서 추가**
- **변경 이유**: 프론트엔드가 팔로우 액션과 공개 조회 기능을 바로 연동할 수 있게 하기 위해
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerDocs.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiController.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiControllerDocs.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/enums/UserStatus.kt`

### 차단 시 팔로우 관계 정리

**차단 시 상호 팔로우 자동 해제**
- **변경 이유**: 차단 이후에도 남아 있을 수 있는 사용자 간 관계 데이터를 즉시 정리하기 위해
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/user/application/UserBanService.kt`, `src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerBanIntegrationTest.kt`

**팔로우 통합 테스트 추가**
- **변경 이유**: 팔로우 생성/취소와 카운트/목록 조회 시나리오를 회귀 없이 유지하기 위해
- **수정 파일**: `src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerFollowIntegrationTest.kt`