### PR TITLE
fix(user): 닉네임 중복 시 충돌 응답 반환

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserWriteService.kt
@@ -8,6 +8,7 @@ import com.techtaurant.mainserver.user.dto.UpdateUserRequest
 import com.techtaurant.mainserver.user.dto.UserResponse
 import com.techtaurant.mainserver.user.enums.UserStatus
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -18,6 +19,10 @@ class UserWriteService(
     private val attachmentService: AttachmentService,
     private val userResponseAssembler: UserResponseAssembler,
 ) {
+    companion object {
+        private const val USER_NAME_UNIQUE_CONSTRAINT = "uk_users_name"
+    }
+
     @Transactional
     fun updateMe(
         userId: UUID,
@@ -34,6 +39,15 @@ class UserWriteService(
                 throw ApiException(DefaultStatus.BAD_REQUEST, "이름은 공백일 수 없습니다")
             }
             user.name = normalizedName
+
+            try {
+                userRepository.flush()
+            } catch (exception: DataIntegrityViolationException) {
+                if (isUserNameUniqueConstraintViolation(exception)) {
+                    throw ApiException(UserStatus.USER_NAME_ALREADY_EXISTS)
+                }
+                throw exception
+            }
         }
 
         if (request.hasServiceProfileImageAttachmentId()) {
@@ -56,5 +70,11 @@ class UserWriteService(
         }
 
         return userResponseAssembler.assemble(user)
+    }
+
+    private fun isUserNameUniqueConstraintViolation(exception: DataIntegrityViolationException): Boolean {
+        return generateSequence<Throwable>(exception) { current -> current.cause }
+            .mapNotNull { throwable -> throwable.message }
+            .any { message -> message.contains(USER_NAME_UNIQUE_CONSTRAINT, ignoreCase = true) }
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/user/enums/UserStatus.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/enums/UserStatus.kt
@@ -16,6 +16,7 @@ enum class UserStatus(
     CANNOT_FOLLOW_SELF(HttpStatus.BAD_REQUEST.value(), 1006, "자기 자신은 팔로우할 수 없습니다"),
     USER_ALREADY_FOLLOWED(HttpStatus.CONFLICT.value(), 1007, "이미 팔로우한 사용자입니다"),
     USER_FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 1008, "팔로우 관계를 찾을 수 없습니다"),
+    USER_NAME_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), 1009, "이미 사용 중인 닉네임입니다"),
     ;
 
     override fun getHttpStatusCode(): Int {

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerDocs.kt
@@ -41,7 +41,7 @@ interface UserControllerDocs {
     @ApiErrorCodeResponses(
         [
             ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED"]),
-            ApiErrorCodeResponse(UserStatus::class, ["ID_NOT_FOUND"]),
+            ApiErrorCodeResponse(UserStatus::class, ["ID_NOT_FOUND", "USER_NAME_ALREADY_EXISTS"]),
             ApiErrorCodeResponse(DefaultStatus::class, ["BAD_REQUEST", "UNKNOWN_EXCEPTION"]),
         ],
     )

--- a/src/test/kotlin/com/techtaurant/mainserver/user/application/UserWriteServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/application/UserWriteServiceTest.kt
@@ -8,6 +8,7 @@ import com.techtaurant.mainserver.user.dto.UpdateUserRequest
 import com.techtaurant.mainserver.user.dto.UserResponse
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.enums.UserStatus
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import io.mockk.every
 import io.mockk.just
@@ -19,6 +20,7 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.springframework.dao.DataIntegrityViolationException
 import java.util.Optional
 import java.util.UUID
 
@@ -55,6 +57,7 @@ class UserWriteServiceTest {
             val targetUser = firstArg<User>()
             UserResponse.from(targetUser, targetUser.profileImageUrl)
         }
+        every { userRepository.flush() } just runs
         every { attachmentService.confirmAttachmentsByIds(any(), any(), any()) } just runs
         every { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) } just runs
     }
