### PR TITLE
modify(user): 프로필 이미지 해석 경로를 공통 resolver로 통일

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,3 +165,13 @@ spring:
 - `SPRING_PROFILES_ACTIVE=dev`는 **로컬 개발 환경에서만** 사용
 - Production/Staging 환경에서는 절대로 `dev` 프로파일을 활성화하지 않아야 함
 - CI/CD 파이프라인에서 dev 프로파일이 포함되지 않도록 확인
+
+## User Domain
+
+### User Profile Image 접근 규칙
+
+- `User.profileImageUrl`을 응답 생성 코드에서 직접 읽지 않는다.
+- 사용자 프로필 이미지는 반드시 `User.getProfileImageSource()`와 `UserProfileImageResolver`를 통해 계산한다.
+- 우선순위는 `serviceProfileImageAttachmentId` 기반 presigned URL이 먼저이고, 없거나 URL 생성에 실패하면 `profileImageUrl` fallback을 사용한다.
+- `post`, `comment`, `follow`, `ban`, `user` 응답처럼 사용자 프로필 이미지를 노출하는 모든 경로는 위 규칙을 동일하게 따라야 한다.
+- 새 DTO/서비스를 만들 때도 `user.profileImageUrl` 직접 참조를 추가하지 말고, resolver에서 계산한 값을 DTO에 주입한다.

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentResponseAssembler.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentResponseAssembler.kt
@@ -5,6 +5,7 @@ import com.techtaurant.mainserver.comment.entity.Comment
 import com.techtaurant.mainserver.common.enums.LikeStatus
 import com.techtaurant.mainserver.user.application.BannedUserMaskingService
 import com.techtaurant.mainserver.user.application.UserBanService
+import com.techtaurant.mainserver.user.application.UserProfileImageResolver
 import org.springframework.stereotype.Component
 import java.util.UUID
 
