### PR TITLE
게시물 목록에 태그 UUID 필터 추가

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -53,6 +53,7 @@ class PostListReadService(
      * @param currentUserId 현재 로그인 사용자 ID (비회원이면 null)
      * @param authorId 작성자 필터 (null이면 전체 조회)
      * @param categoryId 카테고리 필터 (null이면 전체, authorId 지정 시에만 적용)
+     * @param tagIds 태그 UUID 필터 (여러 개 전달 시 OR 조건)
      * @return 커서 기반 페이지 응답
      */
     fun getPosts(
@@ -63,8 +64,10 @@ class PostListReadService(
         currentUserId: UUID? = null,
         authorId: UUID? = null,
         categoryId: UUID? = null,
+        tagIds: List<UUID>? = null,
     ): CursorPageResponse<PostListItemResponse> {
         val postCursor = cursor?.let { PostCursor.decode(it) }
+        val normalizedTagIds = normalizeTagIds(tagIds)
 
         if (cursor != null && postCursor == null) {
             return CursorPageResponse(
@@ -91,6 +94,7 @@ class PostListReadService(
                     authorId = authorId,
                     statuses = statuses,
                     categoryId = categoryId,
+                    tagIds = normalizedTagIds,
                     viewerId = currentUserId,
                 )
             } else {
@@ -100,6 +104,7 @@ class PostListReadService(
                     period = period,
                     sortType = sortType,
                     visibleToUserId = currentUserId,
+                    tagIds = normalizedTagIds,
                     viewerId = currentUserId,
                 )
             }
@@ -145,6 +150,12 @@ class PostListReadService(
             hasNext = hasNext,
             size = content.size,
         )
+    }
+
+    private fun normalizeTagIds(tagIds: List<UUID>?): List<UUID>? {
+        val normalizedTagIds = tagIds?.distinct()
+
+        return normalizedTagIds?.takeIf { it.isNotEmpty() }
     }
 
     /**

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiController.kt
@@ -39,6 +39,7 @@ class PostReadOpenApiController(
         @RequestParam(defaultValue = "LATEST") sort: PostSortType,
         @RequestParam(required = false) authorId: UUID?,
         @RequestParam(required = false) categoryId: UUID?,
+        @RequestParam(required = false) tagIds: List<UUID>?,
         @AuthenticationPrincipal currentUserId: UUID?,
     ): ApiResponse<CursorPageResponse<PostListItemResponse>> {
         return ApiResponse.ok(
@@ -50,6 +51,7 @@ class PostReadOpenApiController(
                 currentUserId = currentUserId,
                 authorId = authorId,
                 categoryId = categoryId,
+                tagIds = tagIds,
             ),
         )
     }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerDocs.kt
@@ -38,6 +38,7 @@ interface PostReadOpenApiControllerDocs {
         @Parameter(description = "정렬 기준 (LATEST: 최신순, VIEW: 조회순, LIKE: 추천순, COMMENT: 댓글순)") sort: PostSortType,
         @Parameter(description = "작성자 ID 필터 (생략 시 전체 조회, 본인 조회 시 DRAFT/PRIVATE 포함)") authorId: UUID?,
         @Parameter(description = "카테고리 ID 필터 (authorId 지정 시에만 적용, 생략 시 전체)") categoryId: UUID?,
+        @Parameter(description = "태그 UUID 필터 (여러 개 전달 시 OR 조건으로 조회)") tagIds: List<UUID>?,
         currentUserId: UUID?,
     ): ApiResponse<CursorPageResponse<PostListItemResponse>>
 

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
@@ -22,6 +22,7 @@ interface PostRepositoryCustom {
      * @param statuses 게시물 상태 필터 (null이면 PUBLISHED만 조회)
      * @param categoryId 카테고리 ID 필터 (null이면 미적용)
      * @param visibleToUserId PUBLISHED + 해당 사용자의 모든 상태 게시물 조회 (null이면 미적용, statuses보다 우선)
+     * @param tagIds 태그 UUID 필터 (여러 개 전달 시 OR 조건)
      * @return 게시물 목록
      */
     fun findPostsWithConditions(
@@ -33,6 +34,7 @@ interface PostRepositoryCustom {
         statuses: List<PostStatusEnum>? = null,
         categoryId: UUID? = null,
         visibleToUserId: UUID? = null,
+        tagIds: List<UUID>? = null,
         viewerId: UUID? = null,
     ): List<Post>
 

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -48,6 +48,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         statuses: List<PostStatusEnum>?,
         categoryId: UUID?,
         visibleToUserId: UUID?,
+        tagIds: List<UUID>?,
         viewerId: UUID?,
     ): List<Post> {
         val cb = entityManager.criteriaBuilder
@@ -72,6 +73,10 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
 
         authorId?.let { predicates.add(cb.equal(root.get(Post_.author).get(EntityBase_.id), it)) }
         categoryId?.let { predicates.add(cb.equal(root.get(Post_.category).get(EntityBase_.id), it)) }
+        tagIds?.let { ids ->
+            val tagJoin = root.join<Post, Tag>(Post_.TAGS, JoinType.LEFT)
+            predicates.add(tagJoin.get<UUID>("id").`in`(ids))
+        }
         addViewerBanCondition(cb, cq, root, viewerId, predicates)
 
         addPeriodCondition(cb, root, period, predicates)

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -97,6 +97,7 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     visibleToUserId = testUser.id!!,
+                    tagIds = null,
                     viewerId = testUser.id!!,
                 )
             } returns posts
@@ -115,6 +116,7 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     visibleToUserId = testUser.id!!,
+                    tagIds = null,
                     viewerId = testUser.id!!,
                 )
             }
