### PR TITLE
게시물 썸네일 첨부 저장 구조와 tmp 미리보기 API 추가

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -8,10 +8,10 @@ project_name: "test-setting"
 #   fortran             fsharp              go                  groovy              haskell
 #   java                julia               kotlin              lua                 markdown
 #   matlab              nix                 pascal              perl                php
-#   powershell          python              python_jedi         r                   rego
-#   ruby                ruby_solargraph     rust                scala               swift
-#   terraform           toml                typescript          typescript_vts      vue
-#   yaml                zig
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
@@ -35,8 +35,9 @@ encoding: "utf-8"
 # whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
 
-# list of additional paths to ignore in all projects
-# same syntax as gitignore, so you can use * and **
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
 # whether the project is in read-only mode
@@ -44,7 +45,9 @@ ignored_paths: []
 # Added on 2025-04-18
 read_only: false
 
-# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
 # Below is the complete list of tools for convenience.
 # To make sure you have the latest list of tools, and to view their descriptions, 
 # execute `uv run scripts/print_tool_overview.py`.
@@ -85,7 +88,8 @@ read_only: false
 #  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
 excluded_tools: []
 
-# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
@@ -132,3 +136,17 @@ read_only_memory_patterns: []
 # Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
 # This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
 line_ending:
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}

--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
@@ -279,7 +279,6 @@ class AttachmentService(
             }
     }
 