@@ -12,6 +13,7 @@ import java.util.UUID
 class CommentResponseAssembler(
     private val userBanService: UserBanService,
     private val bannedUserMaskingService: BannedUserMaskingService,
+    private val userProfileImageResolver: UserProfileImageResolver,
 ) {
     fun assemble(
         comments: List<Comment>,
@@ -23,11 +25,22 @@ class CommentResponseAssembler(
         }
 
         val bannedUserIds = userBanService.getBannedUserIds(userId)
+        val authorProfileImageUrlByUserId =
+            userProfileImageResolver.resolve(
+                comments
+                    .filterNot { bannedUserIds.contains(it.author.id) }
+                    .map { it.author }
+                    .distinctBy { it.id },
+            )
 
         return comments.map { comment ->
             val likeStatus = likeStatusMap[comment.id!!] ?: LikeStatus.NONE
             if (!bannedUserIds.contains(comment.author.id)) {
-                CommentListResponse.from(comment, likeStatus)
+                CommentListResponse.from(
+                    comment = comment,
+                    likeStatus = likeStatus,
+                    authorProfileImageUrl = authorProfileImageUrlByUserId[comment.author.id] ?: comment.author.getFallbackProfileImageUrl(),
+                )
             } else {
                 CommentListResponse.fromMasked(
                     comment = comment,

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentListResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentListResponse.kt
@@ -45,6 +45,7 @@ data class CommentListResponse(
         fun from(
             comment: Comment,
             likeStatus: LikeStatus = LikeStatus.NONE,
+            authorProfileImageUrl: String,
         ): CommentListResponse {
             return CommentListResponse(
                 id = comment.id!!,
@@ -52,7 +53,7 @@ data class CommentListResponse(
                 postId = comment.post.id!!,
                 authorId = comment.author.id!!,
                 authorName = comment.author.name,
-                authorProfileImageUrl = comment.author.profileImageUrl,
+                authorProfileImageUrl = authorProfileImageUrl,
                 parentId = comment.parent?.id,
                 depth = comment.depth,
                 likeCount = comment.likeCount,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt
@@ -11,6 +11,7 @@ import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostLikeLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import com.techtaurant.mainserver.user.application.UserProfileImageResolver
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -27,6 +28,7 @@ class PostDetailReadService(
     private val postLikeLogRepository: PostLikeLogRepository,
     private val postReadLogRepository: PostReadLogRepository,
     private val attachmentService: AttachmentService,
+    private val userProfileImageResolver: UserProfileImageResolver,
 ) {
     /**
      * 게시물 상세 정보를 조회합니다.
@@ -84,7 +86,14 @@ class PostDetailReadService(
                 .map { (attachmentId, presignedUrl) ->
                     PostDetailAttachmentPresignedUrlResponse.from(attachmentId, presignedUrl)
                 }
+        val authorProfileImageUrl = userProfileImageResolver.resolve(post.author)
 
-        return PostDetailResponse.from(post, likeStatus, isRead, attachmentPresignedUrls = attachmentPresignedUrls)
+        return PostDetailResponse.from(
+            post = post,
+            likeStatus = likeStatus,
+            isRead = isRead,
+            authorProfileImageUrl = authorProfileImageUrl,
+            attachmentPresignedUrls = attachmentPresignedUrls,
+        )
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -15,6 +15,7 @@ import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import com.techtaurant.mainserver.user.application.UserProfileImageResolver
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -31,6 +32,7 @@ class PostListReadService(
     private val postRepository: PostRepository,
     private val postReadLogRepository: PostReadLogRepository,
     private val attachmentService: AttachmentService,
+    private val userProfileImageResolver: UserProfileImageResolver,
     @param:Value("\${app.default-post-thumbnail-url}")
     private val defaultThumbnailUrl: String,
     @param:Value("\${swagger.base-url}")
@@ -156,6 +158,7 @@ class PostListReadService(
                 .takeIf { it.isNotEmpty() }
                 ?.let { attachmentService.generatePresignedDownloadUrlMapByAttachments(it) }
                 ?: emptyMap()
+        val authorProfileImageUrlByUserId = userProfileImageResolver.resolve(content.map { it.author }.distinctBy { it.id })
 
         return CursorPageResponse(
             content =
@@ -164,6 +167,7 @@ class PostListReadService(
                         post,
                         readPostIds.contains(post.id),
                         thumbnailAttachmentByPostId[post.id],
+                        authorProfileImageUrlByUserId[post.author.id] ?: post.author.getFallbackProfileImageUrl(),
                         presignedThumbnailUrlByAttachmentId,
                     )
                 },
@@ -269,6 +273,7 @@ class PostListReadService(
         post: Post,
         isRead: Boolean,
         thumbnailAttachment: Attachment?,
+        authorProfileImageUrl: String,
         presignedThumbnailUrlByAttachmentId: Map<UUID, String>,
     ): PostListItemResponse {
         val thumbnailUrl = thumbnailAttachment?.id?.let { presignedThumbnailUrlByAttachmentId[it] } ?: "$baseUrl$defaultThumbnailUrl"
@@ -279,7 +284,7 @@ class PostListReadService(
             content = post.content.take(POST_LIST_CONTENT_MAX_LENGTH),
             authorId = post.author.id!!,
             authorName = post.author.name,
-            authorProfileImageUrl = post.author.profileImageUrl,
+            authorProfileImageUrl = authorProfileImageUrl,
             thumbnailUrl = thumbnailUrl,
             category = post.category?.let(CategoryResponse::from),
             isRead = isRead,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostDetailResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostDetailResponse.kt
@@ -74,6 +74,7 @@ data class PostDetailResponse(
             post: Post,
             likeStatus: LikeStatus,
             isRead: Boolean,
+            authorProfileImageUrl: String,
             content: String = post.content,
             attachmentPresignedUrls: List<PostDetailAttachmentPresignedUrlResponse> = emptyList(),
         ): PostDetailResponse =
@@ -81,7 +82,7 @@ data class PostDetailResponse(
                 id = post.id!!,
                 title = post.title,
                 content = content,
-                author = AuthorResponse.from(post.author),
+                author = AuthorResponse.from(post.author, authorProfileImageUrl),
                 category = post.category?.let { CategoryResponse.from(it) },
                 tags = post.tags.map { PostListTagResponse.from(it) },
                 viewCount = post.viewCount,
@@ -133,11 +134,14 @@ data class AuthorResponse(
     val profileImageUrl: String,
 ) {
     companion object {
-        fun from(user: User): AuthorResponse =
+        fun from(
+            user: User,
+            profileImageUrl: String,
+        ): AuthorResponse =
             AuthorResponse(
                 id = user.id!!,
                 name = user.name,
-                profileImageUrl = user.profileImageUrl,
+                profileImageUrl = profileImageUrl,
             )
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostListItemResponse.kt
@@ -50,14 +50,17 @@ data class PostListItemResponse(
             message = "Use PostListReadService.convertToResponse() instead",
             level = DeprecationLevel.WARNING,
         )
-        fun from(post: Post): PostListItemResponse =
+        fun from(
+            post: Post,
+            authorProfileImageUrl: String,
+        ): PostListItemResponse =
             PostListItemResponse(
                 id = post.id!!,
                 title = post.title,
                 content = post.content.take(2000),
                 authorId = post.author.id!!,
                 authorName = post.author.name,
-                authorProfileImageUrl = post.author.profileImageUrl,
+                authorProfileImageUrl = authorProfileImageUrl,
                 thumbnailUrl = "",
                 category = post.category?.let(CategoryResponse::from),
                 isRead = false,

--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserBanService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserBanService.kt
@@ -18,6 +18,7 @@ class UserBanService(
     private val userRepository: UserRepository,
     private val userBanRepository: UserBanRepository,
     private val userFollowService: UserFollowService,
+    private val userProfileImageResolver: UserProfileImageResolver,
 ) {
     @Transactional
     fun banUser(
@@ -62,8 +63,15 @@ class UserBanService(
     }
 
     fun getBannedUsers(userId: UUID): List<UserBanListItemResponse> {
-        return userBanRepository.findAllByUserIdOrderByCreatedAtDesc(userId)
-            .map(UserBanListItemResponse::from)
+        val userBans = userBanRepository.findAllByUserIdOrderByCreatedAtDesc(userId)
+        val profileImageUrlByUserId = userProfileImageResolver.resolve(userBans.map { it.bannedUser })
+
+        return userBans.map {
+            UserBanListItemResponse.from(
+                userBan = it,
+                profileImageUrl = profileImageUrlByUserId[it.bannedUser.id] ?: it.bannedUser.getFallbackProfileImageUrl(),
+            )
+        }
     }
 
     fun getBannedUserIds(userId: UUID?): Set<UUID> {

--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserFollowService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserFollowService.kt
@@ -18,6 +18,7 @@ import java.util.UUID
 class UserFollowService(
     private val userRepository: UserRepository,
     private val userFollowRepository: UserFollowRepository,
+    private val userProfileImageResolver: UserProfileImageResolver,
 ) {
     @Transactional
     fun follow(
@@ -76,8 +77,14 @@ class UserFollowService(
     fun getFollowings(userId: UUID): List<UserFollowListItemResponse> {
         getUser(userId, UserStatus.USER_NOT_FOUND)
 
-        return userFollowRepository.findAllByFollowerIdOrderByCreatedAtDesc(userId).map {
-            UserFollowListItemResponse.fromFollowing(it)
+        val userFollows = userFollowRepository.findAllByFollowerIdOrderByCreatedAtDesc(userId)
+        val profileImageUrlByUserId = userProfileImageResolver.resolve(userFollows.map { it.following })
+
+        return userFollows.map {
+            UserFollowListItemResponse.fromFollowing(
+                userFollow = it,
+                profileImageUrl = profileImageUrlByUserId[it.following.id] ?: it.following.getFallbackProfileImageUrl(),
+            )
         }
     }
 
@@ -85,8 +92,14 @@ class UserFollowService(
     fun getFollowers(userId: UUID): List<UserFollowListItemResponse> {
         getUser(userId, UserStatus.USER_NOT_FOUND)
 
-        return userFollowRepository.findAllByFollowingIdOrderByCreatedAtDesc(userId).map {
-            UserFollowListItemResponse.fromFollower(it)
+        val userFollows = userFollowRepository.findAllByFollowingIdOrderByCreatedAtDesc(userId)
+        val profileImageUrlByUserId = userProfileImageResolver.resolve(userFollows.map { it.follower })
+
+        return userFollows.map {
+            UserFollowListItemResponse.fromFollower(
+                userFollow = it,
+                profileImageUrl = profileImageUrlByUserId[it.follower.id] ?: it.follower.getFallbackProfileImageUrl(),
+            )
         }
     }
 

--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserProfileImageResolver.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserProfileImageResolver.kt
@@ -1,0 +1,45 @@
+package com.techtaurant.mainserver.user.application
+
+import com.techtaurant.mainserver.attachment.application.AttachmentService
+import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.entity.UserProfileImageSource
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class UserProfileImageResolver(
+    private val attachmentService: AttachmentService,
+) {
+    fun resolve(user: User): String {
+        val userId = user.id ?: return user.getFallbackProfileImageUrl()
+        return resolve(listOf(user))[userId] ?: user.getFallbackProfileImageUrl()
+    }
+
+    fun resolve(users: List<User>): Map<UUID, String> {
+        val persistedUsers = users.filter { it.id != null }
+        if (persistedUsers.isEmpty()) {
+            return emptyMap()
+        }
+
+        val userIds = persistedUsers.mapNotNull { it.id }
+        val attachmentsByUserId =
+            attachmentService.getConfirmedAttachmentsByReferenceIds(userIds, AttachmentReferenceType.USER)
+        val presignedUrlByAttachmentId =
+            attachmentService.generatePresignedDownloadUrlMapByAttachments(attachmentsByUserId.values.flatten())
+
+        return persistedUsers.associate { user ->
+            user.id!! to resolve(user, presignedUrlByAttachmentId)
+        }
+    }
+
+    private fun resolve(
+        user: User,
+        presignedUrlByAttachmentId: Map<UUID, String>,
+    ): String =
+        when (val source = user.getProfileImageSource()) {
+            is UserProfileImageSource.ServiceAttachment ->
+                presignedUrlByAttachmentId[source.attachmentId] ?: user.getFallbackProfileImageUrl()
+            is UserProfileImageSource.Url -> source.url
+        }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserResponseAssembler.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserResponseAssembler.kt
@@ -1,14 +1,12 @@
 package com.techtaurant.mainserver.user.application
 
-import com.techtaurant.mainserver.attachment.application.AttachmentService
-import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
 import com.techtaurant.mainserver.user.dto.UserResponse
 import com.techtaurant.mainserver.user.entity.User
 import org.springframework.stereotype.Component
 
 @Component
 class UserResponseAssembler(
-    private val attachmentService: AttachmentService,
+    private val userProfileImageResolver: UserProfileImageResolver,
 ) {
     fun assemble(user: User): UserResponse {
         return assemble(listOf(user)).first()
@@ -19,23 +17,10 @@ class UserResponseAssembler(
             return emptyList()
         }
 
-        val userIds = users.mapNotNull { it.id }
-        val attachmentsByUserId =
-            if (userIds.isNotEmpty()) {
-                attachmentService.getConfirmedAttachmentsByReferenceIds(userIds, AttachmentReferenceType.USER)
-            } else {
-                emptyMap()
-            }
-        val presignedUrlByAttachmentId =
-            attachmentService.generatePresignedDownloadUrlMapByAttachments(
-                attachmentsByUserId.values.flatten(),
-            )
+        val profileImageUrlByUserId = userProfileImageResolver.resolve(users)
 
         return users.map { user ->
-            val profileImageUrl =
-                user.serviceProfileImageAttachmentId
-                    ?.let { presignedUrlByAttachmentId[it] }
-                    ?: user.profileImageUrl
+            val profileImageUrl = user.id?.let { profileImageUrlByUserId[it] } ?: user.getFallbackProfileImageUrl()
             UserResponse.from(user, profileImageUrl)
         }
     }

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserBanListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserBanListItemResponse.kt
@@ -17,11 +17,14 @@ data class UserBanListItemResponse(
     val bannedAt: Date,
 ) {
     companion object {
-        fun from(userBan: UserBan): UserBanListItemResponse =
+        fun from(
+            userBan: UserBan,
+            profileImageUrl: String,
+        ): UserBanListItemResponse =
             UserBanListItemResponse(
                 userId = userBan.bannedUser.id!!,
                 name = userBan.bannedUser.name,
-                profileImageUrl = userBan.bannedUser.profileImageUrl,
+                profileImageUrl = profileImageUrl,
                 bannedAt = userBan.createdAt,
             )
     }

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowListItemResponse.kt
@@ -17,19 +17,25 @@ data class UserFollowListItemResponse(
     val followedAt: Date,
 ) {
     companion object {
-        fun fromFollowing(userFollow: UserFollow): UserFollowListItemResponse =
+        fun fromFollowing(
+            userFollow: UserFollow,
+            profileImageUrl: String,
+        ): UserFollowListItemResponse =
             UserFollowListItemResponse(
                 userId = userFollow.following.id!!,
                 name = userFollow.following.name,
-                profileImageUrl = userFollow.following.profileImageUrl,
+                profileImageUrl = profileImageUrl,
                 followedAt = userFollow.createdAt,
             )
 
-        fun fromFollower(userFollow: UserFollow): UserFollowListItemResponse =
+        fun fromFollower(
+            userFollow: UserFollow,
+            profileImageUrl: String,
+        ): UserFollowListItemResponse =
             UserFollowListItemResponse(
                 userId = userFollow.follower.id!!,
                 name = userFollow.follower.name,
-                profileImageUrl = userFollow.follower.profileImageUrl,
+                profileImageUrl = profileImageUrl,
                 followedAt = userFollow.createdAt,
             )
     }

--- a/src/main/kotlin/com/techtaurant/mainserver/user/entity/User.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/entity/User.kt
@@ -31,4 +31,10 @@ class User(
     var profileImageUrl: String,
     @Column(name = "service_profile_image_attachment_id")
     var serviceProfileImageAttachmentId: UUID? = null,
-) : EntityBase()
+) : EntityBase() {
+    fun getProfileImageSource(): UserProfileImageSource =
+        serviceProfileImageAttachmentId?.let(UserProfileImageSource::ServiceAttachment)
+            ?: UserProfileImageSource.Url(profileImageUrl)
+
+    fun getFallbackProfileImageUrl(): String = profileImageUrl
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/user/entity/UserProfileImageSource.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/entity/UserProfileImageSource.kt
@@ -1,0 +1,13 @@
+package com.techtaurant.mainserver.user.entity
+
+import java.util.UUID
+
+sealed interface UserProfileImageSource {
+    data class ServiceAttachment(
+        val attachmentId: UUID,
+    ) : UserProfileImageSource
+
+    data class Url(
+        val url: String,
+    ) : UserProfileImageSource
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/comment/application/CommentResponseAssemblerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/comment/application/CommentResponseAssemblerTest.kt
@@ -1,0 +1,90 @@
+package com.techtaurant.mainserver.comment.application
+
+import com.techtaurant.mainserver.attachment.application.AttachmentService
+import com.techtaurant.mainserver.attachment.entity.Attachment
+import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
+import com.techtaurant.mainserver.attachment.enums.AttachmentStatus
+import com.techtaurant.mainserver.comment.entity.Comment
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.application.BannedUserMaskingService
+import com.techtaurant.mainserver.user.application.UserBanService
+import com.techtaurant.mainserver.user.application.UserProfileImageResolver
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class CommentResponseAssemblerTest {
+    private val userBanService: UserBanService = mockk()
+    private val bannedUserMaskingService: BannedUserMaskingService = mockk()
+    private val attachmentService: AttachmentService = mockk()
+    private val userProfileImageResolver = UserProfileImageResolver(attachmentService)
+    private val commentResponseAssembler =
+        CommentResponseAssembler(
+            userBanService = userBanService,
+            bannedUserMaskingService = bannedUserMaskingService,
+            userProfileImageResolver = userProfileImageResolver,
+        )
+
+    @Test
+    @DisplayName("서비스 프로필 이미지 attachment가 있으면 댓글 작성자 프로필 이미지에 presigned URL을 사용한다")
+    fun assemble_serviceProfileImageAttachment_usesPresignedAuthorProfileImageUrl() {
+        val authorId = UUID.randomUUID()
+        val attachmentId = UUID.randomUUID()
+        val author =
+            User(
+                name = "댓글 작성자",
+                email = "comment@author.com",
+                provider = OAuthProvider.GOOGLE,
+                identifier = "comment-author",
+                role = UserRole.USER,
+                profileImageUrl = "https://example.com/fallback-comment-author.jpg",
+                serviceProfileImageAttachmentId = attachmentId,
+            ).apply { id = authorId }
+        val post =
+            Post(
+                title = "게시물",
+                content = "본문",
+                author = author,
+            ).apply { id = UUID.randomUUID() }
+        val comment =
+            Comment(
+                content = "댓글",
+                post = post,
+                author = author,
+            ).apply { id = UUID.randomUUID() }
+        val profileAttachment = createUserProfileAttachment(authorId, attachmentId)
+
+        every { userBanService.getBannedUserIds(null) } returns emptySet()
+        every {
+            attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(authorId), AttachmentReferenceType.USER)
+        } returns mapOf(authorId to listOf(profileAttachment))
+        every {
+            attachmentService.generatePresignedDownloadUrlMapByAttachments(listOf(profileAttachment))
+        } returns mapOf(attachmentId to "https://cdn.example.com/comments/author-profile.png")
+
+        val result = commentResponseAssembler.assemble(listOf(comment), emptyMap(), null)
+
+        assertThat(result.single().authorProfileImageUrl)
+            .isEqualTo("https://cdn.example.com/comments/author-profile.png")
+    }
+
+    private fun createUserProfileAttachment(
+        userId: UUID,
+        attachmentId: UUID,
+    ): Attachment =
+        Attachment(
+            referenceId = userId,
+            referenceType = AttachmentReferenceType.USER,
+            objectKey = "users/$userId/$attachmentId/profile.png",
+            status = AttachmentStatus.CONFIRMED,
+            originalFileName = "profile.png",
+            contentType = "image/png",
+            fileSize = 1024L,
+        ).apply { id = attachmentId }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadServiceTest.kt
@@ -1,7 +1,9 @@
 package com.techtaurant.mainserver.post.application
 
 import com.techtaurant.mainserver.attachment.application.AttachmentService
+import com.techtaurant.mainserver.attachment.entity.Attachment
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
+import com.techtaurant.mainserver.attachment.enums.AttachmentStatus
 import com.techtaurant.mainserver.common.enums.LikeStatus
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostLikeLog
@@ -10,6 +12,7 @@ import com.techtaurant.mainserver.post.infrastructure.out.PostLikeLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.application.UserProfileImageResolver
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.enums.UserRole
 import io.mockk.every
@@ -30,6 +33,7 @@ class PostDetailReadServiceTest {
     private val postLikeLogRepository: PostLikeLogRepository = mockk()
     private val postReadLogRepository: PostReadLogRepository = mockk()
     private val attachmentService: AttachmentService = mockk()
+    private val userProfileImageResolver = UserProfileImageResolver(attachmentService)
 
     private val postDetailReadService =
         PostDetailReadService(
@@ -38,6 +42,7 @@ class PostDetailReadServiceTest {
             postLikeLogRepository = postLikeLogRepository,
             postReadLogRepository = postReadLogRepository,
             attachmentService = attachmentService,
+            userProfileImageResolver = userProfileImageResolver,
         )
 
     private lateinit var author: User
@@ -56,7 +61,25 @@ class PostDetailReadServiceTest {
 
         every { postViewLogService.recordView(any(), any(), any(), any()) } just runs
         every { attachmentService.generatePresignedDownloadUrlMapByReference(any(), any()) } returns emptyMap()
+        every {
+            attachmentService.getConfirmedAttachmentsByReferenceIds(any(), AttachmentReferenceType.USER)
+        } returns emptyMap()
+        every { attachmentService.generatePresignedDownloadUrlMapByAttachments(emptyList()) } returns emptyMap()
     }
+
+    private fun createUserProfileAttachment(
+        userId: UUID,
+        attachmentId: UUID,
+    ): Attachment =
+        Attachment(
+            referenceId = userId,
+            referenceType = AttachmentReferenceType.USER,
+            objectKey = "users/$userId/$attachmentId/profile.png",
+            status = AttachmentStatus.CONFIRMED,
+            originalFileName = "profile.png",
+            contentType = "image/png",
+            fileSize = 1024L,
+        ).apply { id = attachmentId }
 
     @Nested
     @DisplayName("getPostDetail")
@@ -150,6 +173,34 @@ class PostDetailReadServiceTest {
             // then
             assertThat(result.likeStatus).isEqualTo(LikeStatus.LIKE)
             assertThat(result.attachmentPresignedUrls).isEmpty()
+        }
+
+        @Test
+        @DisplayName("서비스 프로필 이미지 attachment가 있으면 작성자 프로필 이미지에 presigned URL을 사용한다")
+        fun getPostDetail_serviceProfileImageAttachment_usesPresignedAuthorProfileImageUrl() {
+            val postId = UUID.randomUUID()
+            val attachmentId = UUID.randomUUID()
+            author.serviceProfileImageAttachmentId = attachmentId
+            val profileAttachment = createUserProfileAttachment(author.id!!, attachmentId)
+            val post =
+                Post(
+                    title = "게시물",
+                    content = "본문",
+                    author = author,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findVisiblePostDetailById(postId, null) } returns post
+            every {
+                attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(author.id!!), AttachmentReferenceType.USER)
+            } returns mapOf(author.id!! to listOf(profileAttachment))
+            every {
+                attachmentService.generatePresignedDownloadUrlMapByAttachments(listOf(profileAttachment))
+            } returns mapOf(attachmentId to "https://cdn.example.com/authors/detail-author.png")
+
+            val result = postDetailReadService.getPostDetail(postId, null, null, null)
+
+            assertThat(result.author.profileImageUrl).isEqualTo("https://cdn.example.com/authors/detail-author.png")
         }
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -13,6 +13,7 @@ import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.application.UserProfileImageResolver
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.enums.UserRole
 import io.mockk.every
@@ -30,6 +31,7 @@ class PostListReadServiceTest {
     private val postRepository: PostRepository = mockk()
     private val postReadLogRepository: PostReadLogRepository = mockk()
     private val attachmentService: AttachmentService = mockk()
+    private val userProfileImageResolver = UserProfileImageResolver(attachmentService)
     private val defaultThumbnailUrl = "/static/images/post-thumbnail.png"
     private val baseUrl = "http://localhost:8080"
 
@@ -38,6 +40,7 @@ class PostListReadServiceTest {
             postRepository = postRepository,
             postReadLogRepository = postReadLogRepository,
             attachmentService = attachmentService,
+            userProfileImageResolver = userProfileImageResolver,
             defaultThumbnailUrl = defaultThumbnailUrl,
             baseUrl = baseUrl,
         )
@@ -101,6 +104,20 @@ class PostListReadServiceTest {
             this.createdAt = createdAt
         }
 
+    private fun createUserProfileAttachment(
+        userId: UUID,
+        attachmentId: UUID,
+    ): Attachment =
+        Attachment(
+            referenceId = userId,
+            referenceType = AttachmentReferenceType.USER,
+            objectKey = "users/$userId/$attachmentId/profile.png",
+            status = AttachmentStatus.CONFIRMED,
+            originalFileName = "profile.png",
+            contentType = "image/png",
+            fileSize = 1024L,
+        ).apply { id = attachmentId }
+
     private fun createCategory(
         user: User,
         name: String = "백엔드",
@@ -124,6 +141,10 @@ class PostListReadServiceTest {
             every {
                 attachmentService.getConfirmedAttachmentsByReferenceIds(any(), AttachmentReferenceType.POST)
             } returns emptyMap()
+            every {
+                attachmentService.getConfirmedAttachmentsByReferenceIds(any(), AttachmentReferenceType.USER)
+            } returns emptyMap()
+            every { attachmentService.generatePresignedDownloadUrlMapByAttachments(emptyList()) } returns emptyMap()
         }
 
         @Test
@@ -327,6 +348,10 @@ class PostListReadServiceTest {
             every {
                 attachmentService.getConfirmedAttachmentsByReferenceIds(any(), AttachmentReferenceType.POST)
             } returns emptyMap()
+            every {
+                attachmentService.getConfirmedAttachmentsByReferenceIds(any(), AttachmentReferenceType.USER)
+            } returns emptyMap()
+            every { attachmentService.generatePresignedDownloadUrlMapByAttachments(emptyList()) } returns emptyMap()
         }
 
         @Test
@@ -636,6 +661,46 @@ class PostListReadServiceTest {
             assertThat(response.category!!.name).isEqualTo(category.name)
             assertThat(response.category!!.path).isEqualTo(category.path)
             assertThat(response.category!!.depth).isEqualTo(category.depth)
+        }
+
+        @Test
+        @DisplayName("서비스 프로필 이미지 attachment가 있으면 작성자 프로필 이미지에 presigned URL을 사용한다")
+        fun getPosts_serviceProfileImageAttachment_usesPresignedAuthorProfileImageUrl() {
+            val attachmentId = UUID.randomUUID()
+            otherUser.serviceProfileImageAttachmentId = attachmentId
+            val posts = listOf(createPost(otherUser))
+            val profileAttachment = createUserProfileAttachment(otherUser.id!!, attachmentId)
+
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    authorId = otherUser.id!!,
+                    statuses = listOf(PostStatusEnum.PUBLISHED),
+                    categoryId = null,
+                    tagIds = null,
+                    viewerId = null,
+                )
+            } returns posts
+            every {
+                attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(otherUser.id!!), AttachmentReferenceType.USER)
+            } returns mapOf(otherUser.id!! to listOf(profileAttachment))
+            every {
+                attachmentService.generatePresignedDownloadUrlMapByAttachments(listOf(profileAttachment))
+            } returns mapOf(attachmentId to "https://cdn.example.com/authors/other-user.png")
+
+            val result =
+                postListReadService.getPosts(
+                    cursor = null,
+                    size = 20,
+                    currentUserId = null,
+                    authorId = otherUser.id!!,
+                )
+
+            assertThat(result.content.single().authorProfileImageUrl)
+                .isEqualTo("https://cdn.example.com/authors/other-user.png")
         }
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/user/application/UserProfileImageResolverTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/application/UserProfileImageResolverTest.kt
@@ -14,17 +14,16 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
-class UserResponseAssemblerTest {
+class UserProfileImageResolverTest {
     private val attachmentService: AttachmentService = mockk()
-    private val userProfileImageResolver = UserProfileImageResolver(attachmentService)
-    private val userResponseAssembler = UserResponseAssembler(userProfileImageResolver)
+    private val resolver = UserProfileImageResolver(attachmentService)
 
     @Test
     @DisplayName("서비스 프로필 이미지 attachment가 있으면 presigned URL을 우선 반환한다")
-    fun assemble_serviceProfileImageAttachment_usesPresignedUrl() {
+    fun resolve_serviceAttachment_usesPresignedUrl() {
         val userId = UUID.randomUUID()
         val attachmentId = UUID.randomUUID()
-        val user = createUser(userId, attachmentId)
+        val user = createUser(userId, attachmentId, "https://example.com/fallback.jpg")
         val attachment = createAttachment(userId, attachmentId)
 
         every {
@@ -34,16 +33,36 @@ class UserResponseAssemblerTest {
             attachmentService.generatePresignedDownloadUrlMapByAttachments(listOf(attachment))
         } returns mapOf(attachmentId to "https://cdn.example.com/profile.png")
 
-        val response = userResponseAssembler.assemble(user)
+        val resolved = resolver.resolve(user)
 
-        assertThat(response.profileImageUrl).isEqualTo("https://cdn.example.com/profile.png")
+        assertThat(resolved).isEqualTo("https://cdn.example.com/profile.png")
+    }
+
+    @Test
+    @DisplayName("서비스 프로필 이미지 attachment URL 생성에 실패하면 기본 profileImageUrl로 fallback 한다")
+    fun resolve_missingAttachmentUrl_fallsBackToProfileImageUrl() {
+        val userId = UUID.randomUUID()
+        val attachmentId = UUID.randomUUID()
+        val user = createUser(userId, attachmentId, "https://example.com/fallback.jpg")
+        val attachment = createAttachment(userId, attachmentId)
+
+        every {
+            attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(userId), AttachmentReferenceType.USER)
+        } returns mapOf(userId to listOf(attachment))
+        every {
+            attachmentService.generatePresignedDownloadUrlMapByAttachments(listOf(attachment))
+        } returns emptyMap()
+
+        val resolved = resolver.resolve(user)
+
+        assertThat(resolved).isEqualTo("https://example.com/fallback.jpg")
     }
 
     @Test
     @DisplayName("서비스 프로필 이미지 attachment가 없으면 기본 profileImageUrl을 사용한다")
-    fun assemble_withoutServiceProfileImage_usesFallbackUrl() {
+    fun resolve_withoutServiceAttachment_usesProfileImageUrl() {
         val userId = UUID.randomUUID()
-        val user = createUser(userId, null)
+        val user = createUser(userId, null, "https://example.com/default-profile.jpg")
 
         every {
             attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(userId), AttachmentReferenceType.USER)
@@ -52,31 +71,31 @@ class UserResponseAssemblerTest {
             attachmentService.generatePresignedDownloadUrlMapByAttachments(emptyList())
         } returns emptyMap()
 
-        val response = userResponseAssembler.assemble(user)
+        val resolved = resolver.resolve(user)
 
-        assertThat(response.profileImageUrl).isEqualTo("https://example.com/default-profile.jpg")
+        assertThat(resolved).isEqualTo("https://example.com/default-profile.jpg")
     }
 
     private fun createUser(
         userId: UUID,
         attachmentId: UUID?,
-    ): User {
-        return User(
+        profileImageUrl: String,
+    ): User =
+        User(
             name = "테스트사용자",
             email = "user@example.com",
             provider = OAuthProvider.GOOGLE,
             identifier = "google-${UUID.randomUUID()}",
             role = UserRole.USER,
-            profileImageUrl = "https://example.com/default-profile.jpg",
+            profileImageUrl = profileImageUrl,
             serviceProfileImageAttachmentId = attachmentId,
         ).apply { id = userId }
-    }
 
     private fun createAttachment(
         userId: UUID,
         attachmentId: UUID,
-    ): Attachment {
-        return Attachment(
+    ): Attachment =
+        Attachment(
             referenceId = userId,
             referenceType = AttachmentReferenceType.USER,
             objectKey = "users/$userId/$attachmentId/profile.png",
@@ -85,5 +104,4 @@ class UserResponseAssemblerTest {
             contentType = "image/png",
             fileSize = 1024L,
         ).apply { id = attachmentId }
-    }
 }


### PR DESCRIPTION
## Summary
- user, post, comment, follow, ban 응답에서 사용자 프로필 이미지를 `UserProfileImageResolver`로 일원화했습니다.
- `serviceProfileImageAttachmentId`가 있으면 presigned URL을 우선 사용하고, 실패 시 `profileImageUrl`로 fallback 하도록 통일했습니다.
- 회귀 테스트를 추가하고 `CLAUDE.md`에 user 프로필 이미지 접근 규칙을 문서화했습니다.

## Testing
- ./gradlew test --tests "*UserResponseAssemblerTest" --tests "*UserProfileImageResolverTest" --tests "*PostListReadServiceTest" --tests "*PostDetailReadServiceTest" --tests "*CommentResponseAssemblerTest" -x jacocoTestCoverageVerification
- ./gradlew spotlessApply && ./gradlew spotlessCheck
- ./gradlew compileKotlin compileTestKotlin