### PR TITLE
modify(post): 게시물 목록 조회 전략과 공개 범위를 정리

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/AllVisiblePostsQueryStrategy.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/AllVisiblePostsQueryStrategy.kt
@@ -1,0 +1,23 @@
+package com.techtaurant.mainserver.post.application
+
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import org.springframework.stereotype.Component
+
+@Component
+internal class AllVisiblePostsQueryStrategy(
+    private val postRepository: PostRepository,
+) : PostListQueryStrategy {
+    override val queryType: PostListQueryType = PostListQueryType.ALL_VISIBLE
+
+    override fun findPosts(criteria: PostListQueryCriteria): List<Post> =
+        postRepository.findPostsWithConditions(
+            cursor = criteria.cursor,
+            size = criteria.querySize,
+            period = criteria.period,
+            sortType = criteria.sortType,
+            visibleToUserId = criteria.currentUserId,
+            tagIds = criteria.tagIds,
+            viewerId = criteria.currentUserId,
+        )
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/AuthorPublicPostsQueryStrategy.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/AuthorPublicPostsQueryStrategy.kt
@@ -1,0 +1,26 @@
+package com.techtaurant.mainserver.post.application
+
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import org.springframework.stereotype.Component
+
+@Component
+internal class AuthorPublicPostsQueryStrategy(
+    private val postRepository: PostRepository,
+) : PostListQueryStrategy {
+    override val queryType: PostListQueryType = PostListQueryType.AUTHOR_PUBLIC
+
+    override fun findPosts(criteria: PostListQueryCriteria): List<Post> =
+        postRepository.findPostsWithConditions(
+            cursor = criteria.cursor,
+            size = criteria.querySize,
+            period = criteria.period,
+            sortType = criteria.sortType,
+            authorId = criteria.authorId!!,
+            statuses = listOf(PostStatusEnum.PUBLISHED),
+            categoryId = criteria.categoryId,
+            tagIds = criteria.tagIds,
+            viewerId = criteria.currentUserId,
+        )
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/OwnVisiblePostsQueryStrategy.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/OwnVisiblePostsQueryStrategy.kt
@@ -1,0 +1,26 @@
+package com.techtaurant.mainserver.post.application
+
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import org.springframework.stereotype.Component
+
+@Component
+internal class OwnVisiblePostsQueryStrategy(
+    private val postRepository: PostRepository,
+) : PostListQueryStrategy {
+    override val queryType: PostListQueryType = PostListQueryType.OWN_VISIBLE
+
+    override fun findPosts(criteria: PostListQueryCriteria): List<Post> =
+        postRepository.findPostsWithConditions(
+            cursor = criteria.cursor,
+            size = criteria.querySize,
+            period = criteria.period,
+            sortType = criteria.sortType,
+            authorId = criteria.authorId!!,
+            statuses = listOf(PostStatusEnum.PUBLISHED, PostStatusEnum.PRIVATE),
+            categoryId = criteria.categoryId,
+            tagIds = criteria.tagIds,
+            viewerId = criteria.currentUserId,
+        )
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListQueryCriteria.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListQueryCriteria.kt
@@ -1,0 +1,28 @@
+package com.techtaurant.mainserver.post.application
+
+import com.techtaurant.mainserver.post.dto.PostCursor
+import com.techtaurant.mainserver.post.entity.PostPeriod
+import com.techtaurant.mainserver.post.entity.PostSortType
+import java.util.UUID
+
+data class PostListQueryCriteria(
+    val cursor: PostCursor?,
+    val size: Int,
+    val period: PostPeriod,
+    val sortType: PostSortType,
+    val currentUserId: UUID?,
+    val authorId: UUID?,
+    val categoryId: UUID?,
+    val tagIds: List<UUID>?,
+) {
+    val queryType: PostListQueryType
+        get() =
+            when {
+                authorId == null -> PostListQueryType.ALL_VISIBLE
+                currentUserId == authorId -> PostListQueryType.OWN_VISIBLE
+                else -> PostListQueryType.AUTHOR_PUBLIC
+            }
+
+    val querySize: Int
+        get() = size + 1
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListQueryStrategy.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListQueryStrategy.kt
@@ -1,0 +1,9 @@
+package com.techtaurant.mainserver.post.application
+
+import com.techtaurant.mainserver.post.entity.Post
+
+interface PostListQueryStrategy {
+    val queryType: PostListQueryType
+
+    fun findPosts(criteria: PostListQueryCriteria): List<Post>
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListQueryType.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListQueryType.kt
@@ -1,0 +1,7 @@
+package com.techtaurant.mainserver.post.application
+
+enum class PostListQueryType {
+    ALL_VISIBLE,
+    OWN_VISIBLE,
+    AUTHOR_PUBLIC,
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -12,7 +12,6 @@ import com.techtaurant.mainserver.post.dto.PostListTagResponse
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
-import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.user.application.UserProfileImageResolver
@@ -33,6 +32,7 @@ class PostListReadService(
     private val postReadLogRepository: PostReadLogRepository,
     private val attachmentService: AttachmentService,
     private val userProfileImageResolver: UserProfileImageResolver,
+    postListQueryStrategies: List<PostListQueryStrategy>,
     @param:Value("\${app.default-post-thumbnail-url}")
     private val defaultThumbnailUrl: String,
     @param:Value("\${swagger.base-url}")
@@ -43,11 +43,13 @@ class PostListReadService(
         private const val POST_LIST_CONTENT_MAX_LENGTH = 2000
     }
 
+    private val postListQueryStrategyByType = createPostListQueryStrategyByType(postListQueryStrategies)
+
     /**
      * 게시물 목록을 커서 기반 페이지네이션으로 조회
      *
-     * authorId 지정 시 해당 사용자의 게시물만 조회하며, 본인 조회 시 DRAFT/PRIVATE 포함, 타인 조회 시 PUBLISHED만 반환.
-     * authorId 미지정 시 전체 게시물 조회 (로그인 사용자의 DRAFT/PRIVATE 포함).
+     * authorId 지정 시 해당 사용자의 게시물만 조회하며, 본인 조회 시 PUBLISHED/PRIVATE 포함, 타인 조회 시 PUBLISHED만 반환.
+     * authorId 미지정 시 전체 게시물 조회하며, open-api 목록에서는 DRAFT를 제외합니다.
      *
      * @param cursor 이전 응답의 nextCursor (null이면 첫 페이지)
      * @param size 페이지 크기
@@ -81,36 +83,18 @@ class PostListReadService(
             )
         }
 
-        val posts =
-            if (authorId != null) {
-                val statuses =
-                    if (currentUserId == authorId) {
-                        PostStatusEnum.entries
-                    } else {
-                        listOf(PostStatusEnum.PUBLISHED)
-                    }
-                postRepository.findPostsWithConditions(
-                    cursor = postCursor,
-                    size = size + 1,
-                    period = period,
-                    sortType = sortType,
-                    authorId = authorId,
-                    statuses = statuses,
-                    categoryId = categoryId,
-                    tagIds = normalizedTagIds,
-                    viewerId = currentUserId,
-                )
-            } else {
-                postRepository.findPostsWithConditions(
-                    cursor = postCursor,
-                    size = size + 1,
-                    period = period,
-                    sortType = sortType,
-                    visibleToUserId = currentUserId,
-                    tagIds = normalizedTagIds,
-                    viewerId = currentUserId,
-                )
-            }
+        val postListQueryCriteria =
+            PostListQueryCriteria(
+                cursor = postCursor,
+                size = size,
+                period = period,
+                sortType = sortType,
+                currentUserId = currentUserId,
+                authorId = authorId,
+                categoryId = categoryId,
+                tagIds = normalizedTagIds,
+            )
+        val posts = selectPostListQueryStrategy(postListQueryCriteria).findPosts(postListQueryCriteria)
 
         val hasNext = posts.size > size
         val content = posts.take(size)
@@ -182,6 +166,24 @@ class PostListReadService(
 
         return normalizedTagIds?.takeIf { it.isNotEmpty() }
     }
+
+    private fun createPostListQueryStrategyByType(strategies: List<PostListQueryStrategy>): Map<PostListQueryType, PostListQueryStrategy> {
+        val strategiesByType = strategies.groupBy { it.queryType }
+        val duplicatedTypes = strategiesByType.filterValues { it.size > 1 }.keys
+        require(duplicatedTypes.isEmpty()) {
+            "게시물 목록 조회 전략이 중복 등록되었습니다: ${duplicatedTypes.joinToString()}"
+        }
+
+        val missingTypes = PostListQueryType.entries.filterNot { strategiesByType.containsKey(it) }
+        require(missingTypes.isEmpty()) {
+            "게시물 목록 조회 전략이 누락되었습니다: ${missingTypes.joinToString()}"
+        }
+
+        return strategiesByType.mapValues { (_, strategyGroup) -> strategyGroup.single() }
+    }
+
+    private fun selectPostListQueryStrategy(criteria: PostListQueryCriteria): PostListQueryStrategy =
+        postListQueryStrategyByType.getValue(criteria.queryType)
 
     /**
      * 현재 사용자의 DRAFT 게시물 목록을 커서 기반으로 조회합니다.

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
@@ -21,7 +21,7 @@ interface PostRepositoryCustom {
      * @param authorId 작성자 ID 필터 (null이면 미적용)
      * @param statuses 게시물 상태 필터 (null이면 PUBLISHED만 조회)
      * @param categoryId 카테고리 ID 필터 (null이면 미적용)
-     * @param visibleToUserId PUBLISHED + 해당 사용자의 모든 상태 게시물 조회 (null이면 미적용, statuses보다 우선)
+     * @param visibleToUserId PUBLISHED + 해당 사용자의 PRIVATE 게시물 조회 (null이면 미적용, statuses보다 우선)
      * @param tagIds 태그 UUID 필터 (여러 개 전달 시 OR 조건)
      * @return 게시물 목록
      */

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -65,8 +65,12 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
 
         if (visibleToUserId != null) {
             val publishedPredicate = cb.equal(root.get(Post_.status), PostStatusEnum.PUBLISHED)
-            val ownPostPredicate = cb.equal(root.get(Post_.author).get(EntityBase_.id), visibleToUserId)
-            predicates.add(cb.or(publishedPredicate, ownPostPredicate))
+            val ownPrivatePostPredicate =
+                cb.and(
+                    cb.equal(root.get(Post_.author).get(EntityBase_.id), visibleToUserId),
+                    cb.equal(root.get(Post_.status), PostStatusEnum.PRIVATE),
+                )
+            predicates.add(cb.or(publishedPredicate, ownPrivatePostPredicate))
         } else if (statuses != null) {
             predicates.add(root.get(Post_.status).`in`(statuses))
         } else {

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -20,6 +20,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -36,13 +37,26 @@ class PostListReadServiceTest {
     private val baseUrl = "http://localhost:8080"
 
     private val postListReadService =
+        createPostListReadService()
+
+    private fun createPostListReadService(
+        postListQueryStrategies: List<PostListQueryStrategy> = createPostListQueryStrategies(),
+    ) =
         PostListReadService(
             postRepository = postRepository,
             postReadLogRepository = postReadLogRepository,
             attachmentService = attachmentService,
             userProfileImageResolver = userProfileImageResolver,
+            postListQueryStrategies = postListQueryStrategies,
             defaultThumbnailUrl = defaultThumbnailUrl,
             baseUrl = baseUrl,
+        )
+
+    private fun createPostListQueryStrategies(): List<PostListQueryStrategy> =
+        listOf(
+            AllVisiblePostsQueryStrategy(postRepository),
+            OwnVisiblePostsQueryStrategy(postRepository),
+            AuthorPublicPostsQueryStrategy(postRepository),
         )
 
     private lateinit var testUser: User
@@ -132,6 +146,40 @@ class PostListReadServiceTest {
             depth = depth,
             parent = parent,
         ).apply { id = UUID.randomUUID() }
+
+    @Test
+    @DisplayName("게시물 목록 조회 전략이 누락되면 서비스 생성에 실패한다")
+    fun constructor_missingStrategy_throwsException() {
+        assertThatThrownBy {
+            createPostListReadService(
+                postListQueryStrategies =
+                    listOf(
+                        AllVisiblePostsQueryStrategy(postRepository),
+                        OwnVisiblePostsQueryStrategy(postRepository),
+                    ),
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("누락")
+    }
+
+    @Test
+    @DisplayName("게시물 목록 조회 전략이 중복되면 서비스 생성에 실패한다")
+    fun constructor_duplicateStrategy_throwsException() {
+        assertThatThrownBy {
+            createPostListReadService(
+                postListQueryStrategies =
+                    listOf(
+                        AllVisiblePostsQueryStrategy(postRepository),
+                        AllVisiblePostsQueryStrategy(postRepository),
+                        OwnVisiblePostsQueryStrategy(postRepository),
+                        AuthorPublicPostsQueryStrategy(postRepository),
+                    ),
+            )
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("중복")
+    }
 
     @Nested
     @DisplayName("getPosts")
@@ -355,8 +403,8 @@ class PostListReadServiceTest {
         }
 
         @Test
-        @DisplayName("본인 조회 시 모든 상태(DRAFT, PUBLISHED, PRIVATE)로 Repository를 호출한다")
-        fun getPosts_ownPosts_queriesAllStatuses() {
+        @DisplayName("본인 조회 시 DRAFT를 제외한 공개 가능 상태만 Repository에 전달한다")
+        fun getPosts_ownPosts_excludesDraftStatus() {
             // given
             val posts = listOf(createPost(testUser))
             every {
@@ -366,7 +414,7 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     authorId = testUser.id!!,
-                    statuses = PostStatusEnum.entries,
+                    statuses = listOf(PostStatusEnum.PUBLISHED, PostStatusEnum.PRIVATE),
                     categoryId = null,
                     tagIds = null,
                     viewerId = testUser.id!!,
@@ -392,10 +440,56 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     authorId = testUser.id!!,
-                    statuses = PostStatusEnum.entries,
+                    statuses = listOf(PostStatusEnum.PUBLISHED, PostStatusEnum.PRIVATE),
                     categoryId = null,
                     tagIds = null,
                     viewerId = testUser.id!!,
+                )
+            }
+        }
+
+        @Test
+        @DisplayName("본인 조회 시 Repository 상태 필터에 DRAFT가 포함되지 않는다")
+        fun getPosts_ownPosts_doesNotPassDraftStatus() {
+            // given
+            val posts = listOf(createPost(testUser, status = PostStatusEnum.PRIVATE))
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 21,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.LATEST,
+                    authorId = testUser.id!!,
+                    statuses = listOf(PostStatusEnum.PUBLISHED, PostStatusEnum.PRIVATE),
+                    categoryId = null,
+                    tagIds = null,
+                    viewerId = testUser.id!!,
+                )
+            } returns posts
+            every {
+                postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
+            } returns emptyList()
+
+            // when
+            postListReadService.getPosts(
+                cursor = null,
+                size = 20,
+                currentUserId = testUser.id!!,
+                authorId = testUser.id!!,
+            )
+
+            // then
+            verify(exactly = 0) {
+                postRepository.findPostsWithConditions(
+                    cursor = any(),
+                    size = any(),
+                    period = any(),
+                    sortType = any(),
+                    authorId = testUser.id!!,
+                    statuses = match { PostStatusEnum.DRAFT in it },
+                    categoryId = any(),
+                    tagIds = any(),
+                    viewerId = any(),
                 )
             }
         }
@@ -522,7 +616,7 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     authorId = testUser.id!!,
-                    statuses = PostStatusEnum.entries,
+                    statuses = listOf(PostStatusEnum.PUBLISHED, PostStatusEnum.PRIVATE),
                     categoryId = null,
                     tagIds = null,
                     viewerId = testUser.id!!,
@@ -559,7 +653,7 @@ class PostListReadServiceTest {
                     period = PostPeriod.ALL,
                     sortType = PostSortType.LATEST,
                     authorId = testUser.id!!,
-                    statuses = PostStatusEnum.entries,
+                    statuses = listOf(PostStatusEnum.PUBLISHED, PostStatusEnum.PRIVATE),
                     categoryId = null,
                     tagIds = null,
                     viewerId = testUser.id!!,

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -39,9 +39,7 @@ class PostListReadServiceTest {
     private val postListReadService =
         createPostListReadService()
 
-    private fun createPostListReadService(
-        postListQueryStrategies: List<PostListQueryStrategy> = createPostListQueryStrategies(),
-    ) =
+    private fun createPostListReadService(postListQueryStrategies: List<PostListQueryStrategy> = createPostListQueryStrategies()) =
         PostListReadService(
             postRepository = postRepository,
             postReadLogRepository = postReadLogRepository,

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
@@ -116,6 +116,50 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
     }
 
     @Test
+    @DisplayName("로그인 사용자가 게시물 목록 조회 시 본인의 DRAFT 게시물은 포함되지 않는다")
+    fun getPosts_loggedInUser_excludesOwnDraftPost() {
+        // given
+        val myDraftPost =
+            postRepository.save(
+                Post(
+                    title = "내 임시 저장 게시물",
+                    content = "임시 저장 내용",
+                    author = testUser,
+                    status = PostStatusEnum.DRAFT,
+                ),
+            )
+        val myPrivatePost =
+            postRepository.save(
+                Post(
+                    title = "내 비공개 게시물",
+                    content = "비공개 내용",
+                    author = testUser,
+                    status = PostStatusEnum.PRIVATE,
+                ),
+            )
+        val myPublishedPost =
+            postRepository.save(
+                Post(
+                    title = "내 공개 게시물",
+                    content = "공개 내용",
+                    author = testUser,
+                    status = PostStatusEnum.PUBLISHED,
+                ),
+            )
+
+        // when & then
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .get("/open-api/posts")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.content.id", not(hasItem(myDraftPost.id.toString())))
+            .body("data.content.id", hasItem(myPrivatePost.id.toString()))
+            .body("data.content.id", hasItem(myPublishedPost.id.toString()))
+    }
+
+    @Test
     @DisplayName("로그인 사용자가 차단한 작성자의 게시물은 목록에서 제외된다")
     fun getPosts_excludesBannedAuthorPosts() {
         // given

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
@@ -293,7 +293,7 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
     @DisplayName("visibleToUserId 필터링")
     inner class VisibleToUserIdFilter {
         @Test
-        @DisplayName("visibleToUserId 지정 시 PUBLISHED + 해당 사용자의 모든 상태 게시물을 반환한다")
+        @DisplayName("visibleToUserId 지정 시 PUBLISHED + 해당 사용자의 PRIVATE 게시물을 반환한다")
         fun findPostsWithConditions_withVisibleToUserId_returnsPublishedAndOwnPosts() {
             // given
             val publishedByA = createPost(userA, PostStatusEnum.PUBLISHED)
@@ -317,10 +317,10 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
             val resultIds = result.map { it.id }.toSet()
             assertThat(resultIds).containsExactlyInAnyOrder(
                 publishedByA.id,
-                draftByA.id,
                 privateByA.id,
                 publishedByB.id,
             )
+            assertThat(resultIds).doesNotContain(draftByA.id)
         }
 
         @Test
@@ -357,6 +357,7 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
             // given
             val publishedByA = createPost(userA, PostStatusEnum.PUBLISHED)
             val draftByA = createPost(userA, PostStatusEnum.DRAFT)
+            val privateByA = createPost(userA, PostStatusEnum.PRIVATE)
             val publishedByB = createPost(userB, PostStatusEnum.PUBLISHED)
             createPost(userB, PostStatusEnum.DRAFT)
 
@@ -375,9 +376,10 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
             val resultIds = result.map { it.id }.toSet()
             assertThat(resultIds).containsExactlyInAnyOrder(
                 publishedByA.id,
-                draftByA.id,
+                privateByA.id,
                 publishedByB.id,
             )
+            assertThat(resultIds).doesNotContain(draftByA.id)
         }
 
         @Test


### PR DESCRIPTION
## 관련 자료
- 이슈: 없음

## 어떤 작업인가요?
- 게시물 목록 조회에서 본인 draft 노출을 막고 조회 전략 구성을 fail-fast하게 정리합니다.

## 어떻게 해결했나요?
**게시물 노출 규칙 정리**
- 전체 게시물 조회에서 로그인 사용자는 공개 게시물과 본인 PRIVATE 게시물만 보도록 조건을 조정했습니다.
- 서비스, 저장소 구현, 통합 테스트를 함께 수정해 DRAFT가 목록에 섞이지 않도록 맞췄습니다.

**조회 전략 구조 분리**
- 게시물 목록 조회 분기를 전략 인터페이스와 개별 전략 클래스로 분리했습니다.
- 전략 타입 기반 선택과 생성 시점 누락/중복 검증을 추가해 런타임 분기 누락을 초기화 단계에서 감지하도록 바꿨습니다.

## 중요한 변경 사항은 무엇인가요?
### 게시물 노출 규칙 정리

**open-api 목록에서 본인 draft 제외**
- **변경 이유**: 로그인 사용자의 전체 목록 조회에 본인 draft가 섞여 노출되는 동작을 막기 위해
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt`, `src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt`, `src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt`, `src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt`

### 조회 전략 구조 분리

**전략 선택을 fail-fast 구조로 고정**
- **변경 이유**: 전략 누락이나 중복을 요청 처리 중이 아니라 서비스 초기화 시점에 감지하기 위해
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/application/PostListQueryStrategy.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/application/PostListQueryCriteria.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/application/PostListQueryType.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/application/AllVisiblePostsQueryStrategy.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/application/OwnVisiblePostsQueryStrategy.kt`, `src/main/kotlin/com/techtaurant/mainserver/post/application/AuthorPublicPostsQueryStrategy.kt`, `src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt`

## 스크린샷 및 시연 영상 (optional)

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.