-
     private fun validateTmpPreviewAttachment(attachment: Attachment) {
         if (attachment.status != AttachmentStatus.TMP || !attachment.objectKey.startsWith("tmp/")) {
             throw ApiException(DefaultStatus.BAD_REQUEST, "TMP 상태의 첨부파일만 미리보기 URL을 발급할 수 있습니다")

--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
@@ -279,6 +279,7 @@ class AttachmentService(
             }
     }
 
+
     private fun validateTmpPreviewAttachment(attachment: Attachment) {
         if (attachment.status != AttachmentStatus.TMP || !attachment.objectKey.startsWith("tmp/")) {
             throw ApiException(DefaultStatus.BAD_REQUEST, "TMP 상태의 첨부파일만 미리보기 URL을 발급할 수 있습니다")

--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
@@ -1,11 +1,15 @@
 package com.techtaurant.mainserver.attachment.application
 
+import com.techtaurant.mainserver.attachment.dto.AttachmentPreviewUrlResponse
+import com.techtaurant.mainserver.attachment.dto.AttachmentPreviewUrlsRequest
 import com.techtaurant.mainserver.attachment.dto.PresignedUrlRequest
 import com.techtaurant.mainserver.attachment.dto.PresignedUrlResponse
 import com.techtaurant.mainserver.attachment.entity.Attachment
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
 import com.techtaurant.mainserver.attachment.enums.AttachmentStatus
 import com.techtaurant.mainserver.attachment.infrastructure.out.AttachmentRepository
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.common.status.DefaultStatus
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -59,6 +63,47 @@ class AttachmentService(
             )
 
         return PresignedUrlResponse.from(attachment, presignedUrl)
+    }
+
+    /**
+     * TMP 상태 첨부파일의 미리보기용 GET Presigned URL을 발급합니다.
+     * 게시물 발행 전 미리보기에서 임시 이미지를 표시할 때 사용합니다.
+     *
+     * @param attachmentId 미리보기할 TMP Attachment ID
+     * @return attachmentId, objectKey, presignedUrl 응답
+     */
+    @Transactional(readOnly = true)
+    fun issueTmpPreviewUrl(attachmentId: UUID): AttachmentPreviewUrlResponse {
+        return issueTmpPreviewUrls(AttachmentPreviewUrlsRequest(listOf(attachmentId))).first()
+    }
+
+    /**
+     * TMP 상태 첨부파일 여러 건의 미리보기용 GET Presigned URL을 발급합니다.
+     * 요청 순서를 유지하며, 모든 첨부파일이 TMP 상태여야 합니다.
+     *
+     * @param request 미리보기할 TMP Attachment ID 목록
+     * @return attachmentId, objectKey, presignedUrl 응답 목록
+     */
+    @Transactional(readOnly = true)
+    fun issueTmpPreviewUrls(request: AttachmentPreviewUrlsRequest): List<AttachmentPreviewUrlResponse> {
+        val attachmentIds = request.attachmentIds.distinct()
+        val attachmentsById = attachmentRepository.findAllById(attachmentIds).associateBy { it.id!! }
+
+        return attachmentIds.map { attachmentId ->
+            val attachment =
+                attachmentsById[attachmentId]
+                    ?: throw ApiException(DefaultStatus.NOT_FOUND, "임시 첨부파일을 찾을 수 없습니다")
+
+            validateTmpPreviewAttachment(attachment)
+
+            val presignedUrl =
+                s3StorageService.generatePresignedDownloadUrl(
+                    objectKey = attachment.objectKey,
+                    expireMinutes = presignedUrlExpireMinutes,
+                )
+
+            AttachmentPreviewUrlResponse.from(attachment, presignedUrl)
+        }
     }
 
     /**
@@ -212,6 +257,36 @@ class AttachmentService(
                         expireMinutes = presignedUrlExpireMinutes,
                     )
             }
+    }
+
+    /**
+     * 전달된 첨부파일 목록의 attachmentId → presigned GET URL 맵을 반환합니다.
+     * 이미 조회된 첨부파일 목록을 재사용할 때 사용합니다.
+     *
+     * @param attachments presigned URL 발급 대상 첨부파일 목록
+     * @return attachmentId → presigned GET URL 맵
+     */
+    @Transactional(readOnly = true)
+    fun generatePresignedDownloadUrlMapByAttachments(attachments: List<Attachment>): Map<UUID, String> {
+        return attachments
+            .filter { it.status == AttachmentStatus.CONFIRMED }
+            .associate { attachment ->
+                attachment.id!! to
+                    s3StorageService.generatePresignedDownloadUrl(
+                        objectKey = attachment.objectKey,
+                        expireMinutes = presignedUrlExpireMinutes,
+                    )
+            }
+    }
+
+    private fun validateTmpPreviewAttachment(attachment: Attachment) {
+        if (attachment.status != AttachmentStatus.TMP || !attachment.objectKey.startsWith("tmp/")) {
+            throw ApiException(DefaultStatus.BAD_REQUEST, "TMP 상태의 첨부파일만 미리보기 URL을 발급할 수 있습니다")
+        }
+
+        if (!s3StorageService.exists(attachment.objectKey)) {
+            throw ApiException(DefaultStatus.NOT_FOUND, "S3에 임시 첨부파일이 존재하지 않습니다")
+        }
     }
 
     /**

--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/dto/AttachmentPreviewUrlResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/dto/AttachmentPreviewUrlResponse.kt
@@ -1,0 +1,27 @@
+package com.techtaurant.mainserver.attachment.dto
+
+import com.techtaurant.mainserver.attachment.entity.Attachment
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+@Schema(description = "임시 첨부파일 미리보기 URL 응답")
+data class AttachmentPreviewUrlResponse(
+    @field:Schema(description = "첨부파일 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    val attachmentId: UUID,
+    @field:Schema(description = "S3 오브젝트 키", example = "tmp/550e8400-e29b-41d4-a716-446655440000/photo.jpg")
+    val objectKey: String,
+    @field:Schema(description = "S3 GET Presigned URL", example = "https://techtaurant-media.s3.ap-northeast-2.amazonaws.com/tmp/...")
+    val presignedUrl: String,
+) {
+    companion object {
+        fun from(
+            attachment: Attachment,
+            presignedUrl: String,
+        ): AttachmentPreviewUrlResponse =
+            AttachmentPreviewUrlResponse(
+                attachmentId = attachment.id!!,
+                objectKey = attachment.objectKey,
+                presignedUrl = presignedUrl,
+            )
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/dto/AttachmentPreviewUrlsRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/dto/AttachmentPreviewUrlsRequest.kt
@@ -1,0 +1,15 @@
+package com.techtaurant.mainserver.attachment.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotEmpty
+import java.util.UUID
+
+@Schema(description = "임시 첨부파일 미리보기 URL 일괄 발급 요청")
+data class AttachmentPreviewUrlsRequest(
+    @field:NotEmpty
+    @field:Schema(
+        description = "미리보기할 TMP Attachment ID 목록",
+        example = "[\"550e8400-e29b-41d4-a716-446655440000\", \"660e8400-e29b-41d4-a716-446655440000\"]",
+    )
+    val attachmentIds: List<UUID>,
+)

--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/infrastructure/in/AttachmentController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/infrastructure/in/AttachmentController.kt
@@ -1,12 +1,16 @@
 package com.techtaurant.mainserver.attachment.infrastructure.`in`
 
 import com.techtaurant.mainserver.attachment.application.AttachmentService
+import com.techtaurant.mainserver.attachment.dto.AttachmentPreviewUrlResponse
+import com.techtaurant.mainserver.attachment.dto.AttachmentPreviewUrlsRequest
 import com.techtaurant.mainserver.attachment.dto.PresignedUrlRequest
 import com.techtaurant.mainserver.attachment.dto.PresignedUrlResponse
 import com.techtaurant.mainserver.common.dto.ApiResponse
 import jakarta.validation.Valid
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -19,6 +23,18 @@ import java.util.UUID
 class AttachmentController(
     private val attachmentService: AttachmentService,
 ) : AttachmentControllerDocs {
+    @PostMapping("/preview-urls")
+    override fun issueTmpPreviewUrls(
+        @AuthenticationPrincipal userId: UUID,
+        @Valid @RequestBody request: AttachmentPreviewUrlsRequest,
+    ): ApiResponse<List<AttachmentPreviewUrlResponse>> = ApiResponse.ok(attachmentService.issueTmpPreviewUrls(request))
+
+    @GetMapping("/{attachmentId}/preview-url")
+    override fun issueTmpPreviewUrl(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable attachmentId: UUID,
+    ): ApiResponse<AttachmentPreviewUrlResponse> = ApiResponse.ok(attachmentService.issueTmpPreviewUrl(attachmentId))
+
     @PostMapping("/presigned-url")
     override fun issuePresignedUploadUrl(
         @AuthenticationPrincipal userId: UUID,

--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/infrastructure/in/AttachmentControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/infrastructure/in/AttachmentControllerDocs.kt
@@ -1,10 +1,13 @@
 package com.techtaurant.mainserver.attachment.infrastructure.`in`
 
+import com.techtaurant.mainserver.attachment.dto.AttachmentPreviewUrlResponse
+import com.techtaurant.mainserver.attachment.dto.AttachmentPreviewUrlsRequest
 import com.techtaurant.mainserver.attachment.dto.PresignedUrlRequest
 import com.techtaurant.mainserver.attachment.dto.PresignedUrlResponse
 import com.techtaurant.mainserver.common.dto.ApiResponse
 import com.techtaurant.mainserver.common.swagger.ApiCommonBadRequestUnknownAndAuthenticationRequired
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import java.util.UUID
@@ -12,6 +15,34 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 
 @Tag(name = "Attachment", description = "첨부파일 API")
 interface AttachmentControllerDocs {
+    @Operation(
+        summary = "임시 첨부파일 미리보기 URL 일괄 발급",
+        description = "TMP 상태 첨부파일 여러 건을 미리보기 화면에서 표시할 수 있도록 GET Presigned URL을 한 번에 발급합니다.",
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "임시 첨부파일 미리보기 URL 일괄 발급 성공",
+    )
+    @ApiCommonBadRequestUnknownAndAuthenticationRequired
+    fun issueTmpPreviewUrls(
+        userId: UUID,
+        @Valid request: AttachmentPreviewUrlsRequest,
+    ): ApiResponse<List<AttachmentPreviewUrlResponse>>
+
+    @Operation(
+        summary = "임시 첨부파일 미리보기 URL 발급",
+        description = "TMP 상태 첨부파일을 미리보기 화면에서 표시할 수 있도록 GET Presigned URL을 발급합니다.",
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "임시 첨부파일 미리보기 URL 발급 성공",
+    )
+    @ApiCommonBadRequestUnknownAndAuthenticationRequired
+    fun issueTmpPreviewUrl(
+        userId: UUID,
+        @Parameter(description = "미리보기할 TMP Attachment ID") attachmentId: UUID,
+    ): ApiResponse<AttachmentPreviewUrlResponse>
+
     @Operation(
         summary = "Presigned URL 발급",
         description = "S3 직접 업로드를 위한 PUT Presigned URL을 발급합니다. 응답의 objectKey를 게시물 content에 삽입하세요.",

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -136,10 +136,22 @@ class PostListReadService(
             } else {
                 emptyMap()
             }
+        val thumbnailAttachmentByPostId =
+            content.associate { post ->
+                val thumbnailAttachment =
+                    attachmentsByPostId[post.id]
+                        .orEmpty()
+                        .let { attachments ->
+                            post.thumbnailImage?.let { thumbnailAttachmentId ->
+                                attachments.firstOrNull { it.id == thumbnailAttachmentId }
+                            } ?: attachments.minByOrNull { it.createdAt }
+                        }
+                post.id!! to thumbnailAttachment
+            }
         val presignedThumbnailUrlByAttachmentId =
-            attachmentsByPostId
+            thumbnailAttachmentByPostId
                 .values
-                .flatten()
+                .filterNotNull()
                 .takeIf { it.isNotEmpty() }
                 ?.let { attachmentService.generatePresignedDownloadUrlMapByAttachments(it) }
                 ?: emptyMap()
@@ -150,7 +162,7 @@ class PostListReadService(
                     convertToResponse(
                         post,
                         readPostIds.contains(post.id),
-                        attachmentsByPostId[post.id] ?: emptyList(),
+                        thumbnailAttachmentByPostId[post.id],
                         presignedThumbnailUrlByAttachmentId,
                     )
                 },
@@ -255,15 +267,10 @@ class PostListReadService(
     private fun convertToResponse(
         post: Post,
         isRead: Boolean,
-        attachments: List<Attachment>,
+        thumbnailAttachment: Attachment?,
         presignedThumbnailUrlByAttachmentId: Map<UUID, String>,
     ): PostListItemResponse {
-        val thumbnailUrl =
-            attachments
-                .minByOrNull { it.createdAt }
-                ?.id
-                ?.let { presignedThumbnailUrlByAttachmentId[it] }
-                ?: "$baseUrl$defaultThumbnailUrl"
+        val thumbnailUrl = thumbnailAttachment?.id?.let { presignedThumbnailUrlByAttachmentId[it] } ?: "$baseUrl$defaultThumbnailUrl"
 
         return PostListItemResponse(
             id = post.id!!,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -136,6 +136,13 @@ class PostListReadService(
             } else {
                 emptyMap()
             }
+        val presignedThumbnailUrlByAttachmentId =
+            attachmentsByPostId
+                .values
+                .flatten()
+                .takeIf { it.isNotEmpty() }
+                ?.let { attachmentService.generatePresignedDownloadUrlMapByAttachments(it) }
+                ?: emptyMap()
 
         return CursorPageResponse(
             content =
@@ -144,6 +151,7 @@ class PostListReadService(
                         post,
                         readPostIds.contains(post.id),
                         attachmentsByPostId[post.id] ?: emptyList(),
+                        presignedThumbnailUrlByAttachmentId,
                     )
                 },
             nextCursor = nextCursor,
@@ -248,11 +256,13 @@ class PostListReadService(
         post: Post,
         isRead: Boolean,
         attachments: List<Attachment>,
+        presignedThumbnailUrlByAttachmentId: Map<UUID, String>,
     ): PostListItemResponse {
         val thumbnailUrl =
             attachments
                 .minByOrNull { it.createdAt }
-                ?.objectKey
+                ?.id
+                ?.let { presignedThumbnailUrlByAttachmentId[it] }
                 ?: "$baseUrl$defaultThumbnailUrl"
 
         return PostListItemResponse(

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -92,12 +92,16 @@ class PostWriteService(
         val savedPost = postRepository.save(post)
 
         if (status != PostStatusEnum.DRAFT) {
-            val attachmentIds = filterAttachmentIdsIncludedInContent(savedPost.content, request.attachmentIds)
+            val attachmentIds = mergeAttachmentIds(
+                filterAttachmentIdsIncludedInContent(savedPost.content, request.attachmentIds),
+                request.thumbnailAttachmentId,
+            )
             attachmentService.confirmAttachmentsByIds(
                 referenceId = savedPost.id!!,
                 referenceType = AttachmentReferenceType.POST,
                 attachmentIds = attachmentIds,
             )
+            savedPost.thumbnailImage = request.thumbnailAttachmentId ?: attachmentIds.firstOrNull()
         }
 
         return PostResponse.from(savedPost)
@@ -145,7 +149,10 @@ class PostWriteService(
 
         val newStatus = request.status ?: post.status
         if (newStatus != PostStatusEnum.DRAFT) {
-            val attachmentIds = filterAttachmentIdsIncludedInContent(savedPost.content, request.attachmentIds)
+            val attachmentIds = mergeAttachmentIds(
+                filterAttachmentIdsIncludedInContent(savedPost.content, request.attachmentIds),
+                request.thumbnailAttachmentId,
+            )
             attachmentService.confirmAttachmentsByIds(
                 referenceId = postId,
                 referenceType = AttachmentReferenceType.POST,
@@ -155,8 +162,12 @@ class PostWriteService(
             attachmentService.deleteOrphanedAttachmentsByIds(
                 referenceId = postId,
                 referenceType = AttachmentReferenceType.POST,
-                keepAttachmentIds = attachmentIds,
+                keepAttachmentIds = mergeAttachmentIds(attachmentIds, post.thumbnailImage),
             )
+
+            post.thumbnailImage = request.thumbnailAttachmentId ?: post.thumbnailImage ?: attachmentIds.firstOrNull()
+        } else {
+            post.thumbnailImage = null
         }
 
         return PostResponse.from(savedPost)
@@ -183,6 +194,7 @@ class PostWriteService(
             throw ApiException(PostStatus.CANNOT_MODIFY_OTHERS_POST)
         }
 
+        post.thumbnailImage = null
         attachmentService.deleteAttachmentsByReference(postId, AttachmentReferenceType.POST)
         postRepository.delete(post)
     }
@@ -203,6 +215,12 @@ class PostWriteService(
             .filter { attachmentId ->
                 content.contains(attachmentId.toString())
             }
+
+    private fun mergeAttachmentIds(
+        attachmentIds: List<UUID>,
+        thumbnailAttachmentId: UUID?,
+    ): List<UUID> =
+        (attachmentIds + listOfNotNull(thumbnailAttachmentId)).distinct()
 
     /**
      * 카테고리 경로를 파싱하여 해당 카테고리를 반환합니다.

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -92,10 +92,11 @@ class PostWriteService(
         val savedPost = postRepository.save(post)
 
         if (status != PostStatusEnum.DRAFT) {
-            val attachmentIds = mergeAttachmentIds(
-                filterAttachmentIdsIncludedInContent(savedPost.content, request.attachmentIds),
-                request.thumbnailAttachmentId,
-            )
+            val attachmentIds =
+                mergeAttachmentIds(
+                    filterAttachmentIdsIncludedInContent(savedPost.content, request.attachmentIds),
+                    request.thumbnailAttachmentId,
+                )
             attachmentService.confirmAttachmentsByIds(
                 referenceId = savedPost.id!!,
                 referenceType = AttachmentReferenceType.POST,
@@ -149,10 +150,11 @@ class PostWriteService(
 
         val newStatus = request.status ?: post.status
         if (newStatus != PostStatusEnum.DRAFT) {
-            val attachmentIds = mergeAttachmentIds(
-                filterAttachmentIdsIncludedInContent(savedPost.content, request.attachmentIds),
-                request.thumbnailAttachmentId,
-            )
+            val attachmentIds =
+                mergeAttachmentIds(
+                    filterAttachmentIdsIncludedInContent(savedPost.content, request.attachmentIds),
+                    request.thumbnailAttachmentId,
+                )
             attachmentService.confirmAttachmentsByIds(
                 referenceId = postId,
                 referenceType = AttachmentReferenceType.POST,
@@ -219,8 +221,7 @@ class PostWriteService(
     private fun mergeAttachmentIds(
         attachmentIds: List<UUID>,
         thumbnailAttachmentId: UUID?,
-    ): List<UUID> =
-        (attachmentIds + listOfNotNull(thumbnailAttachmentId)).distinct()
+    ): List<UUID> = (attachmentIds + listOfNotNull(thumbnailAttachmentId)).distinct()
 
     /**
      * 카테고리 경로를 파싱하여 해당 카테고리를 반환합니다.

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/CreatePostRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/CreatePostRequest.kt
@@ -27,6 +27,8 @@ data class CreatePostRequest(
     val tags: List<String>? = null,
     @field:Schema(description = "게시물에 연결할 attachment ID 목록", example = "[\"01234567-89ab-cdef-0123-456789abcdef\"]")
     val attachmentIds: List<UUID>? = null,
+    @field:Schema(description = "대표 썸네일로 사용할 attachment ID", example = "01234567-89ab-cdef-0123-456789abcdef")
+    val thumbnailAttachmentId: UUID? = null,
     @field:Schema(description = "게시물 상태 (DRAFT/PUBLISHED/PRIVATE, 기본값: PUBLISHED)", example = "PUBLISHED")
     val status: PostStatusEnum? = null,
 )

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
@@ -30,6 +30,8 @@ data class UpdatePostRequest(
     val tags: List<String>? = null,
     @field:Schema(description = "게시물에 연결할 attachment ID 목록", example = "[\"01234567-89ab-cdef-0123-456789abcdef\"]")
     val attachmentIds: List<UUID>? = null,
+    @field:Schema(description = "대표 썸네일로 사용할 attachment ID", example = "01234567-89ab-cdef-0123-456789abcdef")
+    val thumbnailAttachmentId: UUID? = null,
     @field:Schema(description = "게시물 상태 (DRAFT/PUBLISHED/PRIVATE)", example = "PUBLISHED")
     val status: PostStatusEnum? = null,
 )

--- a/src/main/kotlin/com/techtaurant/mainserver/post/entity/Post.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/entity/Post.kt
@@ -26,6 +26,7 @@ import jakarta.persistence.Table
  * @property viewCount 조회수 (이벤트 발생 시 원자적 증분)
  * @property likeCount 좋아요수 (이벤트 발생 시 원자적 증분)
  * @property commentCount 댓글수 (이벤트 발생 시 원자적 증분)
+ * @property thumbnailImage 게시물 썸네일 이미지 attachment ID
  * @property status 게시물 상태 (DRAFT: 임시저장, PUBLISHED: 발행, PRIVATE: 비공개)
  */
 @Entity
@@ -54,6 +55,8 @@ class Post(
     var likeCount: Long = 0,
     @Column(name = "comment_count", nullable = false)
     var commentCount: Long = 0,
+    @Column(name = "thumbnail_image")
+    var thumbnailImage: java.util.UUID? = null,
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     var status: PostStatusEnum = PostStatusEnum.PUBLISHED,

--- a/src/main/resources/db/migration/V20__add_post_thumbnail_image.sql
+++ b/src/main/resources/db/migration/V20__add_post_thumbnail_image.sql
@@ -1,0 +1,20 @@
+ALTER TABLE posts
+    ADD COLUMN thumbnail_image UUID;
+
+UPDATE posts p
+SET thumbnail_image = a.id
+FROM (
+    SELECT DISTINCT ON (reference_id)
+        reference_id,
+        id
+    FROM attachments
+    WHERE reference_type = 'POST'::attachment_reference_type
+      AND status = 'CONFIRMED'::attachment_status
+    ORDER BY reference_id, created_at ASC, id ASC
+) a
+WHERE p.id = a.reference_id
+  AND p.thumbnail_image IS NULL;
+
+ALTER TABLE posts
+    ADD CONSTRAINT fk_posts_thumbnail_image
+        FOREIGN KEY (thumbnail_image) REFERENCES attachments(id) ON DELETE SET NULL;

--- a/src/test/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentServiceTest.kt
@@ -1,10 +1,12 @@
 package com.techtaurant.mainserver.attachment.application
 
+import com.techtaurant.mainserver.attachment.dto.AttachmentPreviewUrlsRequest
 import com.techtaurant.mainserver.attachment.dto.PresignedUrlRequest
 import com.techtaurant.mainserver.attachment.entity.Attachment
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
 import com.techtaurant.mainserver.attachment.enums.AttachmentStatus
 import com.techtaurant.mainserver.attachment.infrastructure.out.AttachmentRepository
+import com.techtaurant.mainserver.common.exception.ApiException
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -12,6 +14,7 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -179,6 +182,76 @@ class AttachmentServiceTest {
             assertThat(tmpAttachment.status).isEqualTo(AttachmentStatus.CONFIRMED)
             assertThat(tmpAttachment.referenceId).isEqualTo(postId)
             assertThat(tmpAttachment.referenceType).isEqualTo(AttachmentReferenceType.POST)
+        }
+    }
+
+    @Nested
+    @DisplayName("issueTmpPreviewUrl")
+    inner class IssueTmpPreviewUrl {
+        @Test
+        @DisplayName("TMP 첨부파일이면 미리보기 presigned URL을 반환한다")
+        fun issueTmpPreviewUrl_tmpAttachment_returnsPreviewUrl() {
+            // given
+            val tmpAttachment = makeAttachment("tmp/${UUID.randomUUID()}/preview.jpg", AttachmentStatus.TMP, referenceId = null)
+            every { attachmentRepository.findAllById(listOf(tmpAttachment.id!!)) } returns listOf(tmpAttachment)
+            every { s3StorageService.exists(tmpAttachment.objectKey) } returns true
+            every {
+                s3StorageService.generatePresignedDownloadUrl(tmpAttachment.objectKey, presignedUrlExpireMinutes)
+            } returns "https://preview-url"
+
+            // when
+            val result = attachmentService.issueTmpPreviewUrl(tmpAttachment.id!!)
+
+            // then
+            assertThat(result.attachmentId).isEqualTo(tmpAttachment.id)
+            assertThat(result.objectKey).isEqualTo(tmpAttachment.objectKey)
+            assertThat(result.presignedUrl).isEqualTo("https://preview-url")
+        }
+
+        @Test
+        @DisplayName("TMP 상태가 아니면 예외를 던진다")
+        fun issueTmpPreviewUrl_confirmedAttachment_throwsBadRequest() {
+            // given
+            val confirmedAttachment = makeAttachment("posts/$postId/${UUID.randomUUID()}/preview.jpg", AttachmentStatus.CONFIRMED)
+            every { attachmentRepository.findAllById(listOf(confirmedAttachment.id!!)) } returns listOf(confirmedAttachment)
+
+            // when & then
+            assertThatThrownBy { attachmentService.issueTmpPreviewUrl(confirmedAttachment.id!!) }
+                .isInstanceOf(ApiException::class.java)
+                .hasMessage("TMP 상태의 첨부파일만 미리보기 URL을 발급할 수 있습니다")
+        }
+    }
+
+    @Nested
+    @DisplayName("issueTmpPreviewUrls")
+    inner class IssueTmpPreviewUrls {
+        @Test
+        @DisplayName("여러 TMP 첨부파일의 미리보기 presigned URL을 요청 순서대로 반환한다")
+        fun issueTmpPreviewUrls_tmpAttachments_returnsPreviewUrlsInOrder() {
+            // given
+            val firstAttachment = makeAttachment("tmp/${UUID.randomUUID()}/first.jpg", AttachmentStatus.TMP, referenceId = null)
+            val secondAttachment = makeAttachment("tmp/${UUID.randomUUID()}/second.jpg", AttachmentStatus.TMP, referenceId = null)
+            every {
+                attachmentRepository.findAllById(listOf(secondAttachment.id!!, firstAttachment.id!!))
+            } returns listOf(firstAttachment, secondAttachment)
+            every { s3StorageService.exists(firstAttachment.objectKey) } returns true
+            every { s3StorageService.exists(secondAttachment.objectKey) } returns true
+            every {
+                s3StorageService.generatePresignedDownloadUrl(firstAttachment.objectKey, presignedUrlExpireMinutes)
+            } returns "https://preview-first"
+            every {
+                s3StorageService.generatePresignedDownloadUrl(secondAttachment.objectKey, presignedUrlExpireMinutes)
+            } returns "https://preview-second"
+
+            // when
+            val result =
+                attachmentService.issueTmpPreviewUrls(
+                    AttachmentPreviewUrlsRequest(listOf(secondAttachment.id!!, firstAttachment.id!!)),
+                )
+
+            // then
+            assertThat(result.map { it.attachmentId }).containsExactly(secondAttachment.id!!, firstAttachment.id!!)
+            assertThat(result.map { it.presignedUrl }).containsExactly("https://preview-second", "https://preview-first")
         }
     }
 
@@ -378,6 +451,44 @@ class AttachmentServiceTest {
             // then
             assertThat(result).isEmpty()
             verify(exactly = 0) { s3StorageService.generatePresignedDownloadUrl(any(), any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("generatePresignedDownloadUrlMapByAttachments")
+    inner class GeneratePresignedDownloadUrlMapByAttachments {
+        @Test
+        @DisplayName("전달된 CONFIRMED 첨부파일 목록으로 attachmentId → URL 맵을 만든다")
+        fun generatePresignedDownloadUrlMapByAttachments_confirmedAttachments_returnsUrlMap() {
+            // given
+            val confirmed1 = makeAttachment("posts/$postId/uuid1/a.jpg", AttachmentStatus.CONFIRMED)
+            val confirmed2 = makeAttachment("posts/$postId/uuid2/b.jpg", AttachmentStatus.CONFIRMED)
+            every { s3StorageService.generatePresignedDownloadUrl(confirmed1.objectKey, presignedUrlExpireMinutes) } returns "https://url1"
+            every { s3StorageService.generatePresignedDownloadUrl(confirmed2.objectKey, presignedUrlExpireMinutes) } returns "https://url2"
+
+            // when
+            val result = attachmentService.generatePresignedDownloadUrlMapByAttachments(listOf(confirmed1, confirmed2))
+
+            // then
+            assertThat(result[confirmed1.id!!]).isEqualTo("https://url1")
+            assertThat(result[confirmed2.id!!]).isEqualTo("https://url2")
+        }
+
+        @Test
+        @DisplayName("TMP 첨부파일은 제외한다")
+        fun generatePresignedDownloadUrlMapByAttachments_tmpAttachment_excluded() {
+            // given
+            val confirmed = makeAttachment("posts/$postId/uuid1/a.jpg", AttachmentStatus.CONFIRMED)
+            val tmp = makeAttachment("tmp/${UUID.randomUUID()}/tmp.jpg", AttachmentStatus.TMP, referenceId = null)
+            every { s3StorageService.generatePresignedDownloadUrl(confirmed.objectKey, presignedUrlExpireMinutes) } returns "https://url"
+
+            // when
+            val result = attachmentService.generatePresignedDownloadUrlMapByAttachments(listOf(confirmed, tmp))
+
+            // then
+            assertThat(result).hasSize(1)
+            assertThat(result).containsKey(confirmed.id!!)
+            assertThat(result).doesNotContainKey(tmp.id!!)
         }
     }
 

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -1,7 +1,9 @@
 package com.techtaurant.mainserver.post.application
 
 import com.techtaurant.mainserver.attachment.application.AttachmentService
+import com.techtaurant.mainserver.attachment.entity.Attachment
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
+import com.techtaurant.mainserver.attachment.enums.AttachmentStatus
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostReadLog
@@ -20,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.util.Date
 import java.util.UUID
 
 class PostListReadServiceTest {
@@ -74,6 +77,24 @@ class PostListReadServiceTest {
             author = author,
             status = status,
         ).apply { id = UUID.randomUUID() }
+
+    private fun createAttachment(
+        postId: UUID,
+        objectKey: String,
+        createdAt: Date,
+    ): Attachment =
+        Attachment(
+            referenceId = postId,
+            referenceType = AttachmentReferenceType.POST,
+            objectKey = objectKey,
+            status = AttachmentStatus.CONFIRMED,
+            originalFileName = "thumbnail.jpg",
+            contentType = "image/jpeg",
+            fileSize = 1024,
+        ).apply {
+            id = UUID.randomUUID()
+            this.createdAt = createdAt
+        }
 
     @Nested
     @DisplayName("getPosts")
@@ -195,6 +216,48 @@ class PostListReadServiceTest {
                     viewerId = null,
                 )
             }
+        }
+
+        @Test
+        @DisplayName("첨부파일 썸네일은 presigned URL로 반환한다")
+        fun getPosts_withThumbnailAttachment_returnsPresignedThumbnailUrl() {
+            // given
+            val post = createPost(otherUser)
+            val firstAttachment =
+                createAttachment(
+                    postId = post.id!!,
+                    objectKey = "posts/${post.id}/uuid-1/first.jpg",
+                    createdAt = Date(1_000L),
+                )
+            val laterAttachment =
+                createAttachment(
+                    postId = post.id!!,
+                    objectKey = "posts/${post.id}/uuid-2/later.jpg",
+                    createdAt = Date(2_000L),
+                )
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    visibleToUserId = null,
+                    tagIds = null,
+                    viewerId = null,
+                )
+            } returns listOf(post)
+            every {
+                attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(post.id!!), AttachmentReferenceType.POST)
+            } returns mapOf(post.id!! to listOf(laterAttachment, firstAttachment))
+            every {
+                attachmentService.generatePresignedDownloadUrlMapByAttachments(listOf(laterAttachment, firstAttachment))
+            } returns mapOf(firstAttachment.id!! to "https://cdn.example.com/first.jpg")
+
+            // when
+            val result = postListReadService.getPosts(cursor = null, size = 20, currentUserId = null)
+
+            // then
+            assertThat(result.content.single().thumbnailUrl).isEqualTo("https://cdn.example.com/first.jpg")
         }
     }
 

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -286,7 +286,12 @@ class PostListReadServiceTest {
             // given
             val thumbnailAttachmentId = UUID.randomUUID()
             val post = createPost(otherUser, thumbnailImage = thumbnailAttachmentId)
-            val thumbnailAttachment = createAttachment(post.id!!, "posts/thumbnail-object-key.jpg", Date(1_000L)).apply { id = thumbnailAttachmentId }
+            val thumbnailAttachment =
+                createAttachment(
+                    post.id!!,
+                    "posts/thumbnail-object-key.jpg",
+                    Date(1_000L),
+                ).apply { id = thumbnailAttachmentId }
             val otherAttachment = createAttachment(post.id!!, "posts/other-object-key.jpg", Date(2_000L))
             every {
                 postRepository.findPostsWithConditions(
@@ -312,7 +317,6 @@ class PostListReadServiceTest {
             // then
             assertThat(result.content.single().thumbnailUrl).isEqualTo("https://cdn.example.com/thumbnail.jpg")
         }
-
     }
 
     @Nested

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -70,11 +70,13 @@ class PostListReadServiceTest {
     private fun createPost(
         author: User,
         status: PostStatusEnum = PostStatusEnum.PUBLISHED,
+        thumbnailImage: UUID? = null,
     ): Post =
         Post(
             title = "테스트 게시물",
             content = "테스트 내용",
             author = author,
+            thumbnailImage = thumbnailImage,
             status = status,
         ).apply { id = UUID.randomUUID() }
 
@@ -250,7 +252,7 @@ class PostListReadServiceTest {
                 attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(post.id!!), AttachmentReferenceType.POST)
             } returns mapOf(post.id!! to listOf(laterAttachment, firstAttachment))
             every {
-                attachmentService.generatePresignedDownloadUrlMapByAttachments(listOf(laterAttachment, firstAttachment))
+                attachmentService.generatePresignedDownloadUrlMapByAttachments(listOf(firstAttachment))
             } returns mapOf(firstAttachment.id!! to "https://cdn.example.com/first.jpg")
 
             // when
@@ -259,6 +261,40 @@ class PostListReadServiceTest {
             // then
             assertThat(result.content.single().thumbnailUrl).isEqualTo("https://cdn.example.com/first.jpg")
         }
+
+        @Test
+        @DisplayName("게시물에 thumbnailImage가 있으면 attachment fallback 없이 해당 값을 사용한다")
+        fun getPosts_withThumbnailImage_usesThumbnailImageFirst() {
+            // given
+            val thumbnailAttachmentId = UUID.randomUUID()
+            val post = createPost(otherUser, thumbnailImage = thumbnailAttachmentId)
+            val thumbnailAttachment = createAttachment(post.id!!, "posts/thumbnail-object-key.jpg", Date(1_000L)).apply { id = thumbnailAttachmentId }
+            val otherAttachment = createAttachment(post.id!!, "posts/other-object-key.jpg", Date(2_000L))
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    visibleToUserId = null,
+                    tagIds = null,
+                    viewerId = null,
+                )
+            } returns listOf(post)
+            every {
+                attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(post.id!!), AttachmentReferenceType.POST)
+            } returns mapOf(post.id!! to listOf(otherAttachment, thumbnailAttachment))
+            every {
+                attachmentService.generatePresignedDownloadUrlMapByAttachments(listOf(thumbnailAttachment))
+            } returns mapOf(thumbnailAttachmentId to "https://cdn.example.com/thumbnail.jpg")
+
+            // when
+            val result = postListReadService.getPosts(cursor = null, size = 20, currentUserId = null)
+
+            // then
+            assertThat(result.content.single().thumbnailUrl).isEqualTo("https://cdn.example.com/thumbnail.jpg")
+        }
+
     }
 
     @Nested

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -79,6 +79,43 @@ class PostWriteServiceAttachmentTest {
     @DisplayName("createPost")
     inner class CreatePost {
         @Test
+        @DisplayName("thumbnailAttachmentId를 지정하면 본문 첨부와 함께 confirm하고 thumbnailImage로 저장한다")
+        fun createPost_withThumbnailAttachmentId_savesThumbnailImage() {
+            // given
+            val attachmentId = UUID.randomUUID()
+            val thumbnailAttachmentId = UUID.randomUUID()
+            var savedPost: Post? = null
+            val request =
+                CreatePostRequest(
+                    title = "게시물",
+                    content = "<p>본문</p><img src=\"$attachmentId\" />",
+                    attachmentIds = listOf(attachmentId),
+                    thumbnailAttachmentId = thumbnailAttachmentId,
+                    status = PostStatusEnum.PUBLISHED,
+                )
+            every { postRepository.save(any()) } answers {
+                firstArg<Post>().apply {
+                    if (id == null) {
+                        id = UUID.randomUUID()
+                    }
+                    savedPost = this
+                }
+            }
+            // when
+            val response = postWriteService.createPost(author.id!!, request)
+
+            // then
+            verify {
+                attachmentService.confirmAttachmentsByIds(
+                    response.id,
+                    AttachmentReferenceType.POST,
+                    listOf(attachmentId, thumbnailAttachmentId),
+                )
+            }
+            assertThat(savedPost?.thumbnailImage).isEqualTo(thumbnailAttachmentId)
+        }
+
+        @Test
         @DisplayName("발행 게시물 본문의 attachmentId를 확정하고 본문은 그대로 유지한다")
         fun createPost_publishedPost_confirmsAttachmentIdsWithoutRewritingContent() {
             // given
@@ -156,11 +193,97 @@ class PostWriteServiceAttachmentTest {
             }
             assertThat(response.content).contains(attachmentId.toString())
         }
+
     }
 
     @Nested
     @DisplayName("updatePost")
     inner class UpdatePost {
+        @Test
+        @DisplayName("thumbnailAttachmentId가 없으면 기존 thumbnailImage를 우선 유지한다")
+        fun updatePost_withoutThumbnailAttachmentId_keepsCurrentThumbnailImage() {
+            // given
+            val postId = UUID.randomUUID()
+            val currentThumbnailAttachmentId = UUID.randomUUID()
+            val otherAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    thumbnailImage = currentThumbnailAttachmentId,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            val request =
+                UpdatePostRequest(
+                    content = "<img src=\"$currentThumbnailAttachmentId\" /><img src=\"$otherAttachmentId\" />",
+                    attachmentIds = listOf(currentThumbnailAttachmentId, otherAttachmentId),
+                    status = PostStatusEnum.PUBLISHED,
+                )
+
+            // when
+            postWriteService.updatePost(postId, request, author.id!!)
+
+            // then
+            assertThat(post.thumbnailImage).isEqualTo(currentThumbnailAttachmentId)
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(currentThumbnailAttachmentId, otherAttachmentId),
+                )
+            }
+        }
+
+        @Test
+        @DisplayName("수정 시 thumbnailAttachmentId를 별도로 전달하면 본문 첨부와 함께 confirm하고 유지한다")
+        fun updatePost_withSeparateThumbnailAttachment_confirmsAndKeepsThumbnail() {
+            // given
+            val postId = UUID.randomUUID()
+            val contentAttachmentId = UUID.randomUUID()
+            val thumbnailAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            val request =
+                UpdatePostRequest(
+                    content = "<img src=\"$contentAttachmentId\" />",
+                    attachmentIds = listOf(contentAttachmentId),
+                    thumbnailAttachmentId = thumbnailAttachmentId,
+                    status = PostStatusEnum.PUBLISHED,
+                )
+
+            // when
+            postWriteService.updatePost(postId, request, author.id!!)
+
+            // then
+            verify {
+                attachmentService.confirmAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(contentAttachmentId, thumbnailAttachmentId),
+                )
+            }
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(contentAttachmentId, thumbnailAttachmentId),
+                )
+            }
+            assertThat(post.thumbnailImage).isEqualTo(thumbnailAttachmentId)
+        }
+
         @Test
         @DisplayName("요청으로 받은 attachmentId 목록 기준으로 orphan 첨부를 정리한다")
         fun updatePost_attachmentIdsRequest_keepsRequestedAttachments() {
@@ -300,11 +423,13 @@ class PostWriteServiceAttachmentTest {
         fun deletePost_existingPost_deletesAttachmentsBeforePost() {
             // given
             val postId = UUID.randomUUID()
+            val thumbnailAttachmentId = UUID.randomUUID()
             val post =
                 Post(
                     title = "삭제 대상",
                     content = "본문",
                     author = author,
+                    thumbnailImage = thumbnailAttachmentId,
                     status = PostStatusEnum.PUBLISHED,
                 ).apply { id = postId }
             every { postRepository.findPostByIdWithAuthor(postId) } returns post
@@ -318,6 +443,7 @@ class PostWriteServiceAttachmentTest {
                 attachmentService.deleteAttachmentsByReference(postId, AttachmentReferenceType.POST)
                 postRepository.delete(post)
             }
+            assertThat(post.thumbnailImage).isNull()
         }
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -193,7 +193,6 @@ class PostWriteServiceAttachmentTest {
             }
             assertThat(response.content).contains(attachmentId.toString())
         }
-
     }
 
     @Nested


