### PR TITLE
modify(user): 사용자 프로필 이미지 업데이트를 지원

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
@@ -108,7 +108,7 @@ class AttachmentService(
 
     /**
      * attachmentId에 해당하는 TMP Attachment를 CONFIRMED 상태로 전환합니다.
-     * S3 파일을 tmp/ 경로에서 posts/{referenceId}/ 경로로 이동합니다.
+     * S3 파일을 tmp/ 경로에서 referenceType에 맞는 확정 경로로 이동합니다.
      *
      * @param referenceId 연관 도메인 PK (게시물 ID 등)
      * @param referenceType 연관 도메인 타입
@@ -139,7 +139,7 @@ class AttachmentService(
 
             val uniqueId = UUID.randomUUID()
             val fileName = tmpObjectKey.substringAfterLast("/")
-            val newObjectKey = "posts/$referenceId/$uniqueId/$fileName"
+            val newObjectKey = buildConfirmedObjectKey(referenceType, referenceId, uniqueId, fileName)
 
             s3StorageService.copyObject(
                 sourceKey = tmpObjectKey,
@@ -287,6 +287,21 @@ class AttachmentService(
         if (!s3StorageService.exists(attachment.objectKey)) {
             throw ApiException(DefaultStatus.NOT_FOUND, "S3에 임시 첨부파일이 존재하지 않습니다")
         }
+    }
+
+    private fun buildConfirmedObjectKey(
+        referenceType: AttachmentReferenceType,
+        referenceId: UUID,
+        uniqueId: UUID,
+        fileName: String,
+    ): String {
+        val prefix =
+            when (referenceType) {
+                AttachmentReferenceType.POST -> "posts"
+                AttachmentReferenceType.USER -> "users"
+            }
+
+        return "$prefix/$referenceId/$uniqueId/$fileName"
     }
 
     /**

--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/enums/AttachmentReferenceType.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/enums/AttachmentReferenceType.kt
@@ -2,4 +2,5 @@ package com.techtaurant.mainserver.attachment.enums
 
 enum class AttachmentReferenceType {
     POST,
+    USER,
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserReadService.kt
@@ -10,6 +10,7 @@ import java.util.UUID
 @Service
 class UserReadService(
     private val userRepository: UserRepository,
+    private val userResponseAssembler: UserResponseAssembler,
 ) {
     fun getMe(userId: UUID): UserResponse {
         // SecurityContext에서 userId를 받아 DB에서 User 조회
@@ -17,11 +18,11 @@ class UserReadService(
             userRepository.findById(userId).orElseThrow {
                 ApiException(UserStatus.ID_NOT_FOUND)
             }
-        return UserResponse.from(user)
+        return userResponseAssembler.assemble(user)
     }
 
     fun searchByName(name: String): List<UserResponse> {
         val users = userRepository.findByNameContainingIgnoreCaseOrderByNameAsc(name)
-        return users.map { UserResponse.from(it) }
+        return userResponseAssembler.assemble(users)
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserResponseAssembler.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserResponseAssembler.kt
@@ -1,0 +1,42 @@
+package com.techtaurant.mainserver.user.application
+
+import com.techtaurant.mainserver.attachment.application.AttachmentService
+import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
+import com.techtaurant.mainserver.user.dto.UserResponse
+import com.techtaurant.mainserver.user.entity.User
+import org.springframework.stereotype.Component
+
+@Component
+class UserResponseAssembler(
+    private val attachmentService: AttachmentService,
+) {
+    fun assemble(user: User): UserResponse {
+        return assemble(listOf(user)).first()
+    }
+
+    fun assemble(users: List<User>): List<UserResponse> {
+        if (users.isEmpty()) {
+            return emptyList()
+        }
+
+        val userIds = users.mapNotNull { it.id }
+        val attachmentsByUserId =
+            if (userIds.isNotEmpty()) {
+                attachmentService.getConfirmedAttachmentsByReferenceIds(userIds, AttachmentReferenceType.USER)
+            } else {
+                emptyMap()
+            }
+        val presignedUrlByAttachmentId =
+            attachmentService.generatePresignedDownloadUrlMapByAttachments(
+                attachmentsByUserId.values.flatten(),
+            )
+
+        return users.map { user ->
+            val profileImageUrl =
+                user.serviceProfileImageAttachmentId
+                    ?.let { presignedUrlByAttachmentId[it] }
+                    ?: user.profileImageUrl
+            UserResponse.from(user, profileImageUrl)
+        }
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserWriteService.kt
@@ -1,0 +1,60 @@
+package com.techtaurant.mainserver.user.application
+
+import com.techtaurant.mainserver.attachment.application.AttachmentService
+import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.common.status.DefaultStatus
+import com.techtaurant.mainserver.user.dto.UpdateUserRequest
+import com.techtaurant.mainserver.user.dto.UserResponse
+import com.techtaurant.mainserver.user.enums.UserStatus
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class UserWriteService(
+    private val userRepository: UserRepository,
+    private val attachmentService: AttachmentService,
+    private val userResponseAssembler: UserResponseAssembler,
+) {
+    @Transactional
+    fun updateMe(
+        userId: UUID,
+        request: UpdateUserRequest,
+    ): UserResponse {
+        val user =
+            userRepository.findById(userId).orElseThrow {
+                ApiException(UserStatus.ID_NOT_FOUND)
+            }
+
+        request.name?.let { requestedName ->
+            val normalizedName = requestedName.trim()
+            if (normalizedName.isEmpty()) {
+                throw ApiException(DefaultStatus.BAD_REQUEST, "이름은 공백일 수 없습니다")
+            }
+            user.name = normalizedName
+        }
+
+        if (request.hasServiceProfileImageAttachmentId()) {
+            val attachmentId = request.parseServiceProfileImageAttachmentId()
+            user.serviceProfileImageAttachmentId = attachmentId
+
+            if (attachmentId != null) {
+                attachmentService.confirmAttachmentsByIds(
+                    referenceId = userId,
+                    referenceType = AttachmentReferenceType.USER,
+                    attachmentIds = listOf(attachmentId),
+                )
+            }
+
+            attachmentService.deleteOrphanedAttachmentsByIds(
+                referenceId = userId,
+                referenceType = AttachmentReferenceType.USER,
+                keepAttachmentIds = listOfNotNull(attachmentId),
+            )
+        }
+
+        return userResponseAssembler.assemble(user)
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UpdateUserRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UpdateUserRequest.kt
@@ -1,0 +1,33 @@
+package com.techtaurant.mainserver.user.dto
+
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.common.status.DefaultStatus
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
+import java.util.UUID
+
+@Schema(description = "사용자 정보 수정 요청")
+data class UpdateUserRequest(
+    @field:Size(max = 255, message = "이름은 최대 255자까지 가능합니다")
+    @field:Schema(description = "수정할 이름", example = "테크식당")
+    val name: String? = null,
+    @field:Schema(
+        description = "서비스에 등록한 프로필 이미지 attachment ID. null이거나 생략하면 변경하지 않습니다.",
+        example = "01234567-89ab-cdef-0123-456789abcdef",
+        nullable = true,
+    )
+    val serviceProfileImageAttachmentId: String? = null,
+) {
+    fun hasServiceProfileImageAttachmentId(): Boolean {
+        return serviceProfileImageAttachmentId != null
+    }
+
+    fun parseServiceProfileImageAttachmentId(): UUID? {
+        return serviceProfileImageAttachmentId?.let { rawValue ->
+            runCatching { UUID.fromString(rawValue) }
+                .getOrElse {
+                    throw ApiException(DefaultStatus.BAD_REQUEST, "serviceProfileImageAttachmentId는 UUID 형식이어야 합니다")
+                }
+        }
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserResponse.kt
@@ -18,12 +18,15 @@ data class UserResponse(
     val profileImageUrl: String,
 ) {
     companion object {
-        fun from(user: User): UserResponse {
+        fun from(
+            user: User,
+            profileImageUrl: String,
+        ): UserResponse {
             return UserResponse(
                 id = user.id ?: throw ApiException(UserStatus.ID_NOT_FOUND),
                 name = user.name,
                 email = user.email,
-                profileImageUrl = user.profileImageUrl,
+                profileImageUrl = profileImageUrl,
             )
         }
     }

--- a/src/main/kotlin/com/techtaurant/mainserver/user/entity/User.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/entity/User.kt
@@ -8,9 +8,8 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
-import java.util.UUID
 import jakarta.persistence.UniqueConstraint
-
+import java.util.UUID
 
 @Entity
 @Table(

--- a/src/main/kotlin/com/techtaurant/mainserver/user/entity/User.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/entity/User.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Table
+import java.util.UUID
 
 @Entity
 @Table(name = "users")
@@ -23,4 +24,6 @@ class User(
     var role: UserRole,
     @Column(name = "profile_image_url")
     var profileImageUrl: String,
+    @Column(name = "service_profile_image_attachment_id")
+    var serviceProfileImageAttachmentId: UUID? = null,
 ) : EntityBase()

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserController.kt
@@ -1,20 +1,26 @@
 package com.techtaurant.mainserver.user.infrastructure.`in`
 
 import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.swagger.ApiErrorResponses
 import com.techtaurant.mainserver.security.SecurityConstants
 import com.techtaurant.mainserver.user.application.UserBanService
 import com.techtaurant.mainserver.user.application.UserFollowService
 import com.techtaurant.mainserver.user.application.UserReadService
+import com.techtaurant.mainserver.user.application.UserWriteService
+import com.techtaurant.mainserver.user.dto.UpdateUserRequest
 import com.techtaurant.mainserver.user.dto.UserBanListItemResponse
 import com.techtaurant.mainserver.user.dto.UserBanResponse
 import com.techtaurant.mainserver.user.dto.UserFollowResponse
 import com.techtaurant.mainserver.user.dto.UserResponse
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
@@ -24,6 +30,7 @@ import java.util.UUID
 @RequestMapping("${SecurityConstants.API_PREFIX}/users")
 class UserController(
     private val userReadService: UserReadService,
+    private val userWriteService: UserWriteService,
     private val userBanService: UserBanService,
     private val userFollowService: UserFollowService,
 ) : UserControllerDocs {
@@ -32,6 +39,15 @@ class UserController(
         @AuthenticationPrincipal userId: UUID,
     ): ApiResponse<UserResponse> {
         return ApiResponse.ok(userReadService.getMe(userId))
+    }
+
+    @ApiErrorResponses(includeAuthenticationErrors = true, includeValidationError = true)
+    @PatchMapping("/me")
+    override fun updateMe(
+        @AuthenticationPrincipal userId: UUID,
+        @Valid @RequestBody request: UpdateUserRequest,
+    ): ApiResponse<UserResponse> {
+        return ApiResponse.ok(userWriteService.updateMe(userId, request))
     }
 
     @PostMapping("/{targetUserId}/ban")

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerDocs.kt
@@ -5,6 +5,7 @@ import com.techtaurant.mainserver.common.status.DefaultStatus
 import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponse
 import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponses
 import com.techtaurant.mainserver.security.jwt.JwtStatus
+import com.techtaurant.mainserver.user.dto.UpdateUserRequest
 import com.techtaurant.mainserver.user.dto.UserBanListItemResponse
 import com.techtaurant.mainserver.user.dto.UserBanResponse
 import com.techtaurant.mainserver.user.dto.UserFollowResponse
@@ -12,6 +13,7 @@ import com.techtaurant.mainserver.user.dto.UserResponse
 import com.techtaurant.mainserver.user.enums.UserStatus
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
 import java.util.UUID
 import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 
@@ -30,6 +32,23 @@ interface UserControllerDocs {
         ],
     )
     fun getMe(userId: UUID): ApiResponse<UserResponse>
+
+    @Operation(summary = "내 정보 수정", description = "현재 로그인한 사용자의 이름과 서비스 프로필 이미지를 수정합니다")
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "수정 성공",
+    )
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED"]),
+            ApiErrorCodeResponse(UserStatus::class, ["ID_NOT_FOUND"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["BAD_REQUEST", "UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun updateMe(
+        userId: UUID,
+        @Valid request: UpdateUserRequest,
+    ): ApiResponse<UserResponse>
 
     @Operation(summary = "사용자 차단", description = "현재 로그인한 사용자가 특정 사용자를 차단합니다")
     @SwaggerApiResponse(

--- a/src/main/resources/db/migration/V22__add_user_service_profile_image.sql
+++ b/src/main/resources/db/migration/V22__add_user_service_profile_image.sql
@@ -1,0 +1,8 @@
+ALTER TYPE attachment_reference_type ADD VALUE IF NOT EXISTS 'USER';
+
+ALTER TABLE users
+    ADD COLUMN service_profile_image_attachment_id UUID;
+
+ALTER TABLE users
+    ADD CONSTRAINT fk_users_service_profile_image_attachment
+        FOREIGN KEY (service_profile_image_attachment_id) REFERENCES attachments(id) ON DELETE SET NULL;

--- a/src/test/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentServiceTest.kt
@@ -183,6 +183,26 @@ class AttachmentServiceTest {
             assertThat(tmpAttachment.referenceId).isEqualTo(postId)
             assertThat(tmpAttachment.referenceType).isEqualTo(AttachmentReferenceType.POST)
         }
+
+        @Test
+        @DisplayName("USER attachment는 users/{referenceId} 경로로 이동한다")
+        fun confirmAttachmentsByIds_userAttachment_movesToUsersPath() {
+            val userId = UUID.randomUUID()
+            val userAttachment =
+                makeAttachment(tmpKey, AttachmentStatus.TMP, referenceId = null).apply {
+                    referenceType = AttachmentReferenceType.USER
+                }
+            every { attachmentRepository.findAllById(listOf(userAttachment.id!!)) } returns listOf(userAttachment)
+
+            attachmentService.confirmAttachmentsByIds(
+                referenceId = userId,
+                referenceType = AttachmentReferenceType.USER,
+                attachmentIds = listOf(userAttachment.id!!),
+            )
+
+            assertThat(userAttachment.objectKey).startsWith("users/$userId/")
+            assertThat(userAttachment.objectKey).endsWith("photo.jpg")
+        }
     }
 
     @Nested

--- a/src/test/kotlin/com/techtaurant/mainserver/user/application/UserResponseAssemblerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/application/UserResponseAssemblerTest.kt
@@ -1,0 +1,88 @@
+package com.techtaurant.mainserver.user.application
+
+import com.techtaurant.mainserver.attachment.application.AttachmentService
+import com.techtaurant.mainserver.attachment.entity.Attachment
+import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
+import com.techtaurant.mainserver.attachment.enums.AttachmentStatus
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class UserResponseAssemblerTest {
+    private val attachmentService: AttachmentService = mockk()
+    private val userResponseAssembler = UserResponseAssembler(attachmentService)
+
+    @Test
+    @DisplayName("서비스 프로필 이미지 attachment가 있으면 presigned URL을 우선 반환한다")
+    fun assemble_serviceProfileImageAttachment_usesPresignedUrl() {
+        val userId = UUID.randomUUID()
+        val attachmentId = UUID.randomUUID()
+        val user = createUser(userId, attachmentId)
+        val attachment = createAttachment(userId, attachmentId)
+
+        every {
+            attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(userId), AttachmentReferenceType.USER)
+        } returns mapOf(userId to listOf(attachment))
+        every {
+            attachmentService.generatePresignedDownloadUrlMapByAttachments(listOf(attachment))
+        } returns mapOf(attachmentId to "https://cdn.example.com/profile.png")
+
+        val response = userResponseAssembler.assemble(user)
+
+        assertThat(response.profileImageUrl).isEqualTo("https://cdn.example.com/profile.png")
+    }
+
+    @Test
+    @DisplayName("서비스 프로필 이미지 attachment가 없으면 기본 profileImageUrl을 사용한다")
+    fun assemble_withoutServiceProfileImage_usesFallbackUrl() {
+        val userId = UUID.randomUUID()
+        val user = createUser(userId, null)
+
+        every {
+            attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(userId), AttachmentReferenceType.USER)
+        } returns emptyMap()
+        every {
+            attachmentService.generatePresignedDownloadUrlMapByAttachments(emptyList())
+        } returns emptyMap()
+
+        val response = userResponseAssembler.assemble(user)
+
+        assertThat(response.profileImageUrl).isEqualTo("https://example.com/default-profile.jpg")
+    }
+
+    private fun createUser(
+        userId: UUID,
+        attachmentId: UUID?,
+    ): User {
+        return User(
+            name = "테스트사용자",
+            email = "user@example.com",
+            provider = OAuthProvider.GOOGLE,
+            identifier = "google-${UUID.randomUUID()}",
+            role = UserRole.USER,
+            profileImageUrl = "https://example.com/default-profile.jpg",
+            serviceProfileImageAttachmentId = attachmentId,
+        ).apply { id = userId }
+    }
+
+    private fun createAttachment(
+        userId: UUID,
+        attachmentId: UUID,
+    ): Attachment {
+        return Attachment(
+            referenceId = userId,
+            referenceType = AttachmentReferenceType.USER,
+            objectKey = "users/$userId/$attachmentId/profile.png",
+            status = AttachmentStatus.CONFIRMED,
+            originalFileName = "profile.png",
+            contentType = "image/png",
+            fileSize = 1024L,
+        ).apply { id = attachmentId }
+    }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/user/application/UserWriteServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/application/UserWriteServiceTest.kt
@@ -1,0 +1,137 @@
+package com.techtaurant.mainserver.user.application
+
+import com.techtaurant.mainserver.attachment.application.AttachmentService
+import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.dto.UpdateUserRequest
+import com.techtaurant.mainserver.user.dto.UserResponse
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.Optional
+import java.util.UUID
+
+class UserWriteServiceTest {
+    private val userRepository: UserRepository = mockk()
+    private val attachmentService: AttachmentService = mockk()
+    private val userResponseAssembler: UserResponseAssembler = mockk()
+
+    private val userWriteService =
+        UserWriteService(
+            userRepository = userRepository,
+            attachmentService = attachmentService,
+            userResponseAssembler = userResponseAssembler,
+        )
+
+    private lateinit var user: User
+
+    @BeforeEach
+    fun setUp() {
+        user =
+            User(
+                name = "기존이름",
+                email = "user@example.com",
+                provider = OAuthProvider.GOOGLE,
+                identifier = "google-${UUID.randomUUID()}",
+                role = UserRole.USER,
+                profileImageUrl = "https://example.com/default-profile.jpg",
+            ).apply { id = UUID.randomUUID() }
+
+        every { userRepository.findById(user.id!!) } returns Optional.of(user)
+        every {
+            userResponseAssembler.assemble(any<User>())
+        } answers {
+            val targetUser = firstArg<User>()
+            UserResponse.from(targetUser, targetUser.profileImageUrl)
+        }
+        every { attachmentService.confirmAttachmentsByIds(any(), any(), any()) } just runs
+        every { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) } just runs
+    }
+
+    @Test
+    @DisplayName("이름만 수정하면 공백을 제거하고 attachment 작업은 수행하지 않는다")
+    fun updateMe_nameOnly_updatesTrimmedName() {
+        val response =
+            userWriteService.updateMe(
+                userId = user.id!!,
+                request = UpdateUserRequest(name = "  새이름  "),
+            )
+
+        assertThat(user.name).isEqualTo("새이름")
+        assertThat(response.name).isEqualTo("새이름")
+
+        verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
+        verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
+    }
+
+    @Test
+    @DisplayName("서비스 프로필 이미지를 설정하면 USER attachment를 확정하고 해당 ID만 유지한다")
+    fun updateMe_serviceProfileImage_confirmsAndKeepsAttachment() {
+        val attachmentId = UUID.randomUUID()
+
+        userWriteService.updateMe(
+            userId = user.id!!,
+            request = UpdateUserRequest(serviceProfileImageAttachmentId = attachmentId.toString()),
+        )
+
+        assertThat(user.serviceProfileImageAttachmentId).isEqualTo(attachmentId)
+        verify {
+            attachmentService.confirmAttachmentsByIds(
+                referenceId = user.id!!,
+                referenceType = AttachmentReferenceType.USER,
+                attachmentIds = listOf(attachmentId),
+            )
+        }
+        verify {
+            attachmentService.deleteOrphanedAttachmentsByIds(
+                referenceId = user.id!!,
+                referenceType = AttachmentReferenceType.USER,
+                keepAttachmentIds = listOf(attachmentId),
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("서비스 프로필 이미지에 null을 보내면 기존 attachment 연결을 유지한다")
+    fun updateMe_nullServiceProfileImage_keepsAttachment() {
+        val existingAttachmentId = UUID.randomUUID()
+        user.serviceProfileImageAttachmentId = existingAttachmentId
+
+        // given
+
+        // when
+        userWriteService.updateMe(
+            userId = user.id!!,
+            request = UpdateUserRequest(serviceProfileImageAttachmentId = null),
+        )
+
+        // then
+        assertThat(user.serviceProfileImageAttachmentId).isEqualTo(existingAttachmentId)
+        verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
+        verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
+    }
+
+    @Test
+    @DisplayName("이름이 공백만 있으면 BAD_REQUEST 예외를 던진다")
+    fun updateMe_blankName_throwsBadRequest() {
+        assertThatThrownBy {
+            userWriteService.updateMe(
+                userId = user.id!!,
+                request = UpdateUserRequest(name = "   "),
+            )
+        }
+            .isInstanceOf(ApiException::class.java)
+            .hasMessage("이름은 공백일 수 없습니다")
+    }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/user/dto/UpdateUserRequestTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/dto/UpdateUserRequestTest.kt
@@ -1,0 +1,51 @@
+package com.techtaurant.mainserver.user.dto
+
+import com.techtaurant.mainserver.common.exception.ApiException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class UpdateUserRequestTest {
+    @Test
+    @DisplayName("서비스 프로필 이미지 attachment ID가 null이면 변경 대상으로 보지 않는다")
+    fun hasServiceProfileImageAttachmentId_null_returnsFalse() {
+        // given
+        val request = UpdateUserRequest(serviceProfileImageAttachmentId = null)
+
+        // when
+        val hasAttachmentId = request.hasServiceProfileImageAttachmentId()
+        val parsedAttachmentId = request.parseServiceProfileImageAttachmentId()
+
+        // then
+        assertThat(hasAttachmentId).isFalse()
+        assertThat(parsedAttachmentId).isNull()
+    }
+
+    @Test
+    @DisplayName("서비스 프로필 이미지 attachment ID가 UUID 문자열이면 파싱한다")
+    fun parseServiceProfileImageAttachmentId_validUuid_returnsUuid() {
+        // given
+        val attachmentId = UUID.randomUUID()
+        val request = UpdateUserRequest(serviceProfileImageAttachmentId = attachmentId.toString())
+
+        // when
+        val parsedAttachmentId = request.parseServiceProfileImageAttachmentId()
+
+        // then
+        assertThat(parsedAttachmentId).isEqualTo(attachmentId)
+    }
+
+    @Test
+    @DisplayName("서비스 프로필 이미지 attachment ID가 UUID 형식이 아니면 예외를 던진다")
+    fun parseServiceProfileImageAttachmentId_invalidUuid_throwsBadRequest() {
+        // given
+        val request = UpdateUserRequest(serviceProfileImageAttachmentId = "invalid-uuid")
+
+        // when then
+        assertThatThrownBy { request.parseServiceProfileImageAttachmentId() }
+            .isInstanceOf(ApiException::class.java)
+            .hasMessage("serviceProfileImageAttachmentId는 UUID 형식이어야 합니다")
+    }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerProfileIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerProfileIntegrationTest.kt
@@ -1,0 +1,85 @@
+package com.techtaurant.mainserver.user.infrastructure.`in`
+
+import com.techtaurant.mainserver.attachment.infrastructure.out.AttachmentRepository
+import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
+import com.techtaurant.mainserver.user.dto.UpdateUserRequest
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
+import com.techtaurant.mainserver.user.infrastructure.out.UserFollowRepository
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import io.restassured.RestAssured.given
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+@DisplayName("UserController profile 통합 테스트")
+class UserControllerProfileIntegrationTest : IntegrationTest() {
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var userBanRepository: UserBanRepository
+
+    @Autowired
+    private lateinit var userFollowRepository: UserFollowRepository
+
+    @Autowired
+    private lateinit var attachmentRepository: AttachmentRepository
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    private lateinit var testUser: User
+    private lateinit var accessToken: String
+
+    @BeforeEach
+    fun setUpTestData() {
+        userBanRepository.deleteAllInBatch()
+        userFollowRepository.deleteAllInBatch()
+        userRepository.deleteAllInBatch()
+        attachmentRepository.deleteAllInBatch()
+
+        testUser =
+            userRepository.save(
+                User(
+                    name = "테스트사용자",
+                    email = "test-${UUID.randomUUID()}@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "test-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/default-profile.jpg",
+                ),
+            )
+        accessToken = jwtTokenProvider.createAccessToken(testUser.id!!, testUser.role)
+    }
+
+    @Test
+    @DisplayName("내 이름 수정이 성공한다")
+    fun updateMe_name_success() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", "Bearer $accessToken")
+            .body(UpdateUserRequest(name = "새이름"))
+            .`when`()
+            .patch("/api/users/me")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.name", equalTo("새이름"))
+            .body("data.profileImageUrl", equalTo("https://example.com/default-profile.jpg"))
+
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .get("/api/users/me")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.name", equalTo("새이름"))
+    }
+}


### PR DESCRIPTION
## Summary
- 사용자 프로필 이미지 attachment ID를 저장하고 `PATCH /api/users/me`에서 이름 및 프로필 이미지 업데이트를 처리합니다.
- USER referenceType에 맞는 attachment 확정 경로와 presigned 프로필 이미지 응답 조립 로직을 추가했습니다.
- 마이그레이션과 단위 테스트, 프로필 수정 통합 테스트를 함께 추가했습니다.

## Test
- ./gradlew test --tests com.techtaurant.mainserver.user.application.UserWriteServiceTest --tests com.techtaurant.mainserver.user.dto.UpdateUserRequestTest -x jacocoTestReport -x jacocoTestCoverageVerification