@@ -133,5 +136,25 @@ class UserWriteServiceTest {
         }
             .isInstanceOf(ApiException::class.java)
             .hasMessage("이름은 공백일 수 없습니다")
+    }
+
+    @Test
+    @DisplayName("중복 닉네임으로 수정하면 중복 닉네임 예외를 던진다")
+    fun updateMe_duplicateName_throwsConflictApiException() {
+        // given
+        every {
+            userRepository.flush()
+        } throws DataIntegrityViolationException("duplicate key value violates unique constraint \"uk_users_name\"")
+
+        // when & then
+        assertThatThrownBy {
+            userWriteService.updateMe(
+                userId = user.id!!,
+                request = UpdateUserRequest(name = "중복닉네임"),
+            )
+        }
+            .isInstanceOf(ApiException::class.java)
+            .extracting { (it as ApiException).status }
+            .isEqualTo(UserStatus.USER_NAME_ALREADY_EXISTS)
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerProfileIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerProfileIntegrationTest.kt
@@ -7,6 +7,7 @@ import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
 import com.techtaurant.mainserver.user.dto.UpdateUserRequest
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.enums.UserStatus
 import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserFollowRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
@@ -63,6 +64,9 @@ class UserControllerProfileIntegrationTest : IntegrationTest() {
     @Test
     @DisplayName("내 이름 수정이 성공한다")
     fun updateMe_name_success() {
+        // given
+
+        // when
         given()
             .contentType("application/json")
             .header("Authorization", "Bearer $accessToken")
@@ -74,6 +78,7 @@ class UserControllerProfileIntegrationTest : IntegrationTest() {
             .body("data.name", equalTo("새이름"))
             .body("data.profileImageUrl", equalTo("https://example.com/default-profile.jpg"))
 
+        // then
         given()
             .header("Authorization", "Bearer $accessToken")
             .`when`()
@@ -81,5 +86,33 @@ class UserControllerProfileIntegrationTest : IntegrationTest() {
             .then()
             .statusCode(HttpStatus.OK.value())
             .body("data.name", equalTo("새이름"))
+    }
+
+    @Test
+    @DisplayName("중복 닉네임으로 수정하면 409와 중복 닉네임 에러를 반환한다")
+    fun updateMe_duplicateName_returnsConflictResponse() {
+        // given
+        userRepository.save(
+            User(
+                name = "중복닉네임",
+                email = "duplicate-${UUID.randomUUID()}@example.com",
+                provider = OAuthProvider.GOOGLE,
+                identifier = "duplicate-id-${UUID.randomUUID()}",
+                role = UserRole.USER,
+                profileImageUrl = "https://example.com/duplicate-profile.jpg",
+            ),
+        )
+
+        // when & then
+        given()
+            .contentType("application/json")
+            .header("Authorization", "Bearer $accessToken")
+            .body(UpdateUserRequest(name = "중복닉네임"))
+            .`when`()
+            .patch("/api/users/me")
+            .then()
+            .statusCode(HttpStatus.CONFLICT.value())
+            .body("status", equalTo(UserStatus.USER_NAME_ALREADY_EXISTS.getCustomStatusCode()))
+            .body("message", equalTo(UserStatus.USER_NAME_ALREADY_EXISTS.getDescription()))
     }
 }


### PR DESCRIPTION
## Summary
- 사용자 닉네임 변경 시 DB unique constraint 위반을 `USER_NAME_ALREADY_EXISTS` 충돌 응답으로 변환했습니다.
- 사용자 수정 API 문서에 중복 닉네임 에러 코드를 추가했습니다.
- 서비스 단위 테스트와 프로필 수정 통합 테스트에 중복 닉네임 케이스를 추가했습니다.

## Test
- `./gradlew test --tests com.techtaurant.mainserver.user.application.UserWriteServiceTest --tests com.techtaurant.mainserver.user.infrastructure.in.UserControllerProfileIntegrationTest -x jacocoTestCoverageVerification -x jacocoTestReport`