### PR TITLE
modify(post): 카테고리 게시물 수 집계를 하위 카테고리까지 확장

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/CategoryResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/CategoryResponse.kt
@@ -13,7 +13,7 @@ import java.util.UUID
  * @property path 전체 경로 (예: "java/spring/deepdive")
  * @property depth 현재 depth (1~5)
  * @property parentId 부모 카테고리 ID (최상위 카테고리인 경우 null)
- * @property postCount 카테고리에 직접 연결된 게시물 개수
+ * @property postCount 카테고리 자신과 하위 카테고리에 속한 게시물 개수
  */
 @Schema(description = "카테고리 응답")
 data class CategoryResponse(
@@ -27,7 +27,7 @@ data class CategoryResponse(
     val depth: Int,
     @Schema(description = "부모 카테고리 ID (최상위인 경우 null)")
     val parentId: UUID?,
-    @Schema(description = "카테고리에 직접 연결된 게시물 개수", example = "3")
+    @Schema(description = "카테고리 자신과 하위 카테고리에 속한 게시물 개수", example = "3")
     val postCount: Long,
 ) {
     companion object {

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/CategoryReadControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/CategoryReadControllerDocs.kt
@@ -18,7 +18,7 @@ interface CategoryReadControllerDocs {
         description =
             "특정 유저의 카테고리를 path prefix로 검색합니다. " +
                 "해당 경로로 시작하는 모든 카테고리를 반환하며, " +
-                "각 카테고리의 직접 연결 게시물 개수도 함께 제공합니다. " +
+                "각 카테고리와 그 하위 카테고리에 속한 게시물 개수도 함께 제공합니다. " +
                 "path가 없으면 전체 카테고리를 반환합니다.",
     )
     @SwaggerApiResponse(

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/CategoryRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/CategoryRepository.kt
@@ -41,14 +41,17 @@ interface CategoryRepository : JpaRepository<Category, UUID> {
 
     /**
      * 유저의 전체 카테고리를 게시물 수와 함께 조회
-     * LEFT JOIN으로 단일 쿼리에서 카테고리와 게시물 수를 함께 집계
+     * 각 카테고리 자신과 하위 카테고리에 속한 게시물 수를 함께 집계한다.
      */
     @Query(
         value = """
             SELECT c.id, c.name, c.path, c.depth, c.parent_id as parentId,
-                   COALESCE(COUNT(p.id), 0) as postCount
+                   COALESCE(COUNT(DISTINCT p.id), 0) as postCount
             FROM categories c
-            LEFT JOIN posts p ON p.category_id = c.id
+            LEFT JOIN categories descendant
+                ON descendant.user_id = c.user_id
+               AND (descendant.path = c.path OR descendant.path LIKE c.path || '/%')
+            LEFT JOIN posts p ON p.category_id = descendant.id
             WHERE c.user_id = :userId
             GROUP BY c.id, c.name, c.path, c.depth, c.parent_id
             ORDER BY c.depth ASC, c.name ASC
@@ -61,14 +64,17 @@ interface CategoryRepository : JpaRepository<Category, UUID> {
 
     /**
      * 유저의 특정 path prefix로 시작하는 카테고리를 게시물 수와 함께 조회
-     * LEFT JOIN으로 단일 쿼리에서 카테고리와 게시물 수를 함께 집계
+     * 각 카테고리 자신과 하위 카테고리에 속한 게시물 수를 함께 집계한다.
      */
     @Query(
         value = """
             SELECT c.id, c.name, c.path, c.depth, c.parent_id as parentId,
-                   COALESCE(COUNT(p.id), 0) as postCount
+                   COALESCE(COUNT(DISTINCT p.id), 0) as postCount
             FROM categories c
-            LEFT JOIN posts p ON p.category_id = c.id
+            LEFT JOIN categories descendant
+                ON descendant.user_id = c.user_id
+               AND (descendant.path = c.path OR descendant.path LIKE c.path || '/%')
+            LEFT JOIN posts p ON p.category_id = descendant.id
             WHERE c.user_id = :userId
               AND c.path LIKE :pathPrefix || '%'
             GROUP BY c.id, c.name, c.path, c.depth, c.parent_id

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/CategoryReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/CategoryReadServiceTest.kt
@@ -59,14 +59,14 @@ class CategoryReadServiceTest {
     @DisplayName("searchByPath")
     inner class SearchByPath {
         @Test
-        @DisplayName("카테고리별 게시물 개수를 함께 반환한다")
+        @DisplayName("카테고리별 누적 게시물 개수를 함께 반환한다")
         fun searchByPath_returnsCategoriesWithPostCounts() {
             // given
             val rootId = UUID.randomUUID()
             val childId = UUID.randomUUID()
             every { categoryRepository.findByUserIdAndPathPrefixWithPostCount(user.id!!, "java") } returns
                 listOf(
-                    createProjection(rootId, "java", "java", 1, null, 2L),
+                    createProjection(rootId, "java", "java", 1, null, 7L),
                     createProjection(childId, "spring", "java/spring", 2, rootId, 5L),
                 )
 
@@ -76,7 +76,7 @@ class CategoryReadServiceTest {
             // then
             assertThat(result).hasSize(2)
             assertThat(result[0].id).isEqualTo(rootId)
-            assertThat(result[0].postCount).isEqualTo(2L)
+            assertThat(result[0].postCount).isEqualTo(7L)
             assertThat(result[1].id).isEqualTo(childId)
             assertThat(result[1].parentId).isEqualTo(rootId)
             assertThat(result[1].postCount).isEqualTo(5L)

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/CategoryRepositoryTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/CategoryRepositoryTest.kt
@@ -86,13 +86,14 @@ class CategoryRepositoryTest : IntegrationTest() {
     @DisplayName("findByUserIdWithPostCount")
     inner class FindByUserIdWithPostCount {
         @Test
-        @DisplayName("게시물이 있는 카테고리와 없는 카테고리 모두 반환하고 게시물 수를 정확히 집계한다")
+        @DisplayName("게시물이 있는 카테고리와 없는 카테고리 모두 반환하고 하위 카테고리까지 포함해 게시물 수를 집계한다")
         fun findByUserIdWithPostCount_returnsAllCategoriesWithAccuratePostCounts() {
             // given
             val javaCategory = createCategory(testUser, "java", "java", 1)
+            val springCategory = createCategory(testUser, "spring", "java/spring", 2, javaCategory)
             val kotlinCategory = createCategory(testUser, "kotlin", "kotlin", 1)
-            createPost(javaCategory, "java 게시물 1")
-            createPost(javaCategory, "java 게시물 2")
+            createPost(springCategory, "spring 게시물 1")
+            createPost(springCategory, "spring 게시물 2")
             postRepository.flush()
             entityManager.clear()
 
@@ -102,9 +103,10 @@ class CategoryRepositoryTest : IntegrationTest() {
                     .associateBy { it.getId() }
 
             // then
-            assertThat(result).hasSize(2)
+            assertThat(result).hasSize(3)
             assertThat(result[javaCategory.id!!]!!.getPostCount()).isEqualTo(2L)
             assertThat(result[kotlinCategory.id!!]!!.getPostCount()).isZero()
+            assertThat(result[springCategory.id!!]!!.getPostCount()).isEqualTo(2L)
         }
 
         @Test
@@ -219,7 +221,7 @@ class CategoryRepositoryTest : IntegrationTest() {
             // then
             assertThat(result).hasSize(2)
             assertThat(result).containsOnlyKeys(javaCategory.id!!, springCategory.id!!)
-            assertThat(result[javaCategory.id!!]!!.getPostCount()).isEqualTo(1L)
+            assertThat(result[javaCategory.id!!]!!.getPostCount()).isEqualTo(3L)
             assertThat(result[springCategory.id!!]!!.getPostCount()).isEqualTo(2L)
         }
 
@@ -252,6 +254,30 @@ class CategoryRepositoryTest : IntegrationTest() {
             // then
             assertThat(result).hasSize(1)
             assertThat(result[0].getPostCount()).isZero()
+        }
+
+        @Test
+        @DisplayName("상위 카테고리의 게시물 수는 하위 카테고리 게시물까지 포함한다")
+        fun findByUserIdAndPathPrefixWithPostCount_includesDescendantPostsInParentCount() {
+            // given
+            val backendCategory = createCategory(testUser, "backend", "backend", 1)
+            val javaCategory = createCategory(testUser, "java", "backend/java", 2, backendCategory)
+            val springCategory = createCategory(testUser, "spring", "backend/java/spring", 3, javaCategory)
+            createPost(springCategory, "spring 게시물 1")
+            createPost(springCategory, "spring 게시물 2")
+            createPost(javaCategory, "java 게시물 1")
+            postRepository.flush()
+            entityManager.clear()
+
+            // when
+            val result =
+                categoryRepository.findByUserIdAndPathPrefixWithPostCount(testUser.id!!, "backend")
+                    .associateBy { it.getId() }
+
+            // then
+            assertThat(result[backendCategory.id!!]!!.getPostCount()).isEqualTo(3L)
+            assertThat(result[javaCategory.id!!]!!.getPostCount()).isEqualTo(3L)
+            assertThat(result[springCategory.id!!]!!.getPostCount()).isEqualTo(2L)
         }
     }
 }


### PR DESCRIPTION
## Summary
- 카테고리 조회 시 `postCount`가 자기 자신과 하위 카테고리 게시물까지 누적 집계되도록 변경했습니다.
- 카테고리 응답 DTO와 Swagger 설명을 누적 집계 기준에 맞게 정리했습니다.
- 저장소/서비스 테스트를 보강해 상위 카테고리 합산 count 동작을 검증했습니다.

## Test
- `./gradlew test --tests 'com.techtaurant.mainserver.post.application.CategoryReadServiceTest' --tests 'com.techtaurant.mainserver.post.infrastructure.out.CategoryRepositoryTest' -x jacocoTestReport -x jacocoTestCoverageVerification`