### PR TITLE
modify(post): 상세 조회 응답에서 첨부 presigned URL 매핑을 분리

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt
@@ -4,6 +4,7 @@ import com.techtaurant.mainserver.attachment.application.AttachmentService
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
 import com.techtaurant.mainserver.common.enums.LikeStatus
 import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.post.dto.PostDetailAttachmentPresignedUrlResponse
 import com.techtaurant.mainserver.post.dto.PostDetailResponse
 import com.techtaurant.mainserver.post.enums.PostStatus
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
@@ -78,13 +79,12 @@ class PostDetailReadService(
                 postReadLogRepository.existsByPostIdAndUserId(postId, it)
             } ?: false
 
-        val contentWithPresignedUrls =
+        val attachmentPresignedUrls =
             attachmentService.generatePresignedDownloadUrlMapByReference(postId, AttachmentReferenceType.POST)
-                .entries
-                .fold(post.content) { acc, (attachmentId, presignedUrl) ->
-                    acc.replace(attachmentId.toString(), presignedUrl)
+                .map { (attachmentId, presignedUrl) ->
+                    PostDetailAttachmentPresignedUrlResponse.from(attachmentId, presignedUrl)
                 }
 
-        return PostDetailResponse.from(post, likeStatus, isRead, contentWithPresignedUrls)
+        return PostDetailResponse.from(post, likeStatus, isRead, attachmentPresignedUrls = attachmentPresignedUrls)
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostDetailResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostDetailResponse.kt
@@ -23,6 +23,7 @@ import java.util.UUID
  * @property likeStatus 현재 사용자의 좋아요 상태
  * @property status 게시물 상태 (DRAFT: 임시저장, PUBLISHED: 발행, PRIVATE: 비공개)
  * @property isRead 현재 사용자가 읽음 표시한 게시물인지 여부 (비회원은 항상 false)
+ * @property attachmentPresignedUrls attachmentId와 presigned URL 매핑 목록
  * @property createdAt 작성일
  * @property updatedAt 수정일
  */
@@ -52,6 +53,8 @@ data class PostDetailResponse(
     val status: PostStatusEnum,
     @field:Schema(description = "현재 사용자가 읽음 표시한 게시물인지 여부")
     val isRead: Boolean,
+    @field:Schema(description = "attachmentId와 presigned URL 매핑 목록")
+    val attachmentPresignedUrls: List<PostDetailAttachmentPresignedUrlResponse>,
     @field:Schema(description = "작성일")
     val createdAt: Date,
     @field:Schema(description = "수정일")
@@ -64,6 +67,7 @@ data class PostDetailResponse(
          * @param post 게시물 엔티티
          * @param likeStatus 현재 사용자의 좋아요 상태
          * @param isRead 현재 사용자가 읽음 표시한 게시물인지 여부
+         * @param attachmentPresignedUrls attachmentId와 presigned URL 매핑 목록
          * @return 게시물 상세 응답 DTO
          */
         fun from(
@@ -71,6 +75,7 @@ data class PostDetailResponse(
             likeStatus: LikeStatus,
             isRead: Boolean,
             content: String = post.content,
+            attachmentPresignedUrls: List<PostDetailAttachmentPresignedUrlResponse> = emptyList(),
         ): PostDetailResponse =
             PostDetailResponse(
                 id = post.id!!,
@@ -85,8 +90,28 @@ data class PostDetailResponse(
                 likeStatus = likeStatus,
                 status = post.status,
                 isRead = isRead,
+                attachmentPresignedUrls = attachmentPresignedUrls,
                 createdAt = post.createdAt,
                 updatedAt = post.updatedAt,
+            )
+    }
+}
+
+@Schema(description = "게시물 본문 attachment presigned URL 매핑")
+data class PostDetailAttachmentPresignedUrlResponse(
+    @field:Schema(description = "첨부파일 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+    val attachmentId: UUID,
+    @field:Schema(description = "첨부파일 다운로드용 presigned URL", example = "https://techtaurant-media.s3.ap-northeast-2.amazonaws.com/post/...")
+    val presignedUrl: String,
+) {
+    companion object {
+        fun from(
+            attachmentId: UUID,
+            presignedUrl: String,
+        ): PostDetailAttachmentPresignedUrlResponse =
+            PostDetailAttachmentPresignedUrlResponse(
+                attachmentId = attachmentId,
+                presignedUrl = presignedUrl,
             )
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadServiceTest.kt
@@ -62,8 +62,8 @@ class PostDetailReadServiceTest {
     @DisplayName("getPostDetail")
     inner class GetPostDetail {
         @Test
-        @DisplayName("연결된 attachmentId를 presigned URL로 치환한다")
-        fun getPostDetail_attachmentReferences_replacesContentTargets() {
+        @DisplayName("연결된 attachmentId와 presigned URL 매핑을 별도 필드로 반환한다")
+        fun getPostDetail_attachmentReferences_returnsPresignedUrlMappings() {
             // given
             val postId = UUID.randomUUID()
             val viewerId = UUID.randomUUID()
@@ -93,7 +93,10 @@ class PostDetailReadServiceTest {
             // then
             assertThat(result.likeStatus).isEqualTo(LikeStatus.NONE)
             assertThat(result.isRead).isTrue()
-            assertThat(result.content).contains("https://cdn.example.com/attachment.png")
+            assertThat(result.content).isEqualTo(content)
+            val attachmentPresignedUrl = result.attachmentPresignedUrls.single()
+            assertThat(attachmentPresignedUrl.attachmentId).isEqualTo(attachmentId)
+            assertThat(attachmentPresignedUrl.presignedUrl).isEqualTo("https://cdn.example.com/attachment.png")
             verify {
                 postViewLogService.recordView(postId, viewerId, "127.0.0.1", "JUnit")
             }
@@ -119,6 +122,7 @@ class PostDetailReadServiceTest {
 
             // then
             assertThat(result.isRead).isFalse()
+            assertThat(result.attachmentPresignedUrls).isEmpty()
         }
 
         @Test
@@ -145,6 +149,7 @@ class PostDetailReadServiceTest {
 
             // then
             assertThat(result.likeStatus).isEqualTo(LikeStatus.LIKE)
+            assertThat(result.attachmentPresignedUrls).isEmpty()
         }
     }
 }


### PR DESCRIPTION
## 어떤 작업인가요?
- 게시물 상세 조회 응답에서 본문 내 attachmentId를 백엔드가 presigned URL로 치환하지 않고, 프론트엔드가 치환할 수 있도록 별도 매핑 정보를 반환하도록 변경했습니다.

## 어떻게 해결했나요?
**상세 응답 계약 변경**
- `PostDetailResponse`에 `attachmentPresignedUrls` 필드를 추가했습니다.
- `content`는 attachmentId가 포함된 원문을 그대로 유지하도록 변경했습니다.

**서비스 로직 정리**
- `PostDetailReadService`에서 본문 문자열 치환 로직을 제거했습니다.
- attachmentId별 presigned URL을 응답 DTO 목록으로 변환해 내려주도록 수정했습니다.

**테스트 갱신**
- 상세 조회 서비스 테스트를 새 응답 계약에 맞게 수정했습니다.
- 본문 원문 유지와 빈 매핑 목록 케이스를 함께 검증하도록 보강했습니다.

## 중요한 변경 사항은 무엇인가요?
### 상세 응답 구조 변경
**본문 치환 제거**
- **변경 이유**: presigned URL 치환 책임을 프론트엔드로 넘기기 위해
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt`

**attachment 매핑 필드 추가**
- **변경 이유**: attachmentId와 presigned URL의 대응 관계를 명시적으로 전달하기 위해
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/post/dto/PostDetailResponse.kt`

### 테스트 계약 갱신
**상세 조회 테스트 수정**
- **변경 이유**: 기존 URL 치환 기대값을 새 응답 구조에 맞추기 위해
- **수정 파일**: `src/test/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadServiceTest.kt`