@@ -132,6 +134,7 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     visibleToUserId = null,
+                    tagIds = null,
                     viewerId = null,
                 )
             } returns posts
@@ -147,6 +150,48 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     visibleToUserId = null,
+                    tagIds = null,
+                    viewerId = null,
+                )
+            }
+        }
+
+        @Test
+        @DisplayName("태그 ID 필터 전달 시 중복 제거된 UUID 목록으로 Repository를 호출한다")
+        fun getPosts_withTagIds_passesDistinctTagIds() {
+            // given
+            val posts = listOf(createPost(otherUser))
+            val firstTagId = UUID.randomUUID()
+            val secondTagId = UUID.randomUUID()
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    visibleToUserId = null,
+                    tagIds = listOf(firstTagId, secondTagId),
+                    viewerId = null,
+                )
+            } returns posts
+
+            // when
+            postListReadService.getPosts(
+                cursor = null,
+                size = 20,
+                currentUserId = null,
+                tagIds = listOf(firstTagId, secondTagId, firstTagId),
+            )
+
+            // then
+            verify {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    visibleToUserId = null,
+                    tagIds = listOf(firstTagId, secondTagId),
                     viewerId = null,
                 )
             }
@@ -177,6 +222,7 @@ class PostListReadServiceTest {
                     authorId = testUser.id!!,
                     statuses = PostStatusEnum.entries,
                     categoryId = null,
+                    tagIds = null,
                     viewerId = testUser.id!!,
                 )
             } returns posts
@@ -202,6 +248,7 @@ class PostListReadServiceTest {
                     authorId = testUser.id!!,
                     statuses = PostStatusEnum.entries,
                     categoryId = null,
+                    tagIds = null,
                     viewerId = testUser.id!!,
                 )
             }
@@ -221,6 +268,7 @@ class PostListReadServiceTest {
                     authorId = otherUser.id!!,
                     statuses = listOf(PostStatusEnum.PUBLISHED),
                     categoryId = null,
+                    tagIds = null,
                     viewerId = testUser.id!!,
                 )
             } returns posts
@@ -246,6 +294,7 @@ class PostListReadServiceTest {
                     authorId = otherUser.id!!,
                     statuses = listOf(PostStatusEnum.PUBLISHED),
                     categoryId = null,
+                    tagIds = null,
                     viewerId = testUser.id!!,
                 )
             }
@@ -265,6 +314,7 @@ class PostListReadServiceTest {
                     authorId = otherUser.id!!,
                     statuses = listOf(PostStatusEnum.PUBLISHED),
                     categoryId = null,
+                    tagIds = null,
                     viewerId = null,
                 )
             } returns posts
@@ -288,6 +338,7 @@ class PostListReadServiceTest {
                     authorId = otherUser.id!!,
                     statuses = listOf(PostStatusEnum.PUBLISHED),
                     categoryId = null,
+                    tagIds = null,
                     viewerId = null,
                 )
             }
@@ -327,6 +378,7 @@ class PostListReadServiceTest {
                     authorId = testUser.id!!,
                     statuses = PostStatusEnum.entries,
                     categoryId = null,
+                    tagIds = null,
                     viewerId = testUser.id!!,
                 )
             } returns posts
@@ -363,6 +415,7 @@ class PostListReadServiceTest {
                     authorId = testUser.id!!,
                     statuses = PostStatusEnum.entries,
                     categoryId = null,
+                    tagIds = null,
                     viewerId = testUser.id!!,
                 )
             } returns posts
@@ -403,6 +456,7 @@ class PostListReadServiceTest {
                     authorId = otherUser.id!!,
                     statuses = listOf(PostStatusEnum.PUBLISHED),
                     categoryId = null,
+                    tagIds = null,
                     viewerId = testUser.id!!,
                 )
             } returns posts

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostControllerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostControllerTest.kt
@@ -454,6 +454,32 @@ class PostControllerTest : IntegrationTest() {
     @DisplayName("필터 조합 검증")
     inner class CombinedFilterTest {
         @Test
+        @DisplayName("태그 ID를 여러 개 전달하면 OR 조건으로 게시물이 조회되어야 한다")
+        fun whenFilterByMultipleTagIds_thenPostsMatchingAnyTagLoaded() {
+            // Given: 각 게시물은 서로 다른 태그를 가진다
+            val firstTagId = testPosts[0].tags.first().id
+            val thirdTagId = testPosts[2].tags.first().id
+
+            // When: 두 태그 ID를 함께 전달해 목록 조회
+            val response =
+                RestAssured
+                    .given()
+                    .queryParam("tagIds", firstTagId, thirdTagId)
+                    .queryParam("size", 10)
+                    .`when`()
+                    .get("/open-api/posts")
+                    .then()
+                    .statusCode(200)
+                    .extract()
+                    .`as`(object : TypeRef<ApiResponse<CursorPageResponse<PostListItemResponse>>>() {})
+
+            // Then: 두 태그 중 하나라도 가진 게시물만 반환되어야 함
+            val returnedIds = response.data!!.content.map { it.id }.toSet()
+            assertEquals(setOf(testPosts[0].id, testPosts[2].id), returnedIds)
+            assertTrue(response.data!!.content.none { it.id == testPosts[1].id })
+        }
+
+        @Test
         @DisplayName("기간 필터와 정렬을 함께 적용하면 올바르게 로딩되어야 한다")
         fun whenApplyBothPeriodAndSort_thenCorrectPostsLoaded() {
             // When: 최근 7일의 게시물을 조회수 기준으로 정렬해서 조회


### PR DESCRIPTION
## 관련 자료
- 없음

## 어떤 작업인가요?
- 게시물 목록 Open API에서 여러 태그 UUID를 OR 조건으로 전달해 원하는 게시물만 안정적으로 조회할 수 있도록 변경했습니다.

## 어떻게 해결했나요?
**태그 필터 계약을 UUID 기준으로 정리**
- `GET /open-api/posts`에 `tagIds` 쿼리 파라미터를 추가했습니다.
- 서비스에서 중복 UUID를 제거한 뒤 조회 조건으로 전달하도록 정리했습니다.

**목록 조회와 테스트를 함께 보강**
- Repository 동적 조회에 태그 UUID `IN` 조건을 추가해 OR 필터로 동작하게 했습니다.
- 서비스 테스트와 통합 테스트를 추가해 `tagIds` 전달과 실제 필터링 결과를 검증했습니다.

## 중요한 변경 사항은 무엇인가요?
### 태그 UUID 기반 필터 추가

**Open API 요청 계약 변경**
- **변경 이유**: 태그 이름 변경이나 정규화에 영향받지 않는 안정적인 식별자 기반 필터가 필요했습니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiController.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerDocs.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt`

**목록 조회 OR 조건 적용**
- **변경 이유**: 여러 태그를 함께 보냈을 때 하나라도 일치하는 게시물을 반환해야 했습니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt`

### 회귀 방지 테스트 추가

**서비스/통합 테스트 보강**
- **변경 이유**: UUID 중복 제거와 실제 `tagIds` 쿼리 필터 동작을 자동 검증하기 위해서입니다.
- **수정 파일**: `src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt`, `src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostControllerTest.kt`
