### PR TITLE
modify: 사용자 게시물 목록에 카테고리 정보를 포함

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -4,6 +4,7 @@ import com.techtaurant.mainserver.attachment.application.AttachmentService
 import com.techtaurant.mainserver.attachment.entity.Attachment
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
 import com.techtaurant.mainserver.common.dto.CursorPageResponse
+import com.techtaurant.mainserver.post.dto.CategoryResponse
 import com.techtaurant.mainserver.post.dto.DraftListItemResponse
 import com.techtaurant.mainserver.post.dto.PostCursor
 import com.techtaurant.mainserver.post.dto.PostListItemResponse
@@ -263,6 +264,7 @@ class PostListReadService(
             authorName = post.author.name,
             authorProfileImageUrl = post.author.profileImageUrl,
             thumbnailUrl = thumbnailUrl,
+            category = post.category?.let(CategoryResponse::from),
             isRead = isRead,
             tags = post.tags.map { PostListTagResponse.from(it) },
             viewCount = post.viewCount,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostListItemResponse.kt
@@ -22,6 +22,8 @@ data class PostListItemResponse(
     val authorProfileImageUrl: String,
     @field:Schema(description = "게시물 썸네일 이미지 URL")
     val thumbnailUrl: String,
+    @field:Schema(description = "게시물 카테고리")
+    val category: CategoryResponse?,
     @field:Schema(description = "로그인한 사용자가 읽은 게시물인지 여부")
     val isRead: Boolean,
     @field:Schema(description = "태그 목록")
@@ -57,6 +59,7 @@ data class PostListItemResponse(
                 authorName = post.author.name,
                 authorProfileImageUrl = post.author.profileImageUrl,
                 thumbnailUrl = "",
+                category = post.category?.let(CategoryResponse::from),
                 isRead = false,
                 tags = post.tags.map { PostListTagResponse.from(it) },
                 viewCount = post.viewCount,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -3,6 +3,7 @@ package com.techtaurant.mainserver.post.infrastructure.out
 import com.techtaurant.mainserver.common.base.EntityBase_
 import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.post.dto.PostCursor
+import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
@@ -37,7 +38,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
     /**
      * 기간 필터 + 정렬 조건을 적용하여 게시물 목록 조회
      *
-     * N+1 방지를 위해 author, tags, pictures를 fetch join하며 커서 기반 페이지네이션으로 조회
+     * N+1 방지를 위해 author, category, tags를 fetch join하며 커서 기반 페이지네이션으로 조회
      */
     override fun findPostsWithConditions(
         cursor: PostCursor?,
@@ -57,6 +58,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         cq.distinct(true)
 
         root.fetch<Post, User>(Post_.AUTHOR)
+        root.fetch<Post, Category>(Post_.CATEGORY, JoinType.LEFT)
         root.fetch<Post, Tag>(Post_.TAGS, JoinType.LEFT)
 
         val predicates = mutableListOf<Predicate>()

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -2,6 +2,7 @@ package com.techtaurant.mainserver.post.application
 
 import com.techtaurant.mainserver.attachment.application.AttachmentService
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
+import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostReadLog
@@ -67,12 +68,29 @@ class PostListReadServiceTest {
     private fun createPost(
         author: User,
         status: PostStatusEnum = PostStatusEnum.PUBLISHED,
+        category: Category? = null,
     ): Post =
         Post(
             title = "테스트 게시물",
             content = "테스트 내용",
             author = author,
+            category = category,
             status = status,
+        ).apply { id = UUID.randomUUID() }
+
+    private fun createCategory(
+        user: User,
+        name: String = "백엔드",
+        path: String = "backend",
+        depth: Int = 1,
+        parent: Category? = null,
+    ): Category =
+        Category(
+            user = user,
+            name = name,
+            path = path,
+            depth = depth,
+            parent = parent,
         ).apply { id = UUID.randomUUID() }
 
     @Nested
@@ -477,6 +495,44 @@ class PostListReadServiceTest {
             val responseMap = result.content.associateBy { it.id }
             assertThat(responseMap[post1.id!!]!!.isRead).isTrue()
             assertThat(responseMap[post2.id!!]!!.isRead).isFalse()
+        }
+
+        @Test
+        @DisplayName("게시물 카테고리가 있으면 응답에 함께 포함된다")
+        fun getPosts_includesCategoryInResponse() {
+            // given
+            val category = createCategory(otherUser, name = "Kotlin", path = "backend/kotlin", depth = 2)
+            val posts = listOf(createPost(otherUser, category = category))
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    authorId = otherUser.id!!,
+                    statuses = listOf(PostStatusEnum.PUBLISHED),
+                    categoryId = null,
+                    tagIds = null,
+                    viewerId = null,
+                )
+            } returns posts
+
+            // when
+            val result =
+                postListReadService.getPosts(
+                    cursor = null,
+                    size = 20,
+                    currentUserId = null,
+                    authorId = otherUser.id!!,
+                )
+
+            // then
+            val response = result.content.single()
+            assertThat(response.category).isNotNull
+            assertThat(response.category!!.id).isEqualTo(category.id)
+            assertThat(response.category!!.name).isEqualTo(category.name)
+            assertThat(response.category!!.path).isEqualTo(category.path)
+            assertThat(response.category!!.depth).isEqualTo(category.depth)
         }
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiControllerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiControllerTest.kt
@@ -2,6 +2,13 @@ package com.techtaurant.mainserver.user.infrastructure.`in`
 
 import com.techtaurant.mainserver.base.IntegrationTest
 import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.dto.CursorPageResponse
+import com.techtaurant.mainserver.post.dto.PostListItemResponse
+import com.techtaurant.mainserver.post.entity.Category
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import com.techtaurant.mainserver.post.infrastructure.out.CategoryRepository
+import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.user.dto.UserResponse
 import com.techtaurant.mainserver.user.entity.User
@@ -23,10 +30,62 @@ class UserOpenApiControllerTest : IntegrationTest() {
     @Autowired
     private lateinit var userRepository: UserRepository
 
+    @Autowired
+    private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var categoryRepository: CategoryRepository
+
     @BeforeEach
     fun setup() {
+        postRepository.deleteAllInBatch()
+        categoryRepository.deleteAllInBatch()
         userRepository.deleteAllInBatch()
     }
+
+    private fun createUser(name: String): User =
+        userRepository.save(
+            User(
+                name = name,
+                email = "${UUID.randomUUID()}@example.com",
+                provider = OAuthProvider.GOOGLE,
+                identifier = "google-${UUID.randomUUID()}",
+                role = UserRole.USER,
+                profileImageUrl = "https://example.com/profile.jpg",
+            ),
+        )
+
+    private fun createCategory(
+        user: User,
+        name: String,
+        path: String,
+        depth: Int,
+        parent: Category? = null,
+    ): Category =
+        categoryRepository.save(
+            Category(
+                user = user,
+                name = name,
+                path = path,
+                depth = depth,
+                parent = parent,
+            ),
+        )
+
+    private fun createPost(
+        author: User,
+        title: String,
+        category: Category? = null,
+    ): Post =
+        postRepository.save(
+            Post(
+                title = title,
+                content = "게시물 내용",
+                author = author,
+                category = category,
+                status = PostStatusEnum.PUBLISHED,
+            ),
+        )
 
     @Nested
     @DisplayName("입력값 검증")
@@ -149,6 +208,39 @@ class UserOpenApiControllerTest : IntegrationTest() {
 
             // then
             assertTrue(response.data!!.isEmpty(), "매칭되는 사용자가 없으면 빈 목록이 반환되어야 한다")
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 게시물 목록 조회")
+    inner class UserPostsTest {
+        @Test
+        @DisplayName("카테고리가 있는 게시물 조회 시 category 정보가 함께 반환된다")
+        fun getPostsByUserId_withCategory_returnsCategoryInResponse() {
+            // given
+            val author = createUser("김테크")
+            val rootCategory = createCategory(author, name = "백엔드", path = "backend", depth = 1)
+            val childCategory = createCategory(author, name = "Kotlin", path = "backend/kotlin", depth = 2, parent = rootCategory)
+            val post = createPost(author = author, title = "카테고리 포함 게시물", category = childCategory)
+
+            // when
+            val response =
+                RestAssured
+                    .given()
+                    .`when`()
+                    .get("/open-api/users/${author.id}/posts")
+                    .then()
+                    .statusCode(200)
+                    .extract()
+                    .`as`(object : TypeRef<ApiResponse<CursorPageResponse<PostListItemResponse>>>() {})
+
+            // then
+            val returnedPost = response.data!!.content.single { it.id == post.id }
+            assertEquals(childCategory.id, returnedPost.category?.id)
+            assertEquals(childCategory.name, returnedPost.category?.name)
+            assertEquals(childCategory.path, returnedPost.category?.path)
+            assertEquals(childCategory.depth, returnedPost.category?.depth)
+            assertEquals(rootCategory.id, returnedPost.category?.parentId)
         }
     }
 }


### PR DESCRIPTION
## 어떤 작업인가요?
- 사용자 게시물 목록 API에서 게시물 category 정보를 함께 내려주도록 응답과 조회 경로를 보강한 작업입니다.

## 어떻게 해결했나요?
**게시물 목록 응답 확장**
- `PostListItemResponse`에 `category` 필드를 추가했습니다.
- `PostListReadService`에서 게시물 카테고리를 응답 DTO로 매핑하도록 수정했습니다.

**조회 성능 및 회귀 방지**
- 목록 조회 쿼리에서 category를 fetch join 하도록 보강했습니다.
- 서비스 단위 테스트와 사용자 Open API 통합 테스트를 추가해 응답 구조를 검증했습니다.

## 중요한 변경 사항은 무엇인가요?
### 게시물 목록 응답 확장

**사용자 게시물 목록 응답에 category 추가**
- **변경 이유**: `/open-api/users/{userId}/posts`에서 게시물의 카테고리 정보가 함께 필요했습니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/post/dto/PostListItemResponse.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt`

### 조회 쿼리 및 테스트 보강

**category 연관 조회 보강**
- **변경 이유**: 목록 응답에서 category를 사용할 때 추가 조회를 줄이고 안정적으로 응답하기 위해서입니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt`

**단위/통합 테스트 추가**
- **변경 이유**: 카테고리 매핑과 실제 HTTP 응답에 category가 포함되는지 함께 검증하기 위해서입니다.
- **수정 파일**: `src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt`, `src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserOpenApiControllerTest.kt`