### PR DESCRIPTION
## 관련 자료
- 이슈 : #

## 어떤 작업인가요?
- 게시물 썸네일을 attachment 기반으로 저장하고 목록 조회에서 썸네일만 presigned URL로 노출하도록 정리했습니다.
- tmp 상태 첨부파일을 미리 볼 수 있는 presigned URL API를 추가했습니다.

## 어떻게 해결했나요?
**tmp 미리보기 API 추가**
- TMP 상태이면서 `tmp/` 경로를 가진 첨부파일만 미리보기 presigned URL을 발급하도록 검증 로직을 추가했습니다.
- 단건/다건 미리보기 URL 조회 API와 DTO, 문서를 함께 추가했습니다.

**게시물 썸네일 저장 구조 정리**
- 게시물에 `thumbnail_image` 컬럼을 추가하고 기존 attachment 중 첫 첨부를 썸네일로 백필하는 마이그레이션을 추가했습니다.
- 게시물 생성/수정 시 본문 첨부와 썸네일 첨부를 함께 confirm 및 orphan 정리 대상으로 처리하도록 변경했습니다.
- 목록 조회에서는 게시물별 썸네일 attachment 1개만 선택해 presigned URL을 발급하도록 줄였습니다.

**테스트 보강**
- tmp 미리보기 URL 발급 검증 테스트를 추가했습니다.
- 게시물 목록 썸네일 선택, 게시물 저장/수정 시 썸네일 confirm 및 keep 처리 테스트를 추가했습니다.

