### PR TITLE
feat(security): 관리자 prefix 권한 경로를 분리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,9 @@
 
 코드 변경 작업 완료 시 반드시 아래를 실행하고 통과해야 한다.
 
+- 커밋 전에는 반드시 `./gradlew spotlessApply`를 먼저 실행한 뒤 변경 사항을 확인하고 커밋한다.
+- `spotlessApply`를 실행하지 않은 상태로 코드 변경을 커밋하지 않는다.
+
 ```bash
 ./gradlew spotlessApply && ./gradlew spotlessCheck
 ```

--- a/src/main/kotlin/com/techtaurant/mainserver/security/SecurityConstants.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/SecurityConstants.kt
@@ -5,4 +5,5 @@ object SecurityConstants {
 
     const val OPEN_API_PREFIX = "/open-api"
     const val API_PREFIX = "/api"
+    const val ADMIN_API_PREFIX = "/admin"
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/config/SecurityConfig.kt
@@ -61,6 +61,9 @@ class SecurityConfig(
                         "${SecurityConstants.OPEN_API_PREFIX}/**",
                     ).permitAll()
                     .requestMatchers(
+                        "${SecurityConstants.ADMIN_API_PREFIX}/**",
+                    ).hasAuthority(UserRole.ADMIN.key)
+                    .requestMatchers(
                         "${SecurityConstants.API_PREFIX}/**",
                     ).hasAnyAuthority(
                         UserRole.ADMIN.key,

--- a/src/main/kotlin/com/techtaurant/mainserver/security/dto/DevTestLoginRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/dto/DevTestLoginRequest.kt
@@ -1,5 +1,6 @@
 package com.techtaurant.mainserver.security.dto
 
+import com.techtaurant.mainserver.user.enums.UserRole
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 
@@ -8,6 +9,7 @@ import jakarta.validation.constraints.NotBlank
  *
  * @property identifier 테스트 사용자 식별자
  * @property password 개발 환경 고정 비밀번호 (dev-password)
+ * @property role 테스트 사용자 권한, 기본값은 USER
  */
 @Schema(description = "개발 환경 테스트 로그인 요청")
 data class DevTestLoginRequest(
@@ -17,4 +19,6 @@ data class DevTestLoginRequest(
     @field:NotBlank(message = "비밀번호는 필수입니다")
     @field:Schema(description = "개발 환경 비밀번호", example = "dev-password")
     val password: String,
+    @field:Schema(description = "테스트 사용자 권한", example = "USER", allowableValues = ["USER", "ADMIN"], defaultValue = "USER")
+    val role: UserRole = UserRole.USER,
 )

--- a/src/main/kotlin/com/techtaurant/mainserver/security/infrastructure/in/DevTestAuthControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/infrastructure/in/DevTestAuthControllerDocs.kt
@@ -15,7 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 interface DevTestAuthControllerDocs {
     @Operation(
         summary = "개발용 테스트 로그인",
-        description = "테스트 사용자로 로그인하여 JWT 토큰을 쿠키로 발급받습니다. 사용자가 없으면 자동 생성됩니다.",
+        description = "테스트 사용자로 로그인하여 JWT 토큰을 쿠키로 발급받습니다. 사용자가 없으면 자동 생성되며, 요청 role 값으로 USER 또는 ADMIN 권한을 설정할 수 있습니다.",
     )
     @SwaggerApiResponse(
         responseCode = "200",

--- a/src/main/kotlin/com/techtaurant/mainserver/security/service/DevTestAuthService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/service/DevTestAuthService.kt
@@ -12,7 +12,6 @@ import com.techtaurant.mainserver.security.jwt.JwtProperties
 import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
 import com.techtaurant.mainserver.user.application.UserUniqueNameService
 import com.techtaurant.mainserver.user.entity.User
-import com.techtaurant.mainserver.user.enums.UserRole
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.context.annotation.Profile

--- a/src/main/kotlin/com/techtaurant/mainserver/security/service/DevTestAuthService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/service/DevTestAuthService.kt
@@ -57,7 +57,7 @@ class DevTestAuthService(
     ): DevTestLoginResponse {
         validatePassword(request.password)
 
-        val user = findOrCreateTestUser(request.identifier)
+        val user = findOrCreateTestUser(request)
         val userId = user.id ?: throw ApiException(DefaultStatus.SERVER_ERROR, "테스트 사용자 ID가 없습니다")
 
         val accessToken = jwtTokenProvider.createAccessToken(userId, user.role)
@@ -90,17 +90,22 @@ class DevTestAuthService(
         }
     }
 
-    private fun findOrCreateTestUser(identifier: String): User {
-        return userRepository.findByIdentifierAndProvider(identifier, OAuthProvider.DEV_LOCAL)
-            ?: userUniqueNameService.saveNewUser(
-                User(
-                    name = identifier,
-                    email = "$identifier@dev.local",
-                    provider = OAuthProvider.DEV_LOCAL,
-                    identifier = identifier,
-                    role = UserRole.USER,
-                    profileImageUrl = "",
-                ),
-            )
+    private fun findOrCreateTestUser(request: DevTestLoginRequest): User {
+        val existingUser = userRepository.findByIdentifierAndProvider(request.identifier, OAuthProvider.DEV_LOCAL)
+        if (existingUser != null) {
+            existingUser.role = request.role
+            return existingUser
+        }
+
+        return userUniqueNameService.saveNewUser(
+            User(
+                name = request.identifier,
+                email = "${request.identifier}@dev.local",
+                provider = OAuthProvider.DEV_LOCAL,
+                identifier = request.identifier,
+                role = request.role,
+                profileImageUrl = "",
+            ),
+        )
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/security/config/SecurityConfigAdminPrefixIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/config/SecurityConfigAdminPrefixIntegrationTest.kt
@@ -1,0 +1,131 @@
+package com.techtaurant.mainserver.security.config
+
+import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.security.SecurityConstants
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import io.restassured.RestAssured.given
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@DisplayName("SecurityConfig admin prefix 통합 테스트")
+@Import(SecurityConfigAdminPrefixIntegrationTest.AdminTestControllerConfig::class)
+class SecurityConfigAdminPrefixIntegrationTest : IntegrationTest() {
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    private lateinit var userAccessToken: String
+    private lateinit var adminAccessToken: String
+    private lateinit var userId: UUID
+    private lateinit var adminId: UUID
+
+    @BeforeEach
+    fun setUpUsers() {
+        userRepository.deleteAllInBatch()
+
+        val user =
+            userRepository.save(
+                User(
+                    name = "일반사용자",
+                    email = "user-${UUID.randomUUID()}@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "user-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/user-profile.jpg",
+                ),
+            )
+        val admin =
+            userRepository.save(
+                User(
+                    name = "관리자사용자",
+                    email = "admin-${UUID.randomUUID()}@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "admin-id-${UUID.randomUUID()}",
+                    role = UserRole.ADMIN,
+                    profileImageUrl = "https://example.com/admin-profile.jpg",
+                ),
+            )
+
+        userId = user.id!!
+        adminId = admin.id!!
+        userAccessToken = jwtTokenProvider.createAccessToken(userId, user.role)
+        adminAccessToken = jwtTokenProvider.createAccessToken(adminId, admin.role)
+    }
+
+    @Test
+    @DisplayName("USER 권한은 일반 사용자 API를 호출할 수 있다")
+    fun userCanAccessUserApi() {
+        given()
+            .header("Authorization", "Bearer $userAccessToken")
+            .`when`()
+            .get("/api/users/me")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.id", equalTo(userId.toString()))
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한은 일반 사용자 API를 호출할 수 있다")
+    fun adminCanAccessUserApi() {
+        given()
+            .header("Authorization", "Bearer $adminAccessToken")
+            .`when`()
+            .get("/api/users/me")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.id", equalTo(adminId.toString()))
+    }
+
+    @Test
+    @DisplayName("USER 권한은 admin prefix API에 접근하면 403을 반환한다")
+    fun userCannotAccessAdminPrefixApi() {
+        given()
+            .header("Authorization", "Bearer $userAccessToken")
+            .`when`()
+            .get("${SecurityConstants.ADMIN_API_PREFIX}/test/ping")
+            .then()
+            .statusCode(HttpStatus.FORBIDDEN.value())
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한은 admin prefix API 보안 검사를 통과한다")
+    fun adminPassesAdminPrefixSecurity() {
+        given()
+            .header("Authorization", "Bearer $adminAccessToken")
+            .`when`()
+            .get("${SecurityConstants.ADMIN_API_PREFIX}/test/ping")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("message", equalTo("pong"))
+    }
+
+    @TestConfiguration
+    class AdminTestControllerConfig {
+        @Bean
+        fun adminTestController(): AdminTestController = AdminTestController()
+    }
+
+    @RestController
+    @RequestMapping("${SecurityConstants.ADMIN_API_PREFIX}/test")
+    class AdminTestController {
+        @GetMapping("/ping")
+        fun ping(): Map<String, String> = mapOf("message" to "pong")
+    }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/security/service/DevTestAuthServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/service/DevTestAuthServiceTest.kt
@@ -52,7 +52,7 @@ class DevTestAuthServiceTest {
     @DisplayName("dev 테스트 사용자가 없으면 유니크 닉네임 정책으로 새 사용자를 생성한다")
     fun `create dev test user with unique name policy`() {
         val identifier = "dev-user"
-        val request = DevTestLoginRequest(identifier = identifier, password = "dev-password")
+        val request = DevTestLoginRequest(identifier = identifier, password = "dev-password", role = UserRole.ADMIN)
         val response = mockk<HttpServletResponse>(relaxed = true)
         val userId = UUID.randomUUID()
         val createdUser =
@@ -61,7 +61,7 @@ class DevTestAuthServiceTest {
                 email = "$identifier@dev.local",
                 provider = OAuthProvider.DEV_LOCAL,
                 identifier = identifier,
-                role = UserRole.USER,
+                role = UserRole.ADMIN,
                 profileImageUrl = "",
             ).apply {
                 id = userId
@@ -69,7 +69,7 @@ class DevTestAuthServiceTest {
 
         every { userRepository.findByIdentifierAndProvider(identifier, OAuthProvider.DEV_LOCAL) } returns null
         every { userUniqueNameService.saveNewUser(any()) } returns createdUser
-        every { jwtTokenProvider.createAccessToken(userId, UserRole.USER) } returns "access-token"
+        every { jwtTokenProvider.createAccessToken(userId, UserRole.ADMIN) } returns "access-token"
         every { jwtTokenProvider.createRefreshToken(userId) } returns "refresh-token"
 
         val result = devTestAuthService.execute(request, response)
@@ -81,6 +81,7 @@ class DevTestAuthServiceTest {
                 withArg {
                     assertEquals(identifier, it.name)
                     assertEquals("$identifier@dev.local", it.email)
+                    assertEquals(UserRole.ADMIN, it.role)
                 },
             )
         }
@@ -101,5 +102,36 @@ class DevTestAuthServiceTest {
             )
         }
         verify { tokenCacheManager.saveRefreshToken(userId.toString(), "refresh-token") }
+    }
+
+    @Test
+    @DisplayName("기존 dev 테스트 사용자는 요청한 권한으로 갱신한다")
+    fun `update existing dev test user role`() {
+        val identifier = "existing-user"
+        val request = DevTestLoginRequest(identifier = identifier, password = "dev-password", role = UserRole.ADMIN)
+        val response = mockk<HttpServletResponse>(relaxed = true)
+        val userId = UUID.randomUUID()
+        val existingUser =
+            User(
+                name = identifier,
+                email = "$identifier@dev.local",
+                provider = OAuthProvider.DEV_LOCAL,
+                identifier = identifier,
+                role = UserRole.USER,
+                profileImageUrl = "",
+            ).apply {
+                id = userId
+            }
+
+        every { userRepository.findByIdentifierAndProvider(identifier, OAuthProvider.DEV_LOCAL) } returns existingUser
+        every { jwtTokenProvider.createAccessToken(userId, UserRole.ADMIN) } returns "access-token"
+        every { jwtTokenProvider.createRefreshToken(userId) } returns "refresh-token"
+
+        val result = devTestAuthService.execute(request, response)
+
+        assertEquals(UserRole.ADMIN, existingUser.role)
+        assertEquals("access-token", result.accessToken)
+        assertEquals("refresh-token", result.refreshToken)
+        verify(exactly = 0) { userUniqueNameService.saveNewUser(any()) }
     }
 }


### PR DESCRIPTION
## Summary
- `/admin/**` 경로를 관리자 전용으로 분리하고 `/api/**` 경로는 USER와 ADMIN이 모두 접근하도록 보안 규칙을 정리했습니다.
- 개발용 테스트 로그인에서 `role`을 지정할 수 있게 해 ADMIN 토큰 발급과 기존 dev 계정 권한 갱신을 지원했습니다.
- 관리자 prefix 접근 제어와 USER/API 공용 접근을 검증하는 테스트를 추가했습니다.
- `CLAUDE.md` 체크리스트에 커밋 전 `./gradlew spotlessApply`를 반드시 실행한 뒤 커밋해야 한다는 규칙을 명시했습니다.
- 기존 `users.role` 컬럼을 그대로 사용해 마이그레이션은 추가하지 않았습니다.

## Test
- `./gradlew spotlessApply`
- `./gradlew test --tests "com.techtaurant.mainserver.security.service.DevTestAuthServiceTest" --tests "com.techtaurant.mainserver.security.config.SecurityConfigAdminPrefixIntegrationTest" -x jacocoTestReport -x jacocoTestCoverageVerification`