### PR TITLE
feat(notification): 알림 저장 구조와 생성 서비스 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "${DB_PORT:-5432}:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - techtaurant_postgres_data:/var/lib/postgresql
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-root} -d ${DB_NAME:-techtaurant}"]
@@ -32,5 +32,5 @@ services:
     restart: unless-stopped
 
 volumes:
-  postgres_data:
+  techtaurant_postgres_data:
     driver: local

--- a/src/main/kotlin/com/techtaurant/mainserver/config/MessageSourceConfig.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/config/MessageSourceConfig.kt
@@ -1,0 +1,18 @@
+package com.techtaurant.mainserver.config
+
+import org.springframework.context.MessageSource
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.support.ReloadableResourceBundleMessageSource
+
+@Configuration
+class MessageSourceConfig {
+    @Bean
+    fun messageSource(): MessageSource {
+        val messageSource = ReloadableResourceBundleMessageSource()
+        messageSource.setBasename("classpath:messages")
+        messageSource.setDefaultEncoding("UTF-8")
+        messageSource.setFallbackToSystemLocale(false)
+        return messageSource
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationPayloadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationPayloadService.kt
@@ -1,0 +1,47 @@
+package com.techtaurant.mainserver.notification.application
+
+import com.techtaurant.mainserver.common.util.HtmlSanitizer
+import org.springframework.context.MessageSource
+import org.springframework.context.i18n.LocaleContextHolder
+import org.springframework.stereotype.Service
+import java.util.Locale
+
+@Service
+class NotificationPayloadService(
+    private val messageSource: MessageSource,
+) {
+    fun buildPostCommentPayload(
+        actorName: String,
+        postTitle: String,
+        locale: Locale? = null,
+    ): String = buildMessage("notification.payload.post-comment", locale, actorName, postTitle)
+
+    fun buildCommentReplyPayload(
+        actorName: String,
+        postTitle: String,
+        locale: Locale? = null,
+    ): String = buildMessage("notification.payload.comment-reply", locale, actorName, postTitle)
+
+    fun buildFollowerPostPayload(
+        actorName: String,
+        postTitle: String,
+        locale: Locale? = null,
+    ): String = buildMessage("notification.payload.follower-post", locale, actorName, postTitle)
+
+    fun buildFollowPayload(
+        actorName: String,
+        locale: Locale? = null,
+    ): String = buildMessage("notification.payload.follow", locale, actorName)
+
+    private fun buildMessage(
+        key: String,
+        locale: Locale?,
+        vararg args: String,
+    ): String {
+        val resolvedLocale = locale ?: LocaleContextHolder.getLocale()
+        val sanitizedArgs = args.map(HtmlSanitizer::sanitizeTitle).toTypedArray()
+        val localizedMessage = messageSource.getMessage(key, sanitizedArgs, resolvedLocale)
+
+        return HtmlSanitizer.sanitizeContent(localizedMessage).trim()
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteService.kt
@@ -1,9 +1,9 @@
 package com.techtaurant.mainserver.notification.application
 
 import com.techtaurant.mainserver.comment.enums.CommentStatus
+import com.techtaurant.mainserver.comment.entity.Comment
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepository
 import com.techtaurant.mainserver.common.exception.ApiException
-import com.techtaurant.mainserver.common.util.HtmlSanitizer
 import com.techtaurant.mainserver.notification.entity.Notification
 import com.techtaurant.mainserver.notification.entity.NotificationRecipient
 import com.techtaurant.mainserver.notification.entity.NotificationTarget
@@ -12,6 +12,7 @@ import com.techtaurant.mainserver.notification.enums.NotificationTargetRole
 import com.techtaurant.mainserver.notification.enums.NotificationTargetType
 import com.techtaurant.mainserver.notification.enums.NotificationType
 import com.techtaurant.mainserver.notification.infrastructure.out.NotificationRepository
+import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.enums.PostStatus
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.user.entity.User
@@ -19,11 +20,13 @@ import com.techtaurant.mainserver.user.enums.UserStatus
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.Locale
 import java.util.UUID
 
 @Service
 class NotificationWriteService(
     private val notificationRepository: NotificationRepository,
+    private val notificationPayloadService: NotificationPayloadService,
     private val userRepository: UserRepository,
     private val postRepository: PostRepository,
     private val commentRepository: CommentRepository,
@@ -34,17 +37,17 @@ class NotificationWriteService(
         recipientUserId: UUID,
         postId: UUID,
         commentId: UUID,
-        payloadHtml: String,
+        locale: Locale? = null,
     ): UUID {
         val actor = resolveActor(actorUserId)
         val recipients = resolveRecipients(listOf(recipientUserId))
+        val post = resolvePost(postId)
 
-        requirePost(postId)
-        requireComment(commentId)
+        resolveComment(commentId)
 
         return createNotification(
             type = NotificationType.POST_COMMENT,
-            payloadHtml = payloadHtml,
+            payloadHtml = notificationPayloadService.buildPostCommentPayload(actor.name, post.title, locale),
             recipients = recipients,
             targetSpecs =
                 listOf(
@@ -61,17 +64,17 @@ class NotificationWriteService(
         recipientUserId: UUID,
         postId: UUID,
         commentId: UUID,
-        payloadHtml: String,
+        locale: Locale? = null,
     ): UUID {
         val actor = resolveActor(actorUserId)
         val recipients = resolveRecipients(listOf(recipientUserId))
+        val post = resolvePost(postId)
 
-        requirePost(postId)
-        requireComment(commentId)
+        resolveComment(commentId)
 
         return createNotification(
             type = NotificationType.COMMENT_REPLY,
-            payloadHtml = payloadHtml,
+            payloadHtml = notificationPayloadService.buildCommentReplyPayload(actor.name, post.title, locale),
             recipients = recipients,
             targetSpecs =
                 listOf(
@@ -87,16 +90,15 @@ class NotificationWriteService(
         actorUserId: UUID,
         recipientUserIds: List<UUID>,
         postId: UUID,
-        payloadHtml: String,
+        locale: Locale? = null,
     ): UUID {
         val actor = resolveActor(actorUserId)
         val recipients = resolveRecipients(recipientUserIds)
-
-        requirePost(postId)
+        val post = resolvePost(postId)
 
         return createNotification(
             type = NotificationType.FOLLOWER_POST,
-            payloadHtml = payloadHtml,
+            payloadHtml = notificationPayloadService.buildFollowerPostPayload(actor.name, post.title, locale),
             recipients = recipients,
             targetSpecs =
                 listOf(
@@ -110,14 +112,14 @@ class NotificationWriteService(
     fun createFollowNotification(
         actorUserId: UUID,
         recipientUserId: UUID,
-        payloadHtml: String,
+        locale: Locale? = null,
     ): UUID {
         val actor = resolveActor(actorUserId)
         val recipients = resolveRecipients(listOf(recipientUserId))
 
         return createNotification(
             type = NotificationType.FOLLOW,
-            payloadHtml = payloadHtml,
+            payloadHtml = notificationPayloadService.buildFollowPayload(actor.name, locale),
             recipients = recipients,
             targetSpecs =
                 listOf(
@@ -140,7 +142,7 @@ class NotificationWriteService(
         val notification =
             Notification(
                 type = type,
-                payloadHtml = sanitizePayload(payloadHtml),
+                payloadHtml = requirePayload(payloadHtml),
             )
 
         targetSpecs.distinct().forEach { spec ->
@@ -166,13 +168,12 @@ class NotificationWriteService(
         return notificationRepository.save(notification).id!!
     }
 
-    private fun sanitizePayload(payloadHtml: String): String {
-        val sanitizedPayload = HtmlSanitizer.sanitizeContent(payloadHtml).trim()
-        if (sanitizedPayload.isBlank()) {
+    private fun requirePayload(payloadHtml: String): String {
+        if (payloadHtml.isBlank()) {
             throw ApiException(NotificationStatus.NOTIFICATION_PAYLOAD_REQUIRED)
         }
 
-        return sanitizedPayload
+        return payloadHtml
     }
 
     private fun resolveActor(actorUserId: UUID): User {
@@ -196,15 +197,15 @@ class NotificationWriteService(
         return distinctRecipientIds.map { recipientId -> recipientsById.getValue(recipientId) }
     }
 
-    private fun requirePost(postId: UUID) {
-        if (!postRepository.existsById(postId)) {
-            throw ApiException(PostStatus.POST_NOT_FOUND)
+    private fun resolvePost(postId: UUID): Post {
+        return postRepository.findById(postId).orElseThrow {
+            ApiException(PostStatus.POST_NOT_FOUND)
         }
     }
 
-    private fun requireComment(commentId: UUID) {
-        if (!commentRepository.existsById(commentId)) {
-            throw ApiException(CommentStatus.COMMENT_NOT_FOUND)
+    private fun resolveComment(commentId: UUID): Comment {
+        return commentRepository.findById(commentId).orElseThrow {
+            ApiException(CommentStatus.COMMENT_NOT_FOUND)
         }
     }
 

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteService.kt
@@ -1,0 +1,216 @@
+package com.techtaurant.mainserver.notification.application
+
+import com.techtaurant.mainserver.comment.enums.CommentStatus
+import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepository
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.common.util.HtmlSanitizer
+import com.techtaurant.mainserver.notification.entity.Notification
+import com.techtaurant.mainserver.notification.entity.NotificationRecipient
+import com.techtaurant.mainserver.notification.entity.NotificationTarget
+import com.techtaurant.mainserver.notification.enums.NotificationStatus
+import com.techtaurant.mainserver.notification.enums.NotificationTargetRole
+import com.techtaurant.mainserver.notification.enums.NotificationTargetType
+import com.techtaurant.mainserver.notification.enums.NotificationType
+import com.techtaurant.mainserver.notification.infrastructure.out.NotificationRepository
+import com.techtaurant.mainserver.post.enums.PostStatus
+import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserStatus
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class NotificationWriteService(
+    private val notificationRepository: NotificationRepository,
+    private val userRepository: UserRepository,
+    private val postRepository: PostRepository,
+    private val commentRepository: CommentRepository,
+) {
+    @Transactional
+    fun createPostCommentNotification(
+        actorUserId: UUID,
+        recipientUserId: UUID,
+        postId: UUID,
+        commentId: UUID,
+        payloadHtml: String,
+    ): UUID {
+        val actor = resolveActor(actorUserId)
+        val recipients = resolveRecipients(listOf(recipientUserId))
+
+        requirePost(postId)
+        requireComment(commentId)
+
+        return createNotification(
+            type = NotificationType.POST_COMMENT,
+            payloadHtml = payloadHtml,
+            recipients = recipients,
+            targetSpecs =
+                listOf(
+                    NotificationTargetSpec(NotificationTargetRole.ACTOR, NotificationTargetType.USER, actor.id!!),
+                    NotificationTargetSpec(NotificationTargetRole.TARGET, NotificationTargetType.POST, postId),
+                    NotificationTargetSpec(NotificationTargetRole.TARGET, NotificationTargetType.COMMENT, commentId),
+                ),
+        )
+    }
+
+    @Transactional
+    fun createCommentReplyNotification(
+        actorUserId: UUID,
+        recipientUserId: UUID,
+        postId: UUID,
+        commentId: UUID,
+        payloadHtml: String,
+    ): UUID {
+        val actor = resolveActor(actorUserId)
+        val recipients = resolveRecipients(listOf(recipientUserId))
+
+        requirePost(postId)
+        requireComment(commentId)
+
+        return createNotification(
+            type = NotificationType.COMMENT_REPLY,
+            payloadHtml = payloadHtml,
+            recipients = recipients,
+            targetSpecs =
+                listOf(
+                    NotificationTargetSpec(NotificationTargetRole.ACTOR, NotificationTargetType.USER, actor.id!!),
+                    NotificationTargetSpec(NotificationTargetRole.TARGET, NotificationTargetType.POST, postId),
+                    NotificationTargetSpec(NotificationTargetRole.TARGET, NotificationTargetType.COMMENT, commentId),
+                ),
+        )
+    }
+
+    @Transactional
+    fun createFollowerPostNotification(
+        actorUserId: UUID,
+        recipientUserIds: List<UUID>,
+        postId: UUID,
+        payloadHtml: String,
+    ): UUID {
+        val actor = resolveActor(actorUserId)
+        val recipients = resolveRecipients(recipientUserIds)
+
+        requirePost(postId)
+
+        return createNotification(
+            type = NotificationType.FOLLOWER_POST,
+            payloadHtml = payloadHtml,
+            recipients = recipients,
+            targetSpecs =
+                listOf(
+                    NotificationTargetSpec(NotificationTargetRole.ACTOR, NotificationTargetType.USER, actor.id!!),
+                    NotificationTargetSpec(NotificationTargetRole.TARGET, NotificationTargetType.POST, postId),
+                ),
+        )
+    }
+
+    @Transactional
+    fun createFollowNotification(
+        actorUserId: UUID,
+        recipientUserId: UUID,
+        payloadHtml: String,
+    ): UUID {
+        val actor = resolveActor(actorUserId)
+        val recipients = resolveRecipients(listOf(recipientUserId))
+
+        return createNotification(
+            type = NotificationType.FOLLOW,
+            payloadHtml = payloadHtml,
+            recipients = recipients,
+            targetSpecs =
+                listOf(
+                    NotificationTargetSpec(NotificationTargetRole.ACTOR, NotificationTargetType.USER, actor.id!!),
+                    NotificationTargetSpec(NotificationTargetRole.TARGET, NotificationTargetType.USER, actor.id!!),
+                ),
+        )
+    }
+
+    private fun createNotification(
+        type: NotificationType,
+        payloadHtml: String,
+        recipients: List<User>,
+        targetSpecs: List<NotificationTargetSpec>,
+    ): UUID {
+        if (targetSpecs.isEmpty()) {
+            throw ApiException(NotificationStatus.NOTIFICATION_TARGET_REQUIRED)
+        }
+
+        val notification =
+            Notification(
+                type = type,
+                payloadHtml = sanitizePayload(payloadHtml),
+            )
+
+        targetSpecs.distinct().forEach { spec ->
+            notification.addTarget(
+                NotificationTarget(
+                    notification = notification,
+                    role = spec.role,
+                    targetType = spec.targetType,
+                    targetId = spec.targetId,
+                ),
+            )
+        }
+
+        recipients.distinctBy { it.id }.forEach { recipient ->
+            notification.addRecipient(
+                NotificationRecipient(
+                    notification = notification,
+                    user = recipient,
+                ),
+            )
+        }
+
+        return notificationRepository.save(notification).id!!
+    }
+
+    private fun sanitizePayload(payloadHtml: String): String {
+        val sanitizedPayload = HtmlSanitizer.sanitizeContent(payloadHtml).trim()
+        if (sanitizedPayload.isBlank()) {
+            throw ApiException(NotificationStatus.NOTIFICATION_PAYLOAD_REQUIRED)
+        }
+
+        return sanitizedPayload
+    }
+
+    private fun resolveActor(actorUserId: UUID): User {
+        return userRepository.findById(actorUserId).orElseThrow {
+            ApiException(UserStatus.ID_NOT_FOUND)
+        }
+    }
+
+    private fun resolveRecipients(recipientUserIds: List<UUID>): List<User> {
+        val distinctRecipientIds = recipientUserIds.distinct()
+        if (distinctRecipientIds.isEmpty()) {
+            throw ApiException(NotificationStatus.NOTIFICATION_RECIPIENT_REQUIRED)
+        }
+
+        val recipients = userRepository.findAllById(distinctRecipientIds)
+        if (recipients.size != distinctRecipientIds.size) {
+            throw ApiException(UserStatus.USER_NOT_FOUND)
+        }
+
+        val recipientsById = recipients.associateBy { it.id!! }
+        return distinctRecipientIds.map { recipientId -> recipientsById.getValue(recipientId) }
+    }
+
+    private fun requirePost(postId: UUID) {
+        if (!postRepository.existsById(postId)) {
+            throw ApiException(PostStatus.POST_NOT_FOUND)
+        }
+    }
+
+    private fun requireComment(commentId: UUID) {
+        if (!commentRepository.existsById(commentId)) {
+            throw ApiException(CommentStatus.COMMENT_NOT_FOUND)
+        }
+    }
+
+    private data class NotificationTargetSpec(
+        val role: NotificationTargetRole,
+        val targetType: NotificationTargetType,
+        val targetId: UUID,
+    )
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/entity/Notification.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/entity/Notification.kt
@@ -1,0 +1,37 @@
+package com.techtaurant.mainserver.notification.entity
+
+import com.techtaurant.mainserver.common.base.EntityBase
+import com.techtaurant.mainserver.notification.enums.NotificationType
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+
+@Entity
+@Table(name = "notifications")
+class Notification(
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(nullable = false, columnDefinition = "notification_type")
+    var type: NotificationType,
+    @Column(name = "payload_html", nullable = false, columnDefinition = "TEXT")
+    var payloadHtml: String,
+    @OneToMany(mappedBy = "notification", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    var targets: MutableList<NotificationTarget> = mutableListOf(),
+    @OneToMany(mappedBy = "notification", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    var recipients: MutableList<NotificationRecipient> = mutableListOf(),
+) : EntityBase() {
+    fun addTarget(target: NotificationTarget) {
+        targets.add(target)
+    }
+
+    fun addRecipient(recipient: NotificationRecipient) {
+        recipients.add(recipient)
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/entity/NotificationRecipient.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/entity/NotificationRecipient.kt
@@ -1,0 +1,39 @@
+package com.techtaurant.mainserver.notification.entity
+
+import com.techtaurant.mainserver.common.base.EntityBase
+import com.techtaurant.mainserver.user.entity.User
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.util.Date
+
+@Entity
+@Table(
+    name = "notification_recipients",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_notification_recipients_notification_id_user_id",
+            columnNames = ["notification_id", "user_id"],
+        ),
+    ],
+    indexes = [
+        Index(name = "idx_notification_recipients_notification_id", columnList = "notification_id"),
+        Index(name = "idx_notification_recipients_user_id_created_at", columnList = "user_id, created_at"),
+        Index(name = "idx_notification_recipients_user_id_read_at", columnList = "user_id, read_at"),
+    ],
+)
+class NotificationRecipient(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notification_id", nullable = false)
+    var notification: Notification,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    var user: User,
+    @Column(name = "read_at")
+    var readAt: Date? = null,
+) : EntityBase()

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/entity/NotificationTarget.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/entity/NotificationTarget.kt
@@ -1,0 +1,48 @@
+package com.techtaurant.mainserver.notification.entity
+
+import com.techtaurant.mainserver.common.base.EntityBase
+import com.techtaurant.mainserver.notification.enums.NotificationTargetRole
+import com.techtaurant.mainserver.notification.enums.NotificationTargetType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.util.UUID
+
+@Entity
+@Table(
+    name = "notification_targets",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_notification_targets_notification_id_role_target_type_target_id",
+            columnNames = ["notification_id", "role", "target_type", "target_id"],
+        ),
+    ],
+    indexes = [
+        Index(name = "idx_notification_targets_notification_id", columnList = "notification_id"),
+        Index(name = "idx_notification_targets_target_type_target_id", columnList = "target_type, target_id"),
+    ],
+)
+class NotificationTarget(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notification_id", nullable = false)
+    var notification: Notification,
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(nullable = false, columnDefinition = "notification_target_role")
+    var role: NotificationTargetRole,
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(name = "target_type", nullable = false, columnDefinition = "notification_target_type")
+    var targetType: NotificationTargetType,
+    @Column(name = "target_id", nullable = false, columnDefinition = "UUID")
+    var targetId: UUID,
+) : EntityBase()

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/enums/NotificationStatus.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/enums/NotificationStatus.kt
@@ -1,0 +1,27 @@
+package com.techtaurant.mainserver.notification.enums
+
+import com.techtaurant.mainserver.common.status.StatusIfs
+import org.springframework.http.HttpStatus
+
+enum class NotificationStatus(
+    private val httpStatusCode: Int,
+    private val customStatusCode: Int,
+    private val description: String,
+) : StatusIfs {
+    NOTIFICATION_PAYLOAD_REQUIRED(HttpStatus.BAD_REQUEST.value(), 6001, "알림 payload는 비어 있을 수 없습니다"),
+    NOTIFICATION_RECIPIENT_REQUIRED(HttpStatus.BAD_REQUEST.value(), 6002, "수신자는 최소 1명 이상이어야 합니다"),
+    NOTIFICATION_TARGET_REQUIRED(HttpStatus.BAD_REQUEST.value(), 6003, "알림 대상 정보가 필요합니다"),
+    ;
+
+    override fun getHttpStatusCode(): Int {
+        return httpStatusCode
+    }
+
+    override fun getCustomStatusCode(): Int {
+        return customStatusCode
+    }
+
+    override fun getDescription(): String {
+        return description
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/enums/NotificationTargetRole.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/enums/NotificationTargetRole.kt
@@ -1,0 +1,6 @@
+package com.techtaurant.mainserver.notification.enums
+
+enum class NotificationTargetRole {
+    ACTOR,
+    TARGET,
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/enums/NotificationTargetType.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/enums/NotificationTargetType.kt
@@ -1,0 +1,7 @@
+package com.techtaurant.mainserver.notification.enums
+
+enum class NotificationTargetType {
+    USER,
+    POST,
+    COMMENT,
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/enums/NotificationType.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/enums/NotificationType.kt
@@ -1,0 +1,8 @@
+package com.techtaurant.mainserver.notification.enums
+
+enum class NotificationType {
+    POST_COMMENT,
+    COMMENT_REPLY,
+    FOLLOWER_POST,
+    FOLLOW,
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/infrastructure/out/NotificationRecipientRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/infrastructure/out/NotificationRecipientRepository.kt
@@ -1,0 +1,9 @@
+package com.techtaurant.mainserver.notification.infrastructure.out
+
+import com.techtaurant.mainserver.notification.entity.NotificationRecipient
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface NotificationRecipientRepository : JpaRepository<NotificationRecipient, UUID> {
+    fun findAllByNotificationIdOrderByCreatedAtAsc(notificationId: UUID): List<NotificationRecipient>
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/infrastructure/out/NotificationRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/infrastructure/out/NotificationRepository.kt
@@ -1,0 +1,7 @@
+package com.techtaurant.mainserver.notification.infrastructure.out
+
+import com.techtaurant.mainserver.notification.entity.Notification
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface NotificationRepository : JpaRepository<Notification, UUID>

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/infrastructure/out/NotificationTargetRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/infrastructure/out/NotificationTargetRepository.kt
@@ -1,0 +1,9 @@
+package com.techtaurant.mainserver.notification.infrastructure.out
+
+import com.techtaurant.mainserver.notification.entity.NotificationTarget
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface NotificationTargetRepository : JpaRepository<NotificationTarget, UUID> {
+    fun findAllByNotificationIdOrderByCreatedAtAsc(notificationId: UUID): List<NotificationTarget>
+}

--- a/src/main/resources/db/migration/V23__create_notifications.sql
+++ b/src/main/resources/db/migration/V23__create_notifications.sql
@@ -1,0 +1,54 @@
+CREATE TYPE notification_type AS ENUM (
+    'POST_COMMENT',
+    'COMMENT_REPLY',
+    'FOLLOWER_POST',
+    'FOLLOW'
+);
+
+CREATE TYPE notification_target_role AS ENUM (
+    'ACTOR',
+    'TARGET'
+);
+
+CREATE TYPE notification_target_type AS ENUM (
+    'USER',
+    'POST',
+    'COMMENT'
+);
+
+CREATE TABLE notifications (
+    id UUID PRIMARY KEY,
+    type notification_type NOT NULL,
+    payload_html TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE notification_targets (
+    id UUID PRIMARY KEY,
+    notification_id UUID NOT NULL REFERENCES notifications(id) ON DELETE CASCADE,
+    role notification_target_role NOT NULL,
+    target_type notification_target_type NOT NULL,
+    target_id UUID NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_notification_targets_notification_id_role_target_type_target_id
+        UNIQUE (notification_id, role, target_type, target_id)
+);
+
+CREATE TABLE notification_recipients (
+    id UUID PRIMARY KEY,
+    notification_id UUID NOT NULL REFERENCES notifications(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    read_at TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_notification_recipients_notification_id_user_id UNIQUE (notification_id, user_id)
+);
+
+CREATE INDEX idx_notifications_type_created_at ON notifications(type, created_at DESC);
+CREATE INDEX idx_notification_targets_notification_id ON notification_targets(notification_id);
+CREATE INDEX idx_notification_targets_target_type_target_id ON notification_targets(target_type, target_id);
+CREATE INDEX idx_notification_recipients_notification_id ON notification_recipients(notification_id);
+CREATE INDEX idx_notification_recipients_user_id_created_at ON notification_recipients(user_id, created_at DESC);
+CREATE INDEX idx_notification_recipients_user_id_read_at ON notification_recipients(user_id, read_at);

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,4 @@
+notification.payload.post-comment=<strong>{0}</strong>님이 회원님의 게시물 <strong>{1}</strong>에 댓글을 남겼습니다.
+notification.payload.comment-reply=<strong>{0}</strong>님이 회원님의 댓글이 달린 게시물 <strong>{1}</strong>에 답글을 남겼습니다.
+notification.payload.follower-post=<strong>{0}</strong>님이 새 게시물 <strong>{1}</strong>을 작성했습니다.
+notification.payload.follow=<strong>{0}</strong>님이 회원님을 팔로우했습니다.

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -1,0 +1,4 @@
+notification.payload.post-comment=<strong>{0}</strong> commented on your post <strong>{1}</strong>.
+notification.payload.comment-reply=<strong>{0}</strong> replied to your comment on <strong>{1}</strong>.
+notification.payload.follower-post=<strong>{0}</strong> published a new post <strong>{1}</strong>.
+notification.payload.follow=<strong>{0}</strong> started following you.

--- a/src/test/kotlin/com/techtaurant/mainserver/notification/application/NotificationPayloadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/notification/application/NotificationPayloadServiceTest.kt
@@ -1,0 +1,57 @@
+package com.techtaurant.mainserver.notification.application
+
+import com.techtaurant.mainserver.config.MessageSourceConfig
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.Locale
+
+class NotificationPayloadServiceTest {
+    private lateinit var notificationPayloadService: NotificationPayloadService
+
+    @BeforeEach
+    fun setUp() {
+        notificationPayloadService = NotificationPayloadService(MessageSourceConfig().messageSource())
+    }
+
+    @Test
+    @DisplayName("게시물 댓글 알림 payload는 한국어 템플릿으로 생성된다")
+    fun buildPostCommentPayload_returnsKoreanMessage() {
+        val payload =
+            notificationPayloadService.buildPostCommentPayload(
+                actorName = "민수",
+                postTitle = "JPA 정리",
+                locale = Locale.KOREAN,
+            )
+
+        assertThat(payload).isEqualTo("<strong>민수</strong>님이 회원님의 게시물 <strong>JPA 정리</strong>에 댓글을 남겼습니다.")
+    }
+
+    @Test
+    @DisplayName("팔로우 알림 payload는 영어 템플릿으로 생성된다")
+    fun buildFollowPayload_returnsEnglishMessage() {
+        val payload =
+            notificationPayloadService.buildFollowPayload(
+                actorName = "Minsu",
+                locale = Locale.ENGLISH,
+            )
+
+        assertThat(payload).isEqualTo("<strong>Minsu</strong> started following you.")
+    }
+
+    @Test
+    @DisplayName("payload 생성 시 동적 값의 위험한 HTML은 제거된다")
+    fun buildFollowerPostPayload_sanitizesArguments() {
+        val payload =
+            notificationPayloadService.buildFollowerPostPayload(
+                actorName = "<script>alert('xss')</script><b>민수</b>",
+                postTitle = "<img src=x onerror=alert('xss')>알림 설계",
+                locale = Locale.KOREAN,
+            )
+
+        assertThat(payload).contains("민수")
+        assertThat(payload).contains("알림 설계")
+        assertThat(payload).doesNotContain("<script>", "<img", "onerror", "alert")
+    }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteServiceTest.kt
@@ -1,0 +1,219 @@
+package com.techtaurant.mainserver.notification.application
+
+import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.comment.entity.Comment
+import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepository
+import com.techtaurant.mainserver.notification.enums.NotificationTargetRole
+import com.techtaurant.mainserver.notification.enums.NotificationTargetType
+import com.techtaurant.mainserver.notification.enums.NotificationType
+import com.techtaurant.mainserver.notification.infrastructure.out.NotificationRecipientRepository
+import com.techtaurant.mainserver.notification.infrastructure.out.NotificationRepository
+import com.techtaurant.mainserver.notification.infrastructure.out.NotificationTargetRepository
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Transactional
+@ActiveProfiles("test")
+class NotificationWriteServiceTest : IntegrationTest() {
+    @Autowired
+    private lateinit var notificationWriteService: NotificationWriteService
+
+    @Autowired
+    private lateinit var notificationRepository: NotificationRepository
+
+    @Autowired
+    private lateinit var notificationTargetRepository: NotificationTargetRepository
+
+    @Autowired
+    private lateinit var notificationRecipientRepository: NotificationRecipientRepository
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var commentRepository: CommentRepository
+
+    private lateinit var actorUser: User
+    private lateinit var recipientUser: User
+    private lateinit var secondRecipientUser: User
+    private lateinit var post: Post
+    private lateinit var comment: Comment
+
+    @BeforeEach
+    fun setUpTestData() {
+        actorUser = createUser("actor")
+        recipientUser = createUser("recipient")
+        secondRecipientUser = createUser("recipient-second")
+        post = createPost(actorUser)
+        comment = createComment(post = post, author = recipientUser)
+    }
+
+    @Test
+    @DisplayName("게시물 댓글 알림 생성 시 payload HTML은 sanitize되고 target과 recipient가 저장된다")
+    fun createPostCommentNotification_savesNotificationGraph() {
+        val notificationId =
+            notificationWriteService.createPostCommentNotification(
+                actorUserId = actorUser.id!!,
+                recipientUserId = recipientUser.id!!,
+                postId = post.id!!,
+                commentId = comment.id!!,
+                payloadHtml = "<strong>${actorUser.name}</strong><script>alert('xss')</script>님이 댓글을 남겼습니다",
+            )
+
+        val savedNotification = notificationRepository.findById(notificationId).orElseThrow()
+        val savedTargets = notificationTargetRepository.findAllByNotificationIdOrderByCreatedAtAsc(notificationId)
+        val savedRecipients = notificationRecipientRepository.findAllByNotificationIdOrderByCreatedAtAsc(notificationId)
+
+        assertThat(savedNotification.type).isEqualTo(NotificationType.POST_COMMENT)
+        assertThat(savedNotification.payloadHtml).contains("<strong>${actorUser.name}</strong>")
+        assertThat(savedNotification.payloadHtml).doesNotContain("<script>", "alert")
+        assertThat(savedTargets)
+            .extracting("role", "targetType", "targetId")
+            .containsExactlyInAnyOrder(
+                tuple(NotificationTargetRole.ACTOR, NotificationTargetType.USER, actorUser.id),
+                tuple(NotificationTargetRole.TARGET, NotificationTargetType.POST, post.id),
+                tuple(NotificationTargetRole.TARGET, NotificationTargetType.COMMENT, comment.id),
+            )
+        assertThat(savedRecipients).singleElement().extracting("user.id").isEqualTo(recipientUser.id)
+    }
+
+    @Test
+    @DisplayName("대댓글 알림 생성 시 COMMENT_REPLY 타입으로 저장된다")
+    fun createCommentReplyNotification_savesReplyNotification() {
+        val replyComment = createComment(post = post, author = actorUser, parent = comment)
+
+        val notificationId =
+            notificationWriteService.createCommentReplyNotification(
+                actorUserId = actorUser.id!!,
+                recipientUserId = recipientUser.id!!,
+                postId = post.id!!,
+                commentId = replyComment.id!!,
+                payloadHtml = "<em>${actorUser.name}</em>님이 답글을 남겼습니다",
+            )
+
+        val savedNotification = notificationRepository.findById(notificationId).orElseThrow()
+        val savedTargets = notificationTargetRepository.findAllByNotificationIdOrderByCreatedAtAsc(notificationId)
+
+        assertThat(savedNotification.type).isEqualTo(NotificationType.COMMENT_REPLY)
+        assertThat(savedNotification.payloadHtml).contains("<em>${actorUser.name}</em>")
+        assertThat(savedTargets)
+            .extracting("role", "targetType", "targetId")
+            .containsExactlyInAnyOrder(
+                tuple(NotificationTargetRole.ACTOR, NotificationTargetType.USER, actorUser.id),
+                tuple(NotificationTargetRole.TARGET, NotificationTargetType.POST, post.id),
+                tuple(NotificationTargetRole.TARGET, NotificationTargetType.COMMENT, replyComment.id),
+            )
+    }
+
+    @Test
+    @DisplayName("팔로잉 게시물 알림 생성 시 recipient는 중복 없이 저장된다")
+    fun createFollowerPostNotification_deduplicatesRecipients() {
+        val notificationId =
+            notificationWriteService.createFollowerPostNotification(
+                actorUserId = actorUser.id!!,
+                recipientUserIds = listOf(recipientUser.id!!, secondRecipientUser.id!!, recipientUser.id!!),
+                postId = post.id!!,
+                payloadHtml = "<p>${actorUser.name}님의 새 글</p>",
+            )
+
+        val savedNotification = notificationRepository.findById(notificationId).orElseThrow()
+        val savedTargets = notificationTargetRepository.findAllByNotificationIdOrderByCreatedAtAsc(notificationId)
+        val savedRecipients = notificationRecipientRepository.findAllByNotificationIdOrderByCreatedAtAsc(notificationId)
+
+        assertThat(savedNotification.type).isEqualTo(NotificationType.FOLLOWER_POST)
+        assertThat(savedTargets)
+            .extracting("role", "targetType", "targetId")
+            .containsExactlyInAnyOrder(
+                tuple(NotificationTargetRole.ACTOR, NotificationTargetType.USER, actorUser.id),
+                tuple(NotificationTargetRole.TARGET, NotificationTargetType.POST, post.id),
+            )
+        assertThat(savedRecipients).hasSize(2)
+        assertThat(savedRecipients.map { it.user.id }).containsExactly(recipientUser.id, secondRecipientUser.id)
+    }
+
+    @Test
+    @DisplayName("팔로우 알림 생성 시 actor와 profile target user가 함께 저장된다")
+    fun createFollowNotification_savesUserTargets() {
+        val notificationId =
+            notificationWriteService.createFollowNotification(
+                actorUserId = actorUser.id!!,
+                recipientUserId = recipientUser.id!!,
+                payloadHtml = "<span>${actorUser.name}</span>님이 팔로우했습니다",
+            )
+
+        val savedNotification = notificationRepository.findById(notificationId).orElseThrow()
+        val savedTargets = notificationTargetRepository.findAllByNotificationIdOrderByCreatedAtAsc(notificationId)
+        val savedRecipients = notificationRecipientRepository.findAllByNotificationIdOrderByCreatedAtAsc(notificationId)
+
+        assertThat(savedNotification.type).isEqualTo(NotificationType.FOLLOW)
+        assertThat(savedTargets)
+            .extracting("role", "targetType", "targetId")
+            .containsExactlyInAnyOrder(
+                tuple(NotificationTargetRole.ACTOR, NotificationTargetType.USER, actorUser.id),
+                tuple(NotificationTargetRole.TARGET, NotificationTargetType.USER, actorUser.id),
+            )
+        assertThat(savedRecipients).singleElement().extracting("user.id").isEqualTo(recipientUser.id)
+    }
+
+    private fun createUser(prefix: String): User {
+        val uniqueSuffix = UUID.randomUUID().toString().take(8)
+        return userRepository.save(
+            User(
+                name = "$prefix-$uniqueSuffix",
+                email = "$prefix-$uniqueSuffix@example.com",
+                provider = OAuthProvider.GOOGLE,
+                identifier = "$prefix-id-$uniqueSuffix",
+                role = UserRole.USER,
+                profileImageUrl = "https://example.com/$prefix-$uniqueSuffix.jpg",
+            ),
+        )
+    }
+
+    private fun createPost(author: User): Post {
+        return postRepository.save(
+            Post(
+                title = "알림 테스트 게시물",
+                content = "<p>본문</p>",
+                author = author,
+            ),
+        )
+    }
+
+    private fun createComment(
+        post: Post,
+        author: User,
+        parent: Comment? = null,
+    ): Comment {
+        return commentRepository.save(
+            Comment(
+                content = "<p>댓글</p>",
+                post = post,
+                author = author,
+                parent = parent,
+                depth = if (parent == null) 0 else 1,
+            ),
+        )
+    }
+
+    private fun tuple(
+        role: NotificationTargetRole,
+        targetType: NotificationTargetType,
+        targetId: UUID?,
+    ): org.assertj.core.groups.Tuple =
+        org.assertj.core.groups.Tuple.tuple(role, targetType, targetId)
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteServiceTest.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.util.Locale
 import java.util.UUID
 
 @Transactional
@@ -72,7 +73,7 @@ class NotificationWriteServiceTest : IntegrationTest() {
                 recipientUserId = recipientUser.id!!,
                 postId = post.id!!,
                 commentId = comment.id!!,
-                payloadHtml = "<strong>${actorUser.name}</strong><script>alert('xss')</script>님이 댓글을 남겼습니다",
+                locale = Locale.KOREAN,
             )
 
         val savedNotification = notificationRepository.findById(notificationId).orElseThrow()
@@ -81,7 +82,8 @@ class NotificationWriteServiceTest : IntegrationTest() {
 
         assertThat(savedNotification.type).isEqualTo(NotificationType.POST_COMMENT)
         assertThat(savedNotification.payloadHtml).contains("<strong>${actorUser.name}</strong>")
-        assertThat(savedNotification.payloadHtml).doesNotContain("<script>", "alert")
+        assertThat(savedNotification.payloadHtml).contains("<strong>${post.title}</strong>")
+        assertThat(savedNotification.payloadHtml).contains("댓글을 남겼습니다")
         assertThat(savedTargets)
             .extracting("role", "targetType", "targetId")
             .containsExactlyInAnyOrder(
@@ -103,14 +105,15 @@ class NotificationWriteServiceTest : IntegrationTest() {
                 recipientUserId = recipientUser.id!!,
                 postId = post.id!!,
                 commentId = replyComment.id!!,
-                payloadHtml = "<em>${actorUser.name}</em>님이 답글을 남겼습니다",
+                locale = Locale.ENGLISH,
             )
 
         val savedNotification = notificationRepository.findById(notificationId).orElseThrow()
         val savedTargets = notificationTargetRepository.findAllByNotificationIdOrderByCreatedAtAsc(notificationId)
 
         assertThat(savedNotification.type).isEqualTo(NotificationType.COMMENT_REPLY)
-        assertThat(savedNotification.payloadHtml).contains("<em>${actorUser.name}</em>")
+        assertThat(savedNotification.payloadHtml).contains("<strong>${actorUser.name}</strong>")
+        assertThat(savedNotification.payloadHtml).contains("replied to your comment")
         assertThat(savedTargets)
             .extracting("role", "targetType", "targetId")
             .containsExactlyInAnyOrder(
@@ -128,7 +131,7 @@ class NotificationWriteServiceTest : IntegrationTest() {
                 actorUserId = actorUser.id!!,
                 recipientUserIds = listOf(recipientUser.id!!, secondRecipientUser.id!!, recipientUser.id!!),
                 postId = post.id!!,
-                payloadHtml = "<p>${actorUser.name}님의 새 글</p>",
+                locale = Locale.ENGLISH,
             )
 
         val savedNotification = notificationRepository.findById(notificationId).orElseThrow()
@@ -136,6 +139,8 @@ class NotificationWriteServiceTest : IntegrationTest() {
         val savedRecipients = notificationRecipientRepository.findAllByNotificationIdOrderByCreatedAtAsc(notificationId)
 
         assertThat(savedNotification.type).isEqualTo(NotificationType.FOLLOWER_POST)
+        assertThat(savedNotification.payloadHtml).contains("published a new post")
+        assertThat(savedNotification.payloadHtml).contains("<strong>${post.title}</strong>")
         assertThat(savedTargets)
             .extracting("role", "targetType", "targetId")
             .containsExactlyInAnyOrder(
@@ -153,7 +158,7 @@ class NotificationWriteServiceTest : IntegrationTest() {
             notificationWriteService.createFollowNotification(
                 actorUserId = actorUser.id!!,
                 recipientUserId = recipientUser.id!!,
-                payloadHtml = "<span>${actorUser.name}</span>님이 팔로우했습니다",
+                locale = Locale.KOREAN,
             )
 
         val savedNotification = notificationRepository.findById(notificationId).orElseThrow()
@@ -161,6 +166,8 @@ class NotificationWriteServiceTest : IntegrationTest() {
         val savedRecipients = notificationRecipientRepository.findAllByNotificationIdOrderByCreatedAtAsc(notificationId)
 
         assertThat(savedNotification.type).isEqualTo(NotificationType.FOLLOW)
+        assertThat(savedNotification.payloadHtml).contains("<strong>${actorUser.name}</strong>")
+        assertThat(savedNotification.payloadHtml).contains("팔로우했습니다")
         assertThat(savedTargets)
             .extracting("role", "targetType", "targetId")
             .containsExactlyInAnyOrder(


### PR DESCRIPTION
## 관련 자료
- 없음

## 어떤 작업인가요?
- 이후 게시물 작성, 댓글 작성, 팔로우 이벤트에서 공통으로 사용할 알림 저장 구조와 생성 서비스를 먼저 도입합니다.

## 어떻게 해결했나요?
**알림 저장 모델 추가**
- `notifications`, `notification_targets`, `notification_recipients` 스키마와 JPA 엔티티를 추가했습니다.
- 알림 타입, target role/type, 수신자 읽음 상태를 분리해 fan-out 저장을 지원합니다.

**알림 생성 서비스 추가**
- 댓글, 대댓글, 팔로워 게시물, 팔로우 알림 생성 메서드를 `NotificationWriteService`에 구현했습니다.
- payload HTML sanitize와 사용자, 게시물, 댓글 존재 검증을 서비스 내부에서 처리합니다.

**기본 검증 테스트 추가**
- `NotificationWriteService` 통합 테스트를 추가해 sanitize, target 저장, recipient 중복 제거를 검증했습니다.

## 중요한 변경 사항은 무엇인가요?
### 알림 저장 모델 도입

**알림 본체와 연결 대상을 분리**
- **변경 이유**: 댓글 알림과 팔로잉 게시물 알림을 같은 구조로 저장하기 위해
- **수정 파일**: `src/main/resources/db/migration/V23__create_notifications.sql`, `src/main/kotlin/com/techtaurant/mainserver/notification/entity/*`, `src/main/kotlin/com/techtaurant/mainserver/notification/enums/*`

**수신자별 읽음 상태 테이블 추가**
- **변경 이유**: 하나의 알림을 여러 사용자에게 fan-out하고 읽음 상태를 개별 관리하기 위해
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/notification/entity/NotificationRecipient.kt`, `src/main/kotlin/com/techtaurant/mainserver/notification/infrastructure/out/NotificationRecipientRepository.kt`

### 알림 생성 서비스 추가

**타입별 알림 생성 메서드 구현**
- **변경 이유**: 이후 post/comment/follow 서비스에서 공통 진입점으로 재사용하기 위해
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteService.kt`

**sanitize와 저장 흐름 검증 테스트 추가**
- **변경 이유**: HTML payload 정제와 target/recipient 구성 로직을 회귀 없이 유지하기 위해
- **수정 파일**: `src/test/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteServiceTest.kt`

Generated-By: OpenCode (openai/gpt-5.4)