### PR TITLE
fix(post): 본문 포함 attachmentId만 첨부로 확정

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -92,10 +92,11 @@ class PostWriteService(
         val savedPost = postRepository.save(post)
 
         if (status != PostStatusEnum.DRAFT) {
+            val attachmentIds = filterAttachmentIdsIncludedInContent(savedPost.content, request.attachmentIds)
             attachmentService.confirmAttachmentsByIds(
                 referenceId = savedPost.id!!,
                 referenceType = AttachmentReferenceType.POST,
-                attachmentIds = request.attachmentIds.orEmpty().distinct(),
+                attachmentIds = attachmentIds,
             )
         }
 
@@ -144,20 +145,18 @@ class PostWriteService(
 
         val newStatus = request.status ?: post.status
         if (newStatus != PostStatusEnum.DRAFT) {
-            request.attachmentIds?.let { attachmentIds ->
-                val distinctAttachmentIds = attachmentIds.distinct()
-                attachmentService.confirmAttachmentsByIds(
-                    referenceId = postId,
-                    referenceType = AttachmentReferenceType.POST,
-                    attachmentIds = distinctAttachmentIds,
-                )
+            val attachmentIds = filterAttachmentIdsIncludedInContent(savedPost.content, request.attachmentIds)
+            attachmentService.confirmAttachmentsByIds(
+                referenceId = postId,
+                referenceType = AttachmentReferenceType.POST,
+                attachmentIds = attachmentIds,
+            )
 
-                attachmentService.deleteOrphanedAttachmentsByIds(
-                    referenceId = postId,
-                    referenceType = AttachmentReferenceType.POST,
-                    keepAttachmentIds = distinctAttachmentIds,
-                )
-            }
+            attachmentService.deleteOrphanedAttachmentsByIds(
+                referenceId = postId,
+                referenceType = AttachmentReferenceType.POST,
+                keepAttachmentIds = attachmentIds,
+            )
         }
 
         return PostResponse.from(savedPost)
@@ -193,6 +192,17 @@ class PostWriteService(
             ApiException(UserStatus.ID_NOT_FOUND)
         }
     }
+
+    private fun filterAttachmentIdsIncludedInContent(
+        content: String,
+        requestedAttachmentIds: List<UUID>?,
+    ): List<UUID> =
+        requestedAttachmentIds
+            .orEmpty()
+            .distinct()
+            .filter { attachmentId ->
+                content.contains(attachmentId.toString())
+            }
 
     /**
      * 카테고리 경로를 파싱하여 해당 카테고리를 반환합니다.

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -104,6 +104,58 @@ class PostWriteServiceAttachmentTest {
             }
             assertThat(response.content).contains(attachmentId.toString())
         }
+
+        @Test
+        @DisplayName("요청 attachmentIds에만 있고 본문에 없는 첨부는 확정하지 않는다")
+        fun createPost_requestAttachmentIdsOnly_doesNotConfirmMissingContentIds() {
+            // given
+            val attachmentId = UUID.randomUUID()
+            val request =
+                CreatePostRequest(
+                    title = "게시물",
+                    content = "<p>본문</p>",
+                    attachmentIds = listOf(attachmentId),
+                    status = PostStatusEnum.PUBLISHED,
+                )
+
+            // when
+            val response = postWriteService.createPost(author.id!!, request)
+
+            // then
+            verify {
+                attachmentService.confirmAttachmentsByIds(
+                    response.id,
+                    AttachmentReferenceType.POST,
+                    emptyList(),
+                )
+            }
+        }
+
+        @Test
+        @DisplayName("attachmentIds 없이 본문에 ID가 있어도 확정하지 않는다")
+        fun createPost_withoutRequestAttachmentIds_doesNotConfirmFromContentOnly() {
+            // given
+            val attachmentId = UUID.randomUUID()
+            val request =
+                CreatePostRequest(
+                    title = "게시물",
+                    content = "![이미지]($attachmentId)",
+                    status = PostStatusEnum.PUBLISHED,
+                )
+
+            // when
+            val response = postWriteService.createPost(author.id!!, request)
+
+            // then
+            verify {
+                attachmentService.confirmAttachmentsByIds(
+                    response.id,
+                    AttachmentReferenceType.POST,
+                    emptyList(),
+                )
+            }
+            assertThat(response.content).contains(attachmentId.toString())
+        }
     }
 
     @Nested
@@ -151,6 +203,92 @@ class PostWriteServiceAttachmentTest {
                 )
             }
             assertThat(response.content).contains(newAttachmentId.toString())
+        }
+
+        @Test
+        @DisplayName("attachmentIds 없이 본문만 바꾸면 첨부 확정 없이 orphan 정리도 빈 목록 기준으로 한다")
+        fun updatePost_withoutRequestAttachmentIds_usesEmptyAttachmentIds() {
+            // given
+            val postId = UUID.randomUUID()
+            val newAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            val request =
+                UpdatePostRequest(
+                    content = "<img src=\"$newAttachmentId\" />",
+                    status = PostStatusEnum.PUBLISHED,
+                )
+
+            // when
+            val response = postWriteService.updatePost(postId, request, author.id!!)
+
+            // then
+            verify {
+                attachmentService.confirmAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    emptyList(),
+                )
+            }
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    emptyList(),
+                )
+            }
+            assertThat(response.content).contains(newAttachmentId.toString())
+        }
+
+        @Test
+        @DisplayName("수정 시 요청 attachmentIds에만 있는 첨부는 유지 대상으로 보지 않는다")
+        fun updatePost_requestAttachmentIdsOnly_ignoresMissingContentIds() {
+            // given
+            val postId = UUID.randomUUID()
+            val requestOnlyAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            val request =
+                UpdatePostRequest(
+                    content = "<p>본문만 수정</p>",
+                    attachmentIds = listOf(requestOnlyAttachmentId),
+                    status = PostStatusEnum.PUBLISHED,
+                )
+
+            // when
+            postWriteService.updatePost(postId, request, author.id!!)
+
+            // then
+            verify {
+                attachmentService.confirmAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    emptyList(),
+                )
+            }
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    emptyList(),
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- 게시물 저장/수정 시 요청 attachmentIds 중 본문에 실제 포함된 attachmentId만 confirm 하도록 정리했습니다.
- orphan attachment 정리 기준도 동일한 포함 목록으로 맞춰 본문과 첨부 연결 규칙을 단순화했습니다.
- attachment 포함/미포함 케이스를 검증하는 서비스 테스트를 추가했습니다.

## Test
- ./gradlew test --tests \"com.techtaurant.mainserver.post.application.PostWriteServiceAttachmentTest\" --tests \"com.techtaurant.mainserver.post.application.PostDetailReadServiceTest\" -x jacocoTestReport -x jacocoTestCoverageVerification