## 중요한 변경 사항은 무엇인가요?
### tmp 미리보기 API

**TMP 첨부파일 미리보기 URL 발급 추가**
- **변경 이유**: 미리보기 화면에서 tmp 업로드 이미지를 바로 확인할 수 있어야 합니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt`, `src/main/kotlin/com/techtaurant/mainserver/attachment/infrastructure/in/AttachmentController.kt`, `src/main/kotlin/com/techtaurant/mainserver/attachment/infrastructure/in/AttachmentControllerDocs.kt`, `src/main/kotlin/com/techtaurant/mainserver/attachment/dto/AttachmentPreviewUrlResponse.kt`, `src/main/kotlin/com/techtaurant/mainserver/attachment/dto/AttachmentPreviewUrlsRequest.kt`

### 게시물 썸네일 attachment 저장

**게시물에 대표 썸네일 attachment 저장**
- **변경 이유**: 목록 조회에서 전체 첨부파일을 모두 썸네일 후보로 다루지 않고 대표 썸네일만 안정적으로 선택하기 위해서입니다.
- **수정 파일**: `src/main/resources/db/migration/V20__add_post_thumbnail_image.sql`, `src/main/kotlin/com/techtaurant/mainserver/post/entity/Post.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/dto/CreatePostRequest.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt`

**목록 조회에서 썸네일만 presigned URL 발급**
- **변경 이유**: 게시물 목록 응답에서 필요한 썸네일 1개만 URL을 발급해 불필요한 presigned URL 생성을 줄이기 위해서입니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt`

**테스트 보강**
- **변경 이유**: tmp 미리보기와 게시물 썸네일 저장/조회 동작을 회귀 없이 유지하기 위해서입니다.
- **수정 파일**: `src/test/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentServiceTest.kt`, `src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt`, `src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt`