### PR TITLE
fix(comment): 댓글 수 일별 통계 집계를 UTC 기준으로 정리

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentDeleteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentDeleteService.kt
@@ -3,6 +3,9 @@ package com.techtaurant.mainserver.comment.application
 import com.techtaurant.mainserver.comment.enums.CommentStatus
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepository
 import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.common.util.DateUtils
+import com.techtaurant.mainserver.post.application.PostDailyStatsService
+import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.nio.charset.StandardCharsets
@@ -17,6 +20,8 @@ import java.util.UUID
 @Service
 class CommentDeleteService(
     private val commentRepository: CommentRepository,
+    private val postRepository: PostRepository,
+    private val postDailyStatsService: PostDailyStatsService,
 ) {
     /**
      * 댓글을 soft delete 처리합니다.
@@ -48,6 +53,9 @@ class CommentDeleteService(
         comment.deletedAt = Date()
 
         commentRepository.save(comment)
+        comment.parent?.id?.let(commentRepository::decrementReplyCount)
+        postRepository.decrementCommentCount(comment.post.id!!)
+        postDailyStatsService.decrementCommentCount(comment.post.id!!, DateUtils.toUtcDate(comment.createdAt))
     }
 
     private fun hashContent(content: String): String {

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteService.kt
@@ -7,6 +7,7 @@ import com.techtaurant.mainserver.comment.entity.Comment
 import com.techtaurant.mainserver.comment.enums.CommentStatus
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepository
 import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.common.util.DateUtils
 import com.techtaurant.mainserver.common.util.HtmlSanitizer
 import com.techtaurant.mainserver.post.application.PostDailyStatsService
 import com.techtaurant.mainserver.post.entity.Post
@@ -60,9 +61,11 @@ class CommentWriteService(
             )
 
         val savedComment = commentRepository.save(comment)
+        val statDate = DateUtils.toUtcDate(savedComment.createdAt)
 
+        parent?.id?.let(commentRepository::incrementReplyCount)
         postRepository.incrementCommentCount(request.postId)
-        postDailyStatsService.incrementCommentCount(request.postId)
+        postDailyStatsService.incrementCommentCount(request.postId, statDate)
 
         return CommentResponse.from(savedComment)
     }

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/out/CommentRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/out/CommentRepository.kt
@@ -70,7 +70,7 @@ interface CommentRepository : JpaRepository<Comment, UUID> {
      * @param commentId 부모 댓글 ID
      */
     @Modifying(clearAutomatically = false, flushAutomatically = true)
-    @Query("UPDATE Comment c SET c.replyCount = c.replyCount - 1 WHERE c.id = :commentId")
+    @Query("UPDATE Comment c SET c.replyCount = CASE WHEN c.replyCount > 0 THEN c.replyCount - 1 ELSE 0 END WHERE c.id = :commentId")
     fun decrementReplyCount(
         @Param("commentId") commentId: UUID,
     )

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/out/CommentRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/out/CommentRepository.kt
@@ -52,4 +52,26 @@ interface CommentRepository : JpaRepository<Comment, UUID> {
     fun decrementLikeCount(
         @Param("commentId") commentId: UUID,
     )
+
+    /**
+     * 부모 댓글의 대댓글 수를 원자적으로 1 증가시킵니다.
+     *
+     * @param commentId 부모 댓글 ID
+     */
+    @Modifying(clearAutomatically = false, flushAutomatically = true)
+    @Query("UPDATE Comment c SET c.replyCount = c.replyCount + 1 WHERE c.id = :commentId")
+    fun incrementReplyCount(
+        @Param("commentId") commentId: UUID,
+    )
+
+    /**
+     * 부모 댓글의 대댓글 수를 원자적으로 1 감소시킵니다.
+     *
+     * @param commentId 부모 댓글 ID
+     */
+    @Modifying(clearAutomatically = false, flushAutomatically = true)
+    @Query("UPDATE Comment c SET c.replyCount = c.replyCount - 1 WHERE c.id = :commentId")
+    fun decrementReplyCount(
+        @Param("commentId") commentId: UUID,
+    )
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/common/util/DateUtils.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/common/util/DateUtils.kt
@@ -1,14 +1,34 @@
 package com.techtaurant.mainserver.common.util
 
-import java.time.LocalDate
-import java.time.ZoneOffset
+import java.util.Calendar
+import java.util.Date
+import java.util.TimeZone
 
 object DateUtils {
+    private val utcTimeZone: TimeZone = TimeZone.getTimeZone("UTC")
+
     /**
-     * UTC 기준 현재 날짜를 년-월-일만 포함하는 LocalDate로 반환합니다.
-     * 시간 정보는 포함되지 않으며, UTC 시간대 기준입니다.
+     * UTC 기준 현재 날짜를 자정으로 정규화한 Date로 반환합니다.
      *
-     * @return UTC 기준 현재 날짜 (년-월-일)
+     * @return UTC 기준 현재 날짜의 00:00:00.000 시각
      */
-    fun today(): LocalDate = LocalDate.now(ZoneOffset.UTC)
+    fun today(): java.sql.Date = toUtcDate(Date())
+
+    /**
+     * UTC 기준으로 Date를 해당 날짜의 자정 시각으로 정규화합니다.
+     *
+     * @param date 변환할 날짜/시간
+     * @return UTC 기준 날짜의 00:00:00.000 시각
+     */
+    fun toUtcDate(date: Date): java.sql.Date {
+        val calendar = newUtcCalendar()
+        calendar.time = date
+        calendar.set(Calendar.HOUR_OF_DAY, 0)
+        calendar.set(Calendar.MINUTE, 0)
+        calendar.set(Calendar.SECOND, 0)
+        calendar.set(Calendar.MILLISECOND, 0)
+        return java.sql.Date(calendar.timeInMillis)
+    }
+
+    private fun newUtcCalendar(): Calendar = Calendar.getInstance(utcTimeZone)
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDailyStatsService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDailyStatsService.kt
@@ -1,13 +1,12 @@
 package com.techtaurant.mainserver.post.application
 
-import com.techtaurant.mainserver.common.util.DateUtils
 import com.techtaurant.mainserver.post.entity.PostDailyStats
 import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
-import java.time.LocalDate
+import java.sql.Date
 import java.util.UUID
 
 /**
@@ -27,14 +26,11 @@ class PostDailyStatsService(
      *
      * @param postId 게시물 ID
      */
-    fun incrementViewCount(postId: UUID) {
-        val today = DateUtils.today()
-        val updatedRows = postDailyStatsRepository.incrementViewCount(postId, today)
-        if (updatedRows == 0) {
-            createDailyStatsAndIncrement(postId, today) { id, date ->
-                postDailyStatsRepository.incrementViewCount(id, date)
-            }
-        }
+    fun incrementViewCount(
+        postId: UUID,
+        statDate: Date,
+    ) {
+        applyDailyStatsChange(postId, statDate, postDailyStatsRepository::incrementViewCount)
     }
 
     /**
@@ -42,14 +38,11 @@ class PostDailyStatsService(
      *
      * @param postId 게시물 ID
      */
-    fun incrementLikeCount(postId: UUID) {
-        val today = DateUtils.today()
-        val updatedRows = postDailyStatsRepository.incrementLikeCount(postId, today)
-        if (updatedRows == 0) {
-            createDailyStatsAndIncrement(postId, today) { id, date ->
-                postDailyStatsRepository.incrementLikeCount(id, date)
-            }
-        }
+    fun incrementLikeCount(
+        postId: UUID,
+        statDate: Date,
+    ) {
+        applyDailyStatsChange(postId, statDate, postDailyStatsRepository::incrementLikeCount)
     }
 
     /**
@@ -58,14 +51,11 @@ class PostDailyStatsService(
      *
      * @param postId 게시물 ID
      */
-    fun decrementLikeCount(postId: UUID) {
-        val today = DateUtils.today()
-        val updatedRows = postDailyStatsRepository.decrementLikeCount(postId, today)
-        if (updatedRows == 0) {
-            createDailyStatsAndIncrement(postId, today) { id, date ->
-                postDailyStatsRepository.decrementLikeCount(id, date)
-            }
-        }
+    fun decrementLikeCount(
+        postId: UUID,
+        statDate: Date,
+    ) {
+        applyDailyStatsChange(postId, statDate, postDailyStatsRepository::decrementLikeCount)
     }
 
     /**
@@ -73,31 +63,52 @@ class PostDailyStatsService(
      *
      * @param postId 게시물 ID
      */
-    fun incrementCommentCount(postId: UUID) {
-        val today = DateUtils.today()
-        val updatedRows = postDailyStatsRepository.incrementCommentCount(postId, today)
-        if (updatedRows == 0) {
-            createDailyStatsAndIncrement(postId, today) { id, date ->
-                postDailyStatsRepository.incrementCommentCount(id, date)
-            }
+    fun incrementCommentCount(
+        postId: UUID,
+        statDate: Date,
+    ) {
+        applyDailyStatsChange(postId, statDate, postDailyStatsRepository::incrementCommentCount)
+    }
+
+    /**
+     * 지정한 일자의 댓글수를 원자적으로 1 감소시킵니다.
+     * 레코드가 없으면 생성 후 감소를 재시도하여 음수 값을 가질 수 있습니다.
+     *
+     * @param postId 게시물 ID
+     * @param statDate 통계 일자
+     */
+    fun decrementCommentCount(
+        postId: UUID,
+        statDate: Date,
+    ) {
+        applyDailyStatsChange(postId, statDate, postDailyStatsRepository::decrementCommentCount)
+    }
+
+    private fun applyDailyStatsChange(
+        postId: UUID,
+        statDate: Date,
+        changeFn: (UUID, Date) -> Int,
+    ) {
+        if (changeFn(postId, statDate) == 0) {
+            retryDailyStatsChangeAfterCreate(postId, statDate, changeFn)
         }
     }
 
     /**
-     * DailyStats 레코드를 생성하고 증분 쿼리를 재실행합니다.
-     * Unique Constraint 위반 시 (동시 insert) 증분 쿼리만 재실행합니다.
+     * DailyStats 레코드가 없으면 생성한 뒤 변경 쿼리를 다시 실행합니다.
+     * Unique Constraint 위반 시에는 레코드 생성만 건너뛰고 변경 쿼리만 재시도합니다.
      */
-    private fun createDailyStatsAndIncrement(
+    private fun retryDailyStatsChangeAfterCreate(
         postId: UUID,
-        statDate: LocalDate,
-        incrementFn: (UUID, LocalDate) -> Int,
+        statDate: Date,
+        changeFn: (UUID, Date) -> Int,
     ) {
         try {
             createDailyStats(postId, statDate)
         } catch (e: DataIntegrityViolationException) {
-            logger.debug("DailyStats 동시 생성 감지, 증분 재시도: postId={}", postId)
+            logger.debug("DailyStats 동시 생성 감지, 변경 쿼리 재시도: postId={}", postId)
         }
-        incrementFn(postId, statDate)
+        changeFn(postId, statDate)
     }
 
     /**
@@ -105,7 +116,7 @@ class PostDailyStatsService(
      */
     private fun createDailyStats(
         postId: UUID,
-        statDate: LocalDate,
+        statDate: Date,
     ) {
         val post = postRepository.getReferenceById(postId)
         val dailyStats = PostDailyStats(post = post, statDate = statDate)

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostLikeLogService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostLikeLogService.kt
@@ -50,10 +50,10 @@ class PostLikeLogService(
             }
 
         val existingLog = postLikeLogRepository.findByPostIdAndUserId(postId, userId)
-        val statDate = DateUtils.today()
 
         if (existingLog != null) {
             val previousIsLiked = existingLog.isLiked
+            val statDate = toStatDate(existingLog)
 
             when (likeStatus) {
                 LikeStatus.NONE -> {
@@ -65,18 +65,20 @@ class PostLikeLogService(
                     if (!previousIsLiked) {
                         // DISLIKE → LIKE: +2
                         existingLog.isLiked = true
-                        postLikeLogRepository.save(existingLog)
-                        updateLikeCount(postId, true, statDate)
-                        updateLikeCount(postId, true, statDate)
+                        val savedLog = postLikeLogRepository.save(existingLog)
+                        val updatedStatDate = toStatDate(savedLog)
+                        updateLikeCount(postId, true, updatedStatDate)
+                        updateLikeCount(postId, true, updatedStatDate)
                     }
                 }
                 LikeStatus.DISLIKE -> {
                     if (previousIsLiked) {
                         // LIKE → DISLIKE: -2
                         existingLog.isLiked = false
-                        postLikeLogRepository.save(existingLog)
-                        updateLikeCount(postId, false, statDate)
-                        updateLikeCount(postId, false, statDate)
+                        val savedLog = postLikeLogRepository.save(existingLog)
+                        val updatedStatDate = toStatDate(savedLog)
+                        updateLikeCount(postId, false, updatedStatDate)
+                        updateLikeCount(postId, false, updatedStatDate)
                     }
                 }
             }
@@ -84,12 +86,12 @@ class PostLikeLogService(
             when (likeStatus) {
                 LikeStatus.NONE -> { /* 이미 중립 상태, 무시 */ }
                 LikeStatus.LIKE -> {
-                    postLikeLogRepository.save(PostLikeLog(post = post, user = user, isLiked = true))
-                    updateLikeCount(postId, true, statDate)
+                    val savedLog = postLikeLogRepository.save(PostLikeLog(post = post, user = user, isLiked = true))
+                    updateLikeCount(postId, true, toStatDate(savedLog))
                 }
                 LikeStatus.DISLIKE -> {
-                    postLikeLogRepository.save(PostLikeLog(post = post, user = user, isLiked = false))
-                    updateLikeCount(postId, false, statDate)
+                    val savedLog = postLikeLogRepository.save(PostLikeLog(post = post, user = user, isLiked = false))
+                    updateLikeCount(postId, false, toStatDate(savedLog))
                 }
             }
         }
@@ -114,4 +116,6 @@ class PostLikeLogService(
             postDailyStatsService.decrementLikeCount(postId, statDate)
         }
     }
+
+    private fun toStatDate(log: PostLikeLog): java.sql.Date = DateUtils.toUtcDate(log.createdAt)
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostLikeLogService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostLikeLogService.kt
@@ -2,6 +2,7 @@ package com.techtaurant.mainserver.post.application
 
 import com.techtaurant.mainserver.common.enums.LikeStatus
 import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.common.util.DateUtils
 import com.techtaurant.mainserver.post.entity.PostLikeLog
 import com.techtaurant.mainserver.post.enums.PostStatus
 import com.techtaurant.mainserver.post.infrastructure.out.PostLikeLogRepository
@@ -49,6 +50,7 @@ class PostLikeLogService(
             }
 
         val existingLog = postLikeLogRepository.findByPostIdAndUserId(postId, userId)
+        val statDate = DateUtils.today()
 
         if (existingLog != null) {
             val previousIsLiked = existingLog.isLiked
@@ -57,15 +59,15 @@ class PostLikeLogService(
                 LikeStatus.NONE -> {
                     // 좋아요/싫어요 취소 → 로그 삭제, 카운트 복원
                     postLikeLogRepository.delete(existingLog)
-                    updateLikeCount(postId, !previousIsLiked)
+                    updateLikeCount(postId, !previousIsLiked, statDate)
                 }
                 LikeStatus.LIKE -> {
                     if (!previousIsLiked) {
                         // DISLIKE → LIKE: +2
                         existingLog.isLiked = true
                         postLikeLogRepository.save(existingLog)
-                        updateLikeCount(postId, true)
-                        updateLikeCount(postId, true)
+                        updateLikeCount(postId, true, statDate)
+                        updateLikeCount(postId, true, statDate)
                     }
                 }
                 LikeStatus.DISLIKE -> {
@@ -73,8 +75,8 @@ class PostLikeLogService(
                         // LIKE → DISLIKE: -2
                         existingLog.isLiked = false
                         postLikeLogRepository.save(existingLog)
-                        updateLikeCount(postId, false)
-                        updateLikeCount(postId, false)
+                        updateLikeCount(postId, false, statDate)
+                        updateLikeCount(postId, false, statDate)
                     }
                 }
             }
@@ -83,11 +85,11 @@ class PostLikeLogService(
                 LikeStatus.NONE -> { /* 이미 중립 상태, 무시 */ }
                 LikeStatus.LIKE -> {
                     postLikeLogRepository.save(PostLikeLog(post = post, user = user, isLiked = true))
-                    updateLikeCount(postId, true)
+                    updateLikeCount(postId, true, statDate)
                 }
                 LikeStatus.DISLIKE -> {
                     postLikeLogRepository.save(PostLikeLog(post = post, user = user, isLiked = false))
-                    updateLikeCount(postId, false)
+                    updateLikeCount(postId, false, statDate)
                 }
             }
         }
@@ -102,13 +104,14 @@ class PostLikeLogService(
     private fun updateLikeCount(
         postId: UUID,
         increment: Boolean,
+        statDate: java.sql.Date,
     ) {
         if (increment) {
             postRepository.incrementLikeCount(postId)
-            postDailyStatsService.incrementLikeCount(postId)
+            postDailyStatsService.incrementLikeCount(postId, statDate)
         } else {
             postRepository.decrementLikeCount(postId)
-            postDailyStatsService.decrementLikeCount(postId)
+            postDailyStatsService.decrementLikeCount(postId, statDate)
         }
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostViewLogService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostViewLogService.kt
@@ -1,6 +1,7 @@
 package com.techtaurant.mainserver.post.application
 
 import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.common.util.DateUtils
 import com.techtaurant.mainserver.post.entity.PostViewLog
 import com.techtaurant.mainserver.post.enums.PostStatus
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
@@ -56,9 +57,9 @@ class PostViewLogService(
                 userAgent = userAgent,
             )
 
-        postViewLogRepository.save(viewLog)
+        val savedViewLog = postViewLogRepository.save(viewLog)
 
         postRepository.incrementViewCount(postId)
-        postDailyStatsService.incrementViewCount(postId)
+        postDailyStatsService.incrementViewCount(postId, DateUtils.toUtcDate(savedViewLog.createdAt))
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/entity/PostDailyStats.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/entity/PostDailyStats.kt
@@ -2,16 +2,16 @@ package com.techtaurant.mainserver.post.entity
 
 import com.techtaurant.mainserver.common.base.EntityBase
 import jakarta.persistence.*
-import java.time.LocalDate
+import java.sql.Date
 
 /**
- * 일별 게시물 통계 엔티티 (이벤트 로그)
+ * 일별 게시물 통계 엔티티
  *
  * @property post 대상 게시물
  * @property statDate 통계 집계 일자
  * @property viewCount 해당 일자 조회 증분
- * @property likeCount 해당 일자 좋아요 증분
- * @property commentCount 해당 일자 댓글 증분
+ * @property likeCount 해당 일자 좋아요 증감
+ * @property commentCount 해당 일자 댓글 증감
  */
 @Entity
 @Table(
@@ -23,7 +23,7 @@ class PostDailyStats(
     @JoinColumn(name = "post_id", nullable = false)
     var post: Post,
     @Column(name = "stat_date", nullable = false)
-    var statDate: LocalDate,
+    var statDate: Date,
     @Column(name = "view_count", nullable = false)
     var viewCount: Long = 0,
     @Column(name = "like_count", nullable = false)

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostDailyStatsRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostDailyStatsRepository.kt
@@ -5,8 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
-import java.time.LocalDate
-import java.util.*
+import java.sql.Date
+import java.util.UUID
 
 interface PostDailyStatsRepository : JpaRepository<PostDailyStats, UUID> {
     /**
@@ -27,7 +27,7 @@ interface PostDailyStatsRepository : JpaRepository<PostDailyStats, UUID> {
     )
     fun incrementViewCount(
         @Param("postId") postId: UUID,
-        @Param("statDate") statDate: LocalDate,
+        @Param("statDate") statDate: Date,
     ): Int
 
     /**
@@ -48,7 +48,7 @@ interface PostDailyStatsRepository : JpaRepository<PostDailyStats, UUID> {
     )
     fun incrementLikeCount(
         @Param("postId") postId: UUID,
-        @Param("statDate") statDate: LocalDate,
+        @Param("statDate") statDate: Date,
     ): Int
 
     /**
@@ -70,7 +70,7 @@ interface PostDailyStatsRepository : JpaRepository<PostDailyStats, UUID> {
     )
     fun decrementLikeCount(
         @Param("postId") postId: UUID,
-        @Param("statDate") statDate: LocalDate,
+        @Param("statDate") statDate: Date,
     ): Int
 
     /**
@@ -91,6 +91,28 @@ interface PostDailyStatsRepository : JpaRepository<PostDailyStats, UUID> {
     )
     fun incrementCommentCount(
         @Param("postId") postId: UUID,
-        @Param("statDate") statDate: LocalDate,
+        @Param("statDate") statDate: Date,
+    ): Int
+
+    /**
+     * 특정 게시물의 일별 댓글수를 원자적으로 1 감소시킵니다.
+     * 날짜가 다른 경우(어제 작성 → 오늘 삭제) 음수 값을 가질 수 있습니다.
+     *
+     * @param postId 게시물 ID
+     * @param statDate 통계 날짜
+     * @return 업데이트된 행 수 (0이면 해당 날짜 레코드 미존재)
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(
+        """
+        UPDATE post_daily_stats
+        SET comment_count = comment_count - 1, updated_at = NOW()
+        WHERE post_id = :postId AND stat_date = :statDate
+        """,
+        nativeQuery = true,
+    )
+    fun decrementCommentCount(
+        @Param("postId") postId: UUID,
+        @Param("statDate") statDate: Date,
     ): Int
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepository.kt
@@ -176,7 +176,7 @@ interface PostRepository : JpaRepository<Post, UUID>, PostRepositoryCustom {
      * @param postId 댓글수를 감소시킬 게시물 ID
      */
     @Modifying(clearAutomatically = false, flushAutomatically = true)
-    @Query("UPDATE Post p SET p.commentCount = p.commentCount - 1 WHERE p.id = :postId")
+    @Query("UPDATE Post p SET p.commentCount = CASE WHEN p.commentCount > 0 THEN p.commentCount - 1 ELSE 0 END WHERE p.id = :postId")
     fun decrementCommentCount(
         @Param("postId") postId: UUID,
     )

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepository.kt
@@ -171,6 +171,17 @@ interface PostRepository : JpaRepository<Post, UUID>, PostRepositoryCustom {
     )
 
     /**
+     * 게시물의 댓글수를 원자적으로 1 감소시킵니다.
+     *
+     * @param postId 댓글수를 감소시킬 게시물 ID
+     */
+    @Modifying(clearAutomatically = false, flushAutomatically = true)
+    @Query("UPDATE Post p SET p.commentCount = p.commentCount - 1 WHERE p.id = :postId")
+    fun decrementCommentCount(
+        @Param("postId") postId: UUID,
+    )
+
+    /**
      * 특정 사용자의 2주 이상 경과한 DRAFT 게시물 목록을 조회합니다.
      *
      * @param authorId 작성자 ID

--- a/src/test/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteServiceTest.kt
@@ -10,6 +10,7 @@ import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.enums.PostStatus
 import com.techtaurant.mainserver.post.infrastructure.out.CategoryRepository
+import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.user.entity.User
@@ -48,6 +49,9 @@ class CommentWriteServiceTest : IntegrationTest() {
 
     @Autowired
     private lateinit var entityManager: EntityManager
+
+    @Autowired
+    private lateinit var postDailyStatsRepository: PostDailyStatsRepository
 
     private lateinit var testUser: User
     private lateinit var testPost: Post
@@ -198,8 +202,42 @@ class CommentWriteServiceTest : IntegrationTest() {
 
         // Then
         val savedComment = commentRepository.findById(response.id).orElseThrow()
+        val updatedParentComment = commentRepository.findById(parentComment.id!!).orElseThrow()
         assertThat(savedComment.depth).isEqualTo(1)
         assertThat(savedComment.parent?.id).isEqualTo(parentComment.id)
+        assertThat(updatedParentComment.replyCount).isEqualTo(1)
+    }
+
+    @Test
+    @DisplayName("대댓글 작성 시 게시물 일별 댓글 통계가 1 증가한다")
+    fun createReply_incrementsPostDailyCommentCount() {
+        // Given
+        val parentComment =
+            commentRepository.save(
+                Comment(
+                    content = "부모 댓글",
+                    post = testPost,
+                    author = testUser,
+                    parent = null,
+                    depth = 0,
+                ),
+            )
+        val request =
+            CreateCommentRequest(
+                postId = testPost.id!!,
+                content = "대댓글입니다",
+                parentId = parentComment.id,
+            )
+
+        // When
+        commentWriteService.createComment(testUser.id!!, request)
+        entityManager.flush()
+        entityManager.clear()
+
+        // Then
+        val dailyStats = postDailyStatsRepository.findAll().single()
+        assertThat(dailyStats.post.id).isEqualTo(testPost.id)
+        assertThat(dailyStats.commentCount).isEqualTo(1)
     }
 
     @Test

--- a/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentDeleteIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentDeleteIntegrationTest.kt
@@ -135,6 +135,35 @@ class CommentDeleteIntegrationTest : IntegrationTest() {
     }
 
     @Test
+    @DisplayName("대댓글 삭제 시 드리프트가 있어도 부모 replyCount와 게시물 commentCount는 0 미만으로 내려가지 않는다")
+    fun deleteReply_shouldNotMakePublicCountersNegative() {
+        // given
+        val parentComment = createComment(author, "부모 댓글", replyCount = 0)
+        val replyComment = createComment(author, "대댓글", parent = parentComment)
+        val statDate = DateUtils.toUtcDate(replyComment.createdAt)
+        post.commentCount = 0
+        postRepository.save(post)
+
+        // when
+        given()
+            .header("Authorization", "Bearer $authorAccessToken")
+            .`when`()
+            .delete("/api/comments/${replyComment.id}")
+            .then()
+            .statusCode(HttpStatus.NO_CONTENT.value())
+
+        // then
+        val updatedParent = commentRepository.findById(parentComment.id!!).orElseThrow()
+        val updatedPost = postRepository.findById(post.id!!).orElseThrow()
+        val dailyStats =
+            postDailyStatsRepository.findAll()
+                .single { it.post.id == post.id && it.statDate.toString() == statDate.toString() }
+        assertThat(updatedParent.replyCount).isZero()
+        assertThat(updatedPost.commentCount).isZero()
+        assertThat(dailyStats.commentCount).isEqualTo(-1)
+    }
+
+    @Test
     @DisplayName("댓글 삭제 실패 - 작성자가 아니면 403과 COMMENT_AUTHOR_MISMATCH를 반환한다")
     fun deleteComment_withAnotherUser_shouldReturnForbidden() {
         // given

--- a/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentDeleteIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentDeleteIntegrationTest.kt
@@ -3,9 +3,11 @@ package com.techtaurant.mainserver.comment.infrastructure.`in`
 import com.techtaurant.mainserver.base.IntegrationTest
 import com.techtaurant.mainserver.comment.entity.Comment
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepository
+import com.techtaurant.mainserver.common.util.DateUtils
 import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.infrastructure.out.CategoryRepository
+import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
@@ -40,6 +42,9 @@ class CommentDeleteIntegrationTest : IntegrationTest() {
     @Autowired
     private lateinit var jwtTokenProvider: JwtTokenProvider
 
+    @Autowired
+    private lateinit var postDailyStatsRepository: PostDailyStatsRepository
+
     private lateinit var author: User
     private lateinit var otherUser: User
     private lateinit var post: Post
@@ -68,6 +73,7 @@ class CommentDeleteIntegrationTest : IntegrationTest() {
                     content = "테스트 게시물 내용",
                     author = author,
                     category = category,
+                    commentCount = 1,
                 ),
             )
 
@@ -92,9 +98,40 @@ class CommentDeleteIntegrationTest : IntegrationTest() {
 
         // then
         val deletedComment = commentRepository.findById(comment.id!!).orElseThrow()
+        val updatedPost = postRepository.findById(post.id!!).orElseThrow()
         assertThat(deletedComment.deletedAt).isNotNull()
         assertThat(deletedComment.content).isEqualTo(sha256(originalContent))
+        assertThat(updatedPost.commentCount).isZero()
         assertThat(commentRepository.findByPostIdOrderByCreatedAtAsc(post.id!!)).isEmpty()
+    }
+
+    @Test
+    @DisplayName("대댓글 삭제 성공 - 부모 댓글 replyCount와 게시물 댓글수 및 일별 댓글 통계가 함께 감소한다")
+    fun deleteReply_shouldDecreaseParentReplyCountAndDailyCommentCount() {
+        // given
+        val parentComment = createComment(author, "부모 댓글", replyCount = 1)
+        val replyComment = createComment(author, "대댓글", parent = parentComment)
+        val statDate = DateUtils.toUtcDate(replyComment.createdAt)
+        post.commentCount = 2
+        postRepository.save(post)
+
+        // when
+        given()
+            .header("Authorization", "Bearer $authorAccessToken")
+            .`when`()
+            .delete("/api/comments/${replyComment.id}")
+            .then()
+            .statusCode(HttpStatus.NO_CONTENT.value())
+
+        // then
+        val updatedParent = commentRepository.findById(parentComment.id!!).orElseThrow()
+        val updatedPost = postRepository.findById(post.id!!).orElseThrow()
+        val dailyStats =
+            postDailyStatsRepository.findAll()
+                .single { it.post.id == post.id && it.statDate.toString() == statDate.toString() }
+        assertThat(updatedParent.replyCount).isZero()
+        assertThat(updatedPost.commentCount).isEqualTo(1)
+        assertThat(dailyStats.commentCount).isEqualTo(-1)
     }
 
     @Test
@@ -176,12 +213,17 @@ class CommentDeleteIntegrationTest : IntegrationTest() {
     private fun createComment(
         author: User,
         content: String,
+        parent: Comment? = null,
+        replyCount: Long = 0,
     ): Comment {
         return commentRepository.save(
             Comment(
                 content = content,
                 post = post,
                 author = author,
+                parent = parent,
+                depth = if (parent == null) 0 else 1,
+                replyCount = replyCount,
             ),
         )
     }

--- a/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/out/CommentRepositoryTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/out/CommentRepositoryTest.kt
@@ -1,0 +1,119 @@
+package com.techtaurant.mainserver.comment.infrastructure.out
+
+import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.comment.entity.Comment
+import com.techtaurant.mainserver.post.entity.Category
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.infrastructure.out.CategoryRepository
+import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@ActiveProfiles("test")
+class CommentRepositoryTest : IntegrationTest() {
+    @Autowired
+    private lateinit var commentRepository: CommentRepository
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var categoryRepository: CategoryRepository
+
+    @Autowired
+    private lateinit var entityManager: EntityManager
+
+    private lateinit var testUser: User
+    private lateinit var testPost: Post
+
+    @BeforeEach
+    fun setUpTestData() {
+        testUser =
+            userRepository.save(
+                User(
+                    name = "테스트 사용자",
+                    email = "comment-repository-${java.util.UUID.randomUUID()}@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "comment-repository-${java.util.UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/profile.jpg",
+                ),
+            )
+
+        val category =
+            categoryRepository.save(
+                Category(
+                    user = testUser,
+                    name = "댓글 테스트 카테고리",
+                    path = "댓글-테스트-${java.util.UUID.randomUUID()}",
+                    depth = 1,
+                ),
+            )
+
+        testPost =
+            postRepository.save(
+                Post(
+                    title = "댓글 테스트 게시물",
+                    content = "댓글 테스트 내용",
+                    author = testUser,
+                    category = category,
+                ),
+            )
+    }
+
+    @Test
+    @DisplayName("decrementReplyCount는 replyCount가 0이어도 음수로 만들지 않는다")
+    fun decrementReplyCount_whenCountIsZero_shouldRemainZero() {
+        // Given
+        val parentComment = createComment(replyCount = 0)
+
+        // When
+        commentRepository.decrementReplyCount(parentComment.id!!)
+        commentRepository.flush()
+        entityManager.clear()
+
+        // Then
+        val updatedComment = commentRepository.findById(parentComment.id!!).orElseThrow()
+        assertThat(updatedComment.replyCount).isZero()
+    }
+
+    @Test
+    @DisplayName("decrementReplyCount는 replyCount를 1 감소시킨다")
+    fun decrementReplyCount_whenCountIsPositive_shouldDecreaseByOne() {
+        // Given
+        val parentComment = createComment(replyCount = 2)
+
+        // When
+        commentRepository.decrementReplyCount(parentComment.id!!)
+        commentRepository.flush()
+        entityManager.clear()
+
+        // Then
+        val updatedComment = commentRepository.findById(parentComment.id!!).orElseThrow()
+        assertThat(updatedComment.replyCount).isEqualTo(1)
+    }
+
+    private fun createComment(replyCount: Long): Comment =
+        commentRepository.save(
+            Comment(
+                content = "부모 댓글",
+                post = testPost,
+                author = testUser,
+                replyCount = replyCount,
+            ),
+        )
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostDailyStatsServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostDailyStatsServiceTest.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
+import java.sql.Date
 
 @DisplayName("PostDailyStatsService 통합 테스트")
 @Transactional
@@ -45,14 +46,14 @@ class PostDailyStatsServiceTest : IntegrationTest() {
         val today = DateUtils.today()
 
         // when
-        postDailyStatsService.incrementViewCount(post.id!!)
+        postDailyStatsService.incrementViewCount(post.id!!, today)
         entityManager.flush()
         entityManager.clear()
 
         // then
         val dailyStats =
             postDailyStatsRepository.findAll()
-                .find { it.post.id == post.id && it.statDate == today }
+                .find { it.post.id == post.id && isSameUtcDate(it.statDate, today) }
         assertThat(dailyStats).isNotNull
         assertThat(dailyStats?.viewCount).isEqualTo(1)
     }
@@ -66,14 +67,14 @@ class PostDailyStatsServiceTest : IntegrationTest() {
         val today = DateUtils.today()
 
         // when
-        postDailyStatsService.incrementLikeCount(post.id!!)
+        postDailyStatsService.incrementLikeCount(post.id!!, today)
         entityManager.flush()
         entityManager.clear()
 
         // then
         val dailyStats =
             postDailyStatsRepository.findAll()
-                .find { it.post.id == post.id && it.statDate == today }
+                .find { it.post.id == post.id && isSameUtcDate(it.statDate, today) }
         assertThat(dailyStats).isNotNull
         assertThat(dailyStats?.likeCount).isEqualTo(1)
     }
@@ -87,14 +88,14 @@ class PostDailyStatsServiceTest : IntegrationTest() {
         val today = DateUtils.today()
 
         // when
-        postDailyStatsService.decrementLikeCount(post.id!!)
+        postDailyStatsService.decrementLikeCount(post.id!!, today)
         entityManager.flush()
         entityManager.clear()
 
         // then
         val dailyStats =
             postDailyStatsRepository.findAll()
-                .find { it.post.id == post.id && it.statDate == today }
+                .find { it.post.id == post.id && isSameUtcDate(it.statDate, today) }
         assertThat(dailyStats).isNotNull
         assertThat(dailyStats?.likeCount).isEqualTo(-1)
     }
@@ -109,14 +110,14 @@ class PostDailyStatsServiceTest : IntegrationTest() {
         createDailyStats(post, today, viewCount = 5)
 
         // when
-        postDailyStatsService.incrementViewCount(post.id!!)
+        postDailyStatsService.incrementViewCount(post.id!!, today)
         entityManager.flush()
         entityManager.clear()
 
         // then
         val dailyStats =
             postDailyStatsRepository.findAll()
-                .find { it.post.id == post.id && it.statDate == today }
+                .find { it.post.id == post.id && isSameUtcDate(it.statDate, today) }
         assertThat(dailyStats?.viewCount).isEqualTo(6)
     }
 
@@ -130,14 +131,14 @@ class PostDailyStatsServiceTest : IntegrationTest() {
         createDailyStats(post, today, likeCount = 3)
 
         // when
-        postDailyStatsService.incrementLikeCount(post.id!!)
+        postDailyStatsService.incrementLikeCount(post.id!!, today)
         entityManager.flush()
         entityManager.clear()
 
         // then
         val dailyStats =
             postDailyStatsRepository.findAll()
-                .find { it.post.id == post.id && it.statDate == today }
+                .find { it.post.id == post.id && isSameUtcDate(it.statDate, today) }
         assertThat(dailyStats?.likeCount).isEqualTo(4)
     }
 
@@ -151,14 +152,14 @@ class PostDailyStatsServiceTest : IntegrationTest() {
         createDailyStats(post, today, likeCount = 5)
 
         // when
-        postDailyStatsService.decrementLikeCount(post.id!!)
+        postDailyStatsService.decrementLikeCount(post.id!!, today)
         entityManager.flush()
         entityManager.clear()
 
         // then
         val dailyStats =
             postDailyStatsRepository.findAll()
-                .find { it.post.id == post.id && it.statDate == today }
+                .find { it.post.id == post.id && isSameUtcDate(it.statDate, today) }
         assertThat(dailyStats?.likeCount).isEqualTo(4)
     }
 
@@ -172,14 +173,14 @@ class PostDailyStatsServiceTest : IntegrationTest() {
         createDailyStats(post, today, likeCount = 0)
 
         // when
-        postDailyStatsService.decrementLikeCount(post.id!!)
+        postDailyStatsService.decrementLikeCount(post.id!!, today)
         entityManager.flush()
         entityManager.clear()
 
         // then
         val dailyStats =
             postDailyStatsRepository.findAll()
-                .find { it.post.id == post.id && it.statDate == today }
+                .find { it.post.id == post.id && isSameUtcDate(it.statDate, today) }
         assertThat(dailyStats?.likeCount).isEqualTo(-1)
     }
 
@@ -192,15 +193,78 @@ class PostDailyStatsServiceTest : IntegrationTest() {
         val today = DateUtils.today()
 
         // when
-        postDailyStatsService.incrementCommentCount(post.id!!)
+        postDailyStatsService.incrementCommentCount(post.id!!, today)
         entityManager.flush()
         entityManager.clear()
 
         // then
         val dailyStats =
             postDailyStatsRepository.findAll()
-                .find { it.post.id == post.id && it.statDate == today }
+                .find { it.post.id == post.id && isSameUtcDate(it.statDate, today) }
         assertThat(dailyStats).isNotNull
+        assertThat(dailyStats?.commentCount).isEqualTo(1)
+    }
+
+    @Test
+    @DisplayName("댓글수 감소 시 레코드가 없으면 생성되고 -1이 된다")
+    fun decrementCommentCount_whenNoRecord_shouldCreateRecordWithCountMinus1() {
+        // given
+        val user = createAndSaveUser("comment-decrement-no-record@example.com")
+        val post = createAndSavePost("댓글 감소 테스트 게시글", user)
+        val today = DateUtils.today()
+
+        // when
+        postDailyStatsService.decrementCommentCount(post.id!!, today)
+        entityManager.flush()
+        entityManager.clear()
+
+        // then
+        val dailyStats =
+            postDailyStatsRepository.findAll()
+                .find { it.post.id == post.id && isSameUtcDate(it.statDate, today) }
+        assertThat(dailyStats).isNotNull
+        assertThat(dailyStats?.commentCount).isEqualTo(-1)
+    }
+
+    @Test
+    @DisplayName("댓글수 감소 시 레코드가 있으면 기존 값에서 1이 감소한다")
+    fun decrementCommentCount_whenRecordExists_shouldDecrementExistingValue() {
+        // given
+        val user = createAndSaveUser("comment-decrement-record@example.com")
+        val post = createAndSavePost("댓글 감소 테스트 게시글", user)
+        val today = DateUtils.today()
+        createDailyStats(post, today, commentCount = 3)
+
+        // when
+        postDailyStatsService.decrementCommentCount(post.id!!, today)
+        entityManager.flush()
+        entityManager.clear()
+
+        // then
+        val dailyStats =
+            postDailyStatsRepository.findAll()
+                .find { it.post.id == post.id && isSameUtcDate(it.statDate, today) }
+        assertThat(dailyStats?.commentCount).isEqualTo(2)
+    }
+
+    @Test
+    @DisplayName("댓글수 감소 시 지정한 통계 일자를 기준으로 감소한다")
+    fun decrementCommentCount_withSpecificDate_shouldUseProvidedStatDate() {
+        // given
+        val user = createAndSaveUser("comment-decrement-date@example.com")
+        val post = createAndSavePost("댓글 날짜별 감소 테스트 게시글", user)
+        val statDate = Date.valueOf("2026-03-01")
+        createDailyStats(post, statDate, commentCount = 2)
+
+        // when
+        postDailyStatsService.decrementCommentCount(post.id!!, statDate)
+        entityManager.flush()
+        entityManager.clear()
+
+        // then
+        val dailyStats =
+            postDailyStatsRepository.findAll()
+                .find { it.post.id == post.id && isSameUtcDate(it.statDate, statDate) }
         assertThat(dailyStats?.commentCount).isEqualTo(1)
     }
 
@@ -233,7 +297,7 @@ class PostDailyStatsServiceTest : IntegrationTest() {
 
     private fun createDailyStats(
         post: Post,
-        statDate: java.time.LocalDate,
+        statDate: Date,
         viewCount: Long = 0,
         likeCount: Long = 0,
         commentCount: Long = 0,
@@ -248,4 +312,9 @@ class PostDailyStatsServiceTest : IntegrationTest() {
             )
         return postDailyStatsRepository.save(dailyStats)
     }
+
+    private fun isSameUtcDate(
+        actual: Date,
+        expected: Date,
+    ): Boolean = actual.toString() == expected.toString()
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostLikeLogServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostLikeLogServiceTest.kt
@@ -3,10 +3,12 @@ package com.techtaurant.mainserver.post.application
 import com.techtaurant.mainserver.base.IntegrationTest
 import com.techtaurant.mainserver.common.enums.LikeStatus
 import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.common.util.DateUtils
 import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.enums.PostStatus
 import com.techtaurant.mainserver.post.infrastructure.out.CategoryRepository
+import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostLikeLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
@@ -22,6 +24,9 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
+import java.sql.Date
+import java.sql.Timestamp
+import java.time.LocalDateTime
 import java.util.UUID
 
 /**
@@ -41,6 +46,9 @@ class PostLikeLogServiceTest : IntegrationTest() {
 
     @Autowired
     private lateinit var postLikeLogRepository: PostLikeLogRepository
+
+    @Autowired
+    private lateinit var postDailyStatsRepository: PostDailyStatsRepository
 
     @Autowired
     private lateinit var userRepository: UserRepository
@@ -293,4 +301,44 @@ class PostLikeLogServiceTest : IntegrationTest() {
         val log2 = postLikeLogRepository.findByPostIdAndUserId(testPost.id!!, anotherUser.id!!)
         assertThat(log2?.isLiked).isFalse()
     }
+
+    @Test
+    @DisplayName("좋아요 취소 시 일별 통계는 기존 로그 createdAt 기준 날짜를 사용한다")
+    fun recordLike_cancelShouldUseExistingLogCreatedAtForDailyStats() {
+        // Given - 좋아요 로그 생성
+        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, LikeStatus.LIKE)
+        entityManager.flush()
+        entityManager.clear()
+
+        val savedLog = postLikeLogRepository.findByPostIdAndUserId(testPost.id!!, testUser.id!!)
+        val targetCreatedAt = Timestamp.valueOf(LocalDateTime.of(2026, 3, 1, 12, 0, 0))
+        updateLogCreatedAt(savedLog!!.id!!, targetCreatedAt)
+        entityManager.clear()
+
+        // When - 중립 상태로 되돌리기
+        postLikeLogService.recordLike(testPost.id!!, testUser.id!!, LikeStatus.NONE)
+        entityManager.flush()
+        entityManager.clear()
+
+        // Then - 취소 통계가 기존 로그 생성일 버킷에 반영됨
+        val targetStatDate = DateUtils.toUtcDate(Date(targetCreatedAt.time))
+        val targetDailyStats = findDailyStats(targetStatDate)
+        assertThat(targetDailyStats).isNotNull
+        assertThat(targetDailyStats?.likeCount).isEqualTo(-1)
+    }
+
+    private fun updateLogCreatedAt(
+        logId: UUID,
+        createdAt: Timestamp,
+    ) {
+        entityManager.createNativeQuery("UPDATE post_like_log SET created_at = :createdAt, updated_at = :createdAt WHERE id = :logId")
+            .setParameter("createdAt", createdAt)
+            .setParameter("logId", logId)
+            .executeUpdate()
+        entityManager.flush()
+    }
+
+    private fun findDailyStats(statDate: Date) =
+        postDailyStatsRepository.findAll()
+            .find { it.post.id == testPost.id && it.statDate.toString() == statDate.toString() }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryTest.kt
@@ -206,4 +206,20 @@ class PostRepositoryTest : IntegrationTest() {
         val updatedPost = postRepository.findById(testPost.id!!).orElseThrow()
         assertThat(updatedPost.commentCount).isEqualTo(1)
     }
+
+    @Test
+    @DisplayName("decrementCommentCount는 commentCount가 0이어도 음수로 만들지 않는다")
+    fun decrementCommentCount_whenCountIsZero_shouldRemainZero() {
+        // Given
+        assertThat(testPost.commentCount).isZero()
+
+        // When
+        postRepository.decrementCommentCount(testPost.id!!)
+        postRepository.flush()
+        entityManager.clear()
+
+        // Then
+        val updatedPost = postRepository.findById(testPost.id!!).orElseThrow()
+        assertThat(updatedPost.commentCount).isZero()
+    }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryTest.kt
@@ -181,4 +181,29 @@ class PostRepositoryTest : IntegrationTest() {
         val unchangedPost = postRepository.findById(testPost.id!!).orElseThrow()
         assertThat(unchangedPost.commentCount).isEqualTo(0)
     }
+
+    @Test
+    @DisplayName("decrementCommentCount는 게시물의 commentCount를 1 감소시킨다")
+    fun decrementCommentCount_decreasesCountByOne() {
+        // Given
+        testPost =
+            postRepository.save(
+                Post(
+                    title = "댓글이 있는 게시물",
+                    content = "이미 댓글이 2개 있음",
+                    author = testUser,
+                    category = testCategory,
+                    commentCount = 2,
+                ),
+            )
+
+        // When
+        postRepository.decrementCommentCount(testPost.id!!)
+        postRepository.flush()
+        entityManager.clear()
+
+        // Then
+        val updatedPost = postRepository.findById(testPost.id!!).orElseThrow()
+        assertThat(updatedPost.commentCount).isEqualTo(1)
+    }
 }


### PR DESCRIPTION
## Summary
- 댓글 작성/삭제 시 게시물 댓글 수, 대댓글 수, 일별 댓글 통계가 함께 갱신되도록 정리했습니다.
- `PostDailyStatsService`가 외부에서 주입받은 UTC 날짜 기준으로 일관되게 증감하도록 리팩터링했습니다.
- 댓글 삭제/일별 통계 관련 통합 테스트와 저장소 테스트를 보강했습니다.