### PR TITLE
feat: 댓글·팔로우·게시물 알림 트리거 연결

### DIFF
--- a/.claude/plan/notification/2604/24-create-alert-triggers.plan.md
+++ b/.claude/plan/notification/2604/24-create-alert-triggers.plan.md
@@ -1,0 +1,115 @@
+# Notification Alert Trigger Integration
+
+## Business Goal
+댓글 작성, 팔로우, 글 작성 시점에 사용자에게 필요한 알림을 누락 없이 생성해 참여 흐름을 강화하고, 기존 알림 도메인을 실제 비즈니스 쓰기 흐름에 연결한다.
+
+## Scope
+- **In Scope**: 댓글 작성 시 게시물 작성자 및 부모 체인 댓글 작성자 알림 생성, 팔로우 시 피팔로우 사용자 알림 생성, `PUBLISHED` 글 작성 시 팔로워 알림 생성, 중복 수신자 제거, 자기 자신 알림 제외, 관련 테스트 보강
+- **Out of Scope**: 알림 조회/읽음 API, 비동기 큐/이벤트 도입, 푸시 전송, 기존 데이터 백필
+
+## Codebase Analysis Summary
+알림 저장 로직은 이미 `NotificationWriteService`에 존재하지만 댓글/팔로우/게시물 생성 서비스와 연결되어 있지 않다. 댓글 생성은 `CommentWriteService`, 팔로우는 `UserFollowService`, 게시물 생성은 `PostWriteService`가 각각 트랜잭션 안에서 핵심 도메인 저장을 담당하고 있어 해당 지점에 알림 생성을 연결하는 것이 현재 구조와 가장 잘 맞는다. 테스트는 서비스/통합 테스트 중심으로 작성되어 있고, 알림 저장 구조는 `Notification`, `NotificationTarget`, `NotificationRecipient` 그래프를 저장하는 방식이다.
+
+### Relevant Files
+| File | Role | Action |
+|------|------|--------|
+| `src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteService.kt` | 댓글 생성 유스케이스 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt` | 게시물 생성 유스케이스 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/user/application/UserFollowService.kt` | 팔로우 생성 유스케이스 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteService.kt` | 알림 저장 로직 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/out/CommentRepository.kt` | 댓글 조회/업데이트 저장소 | Modify |
+| `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserFollowRepository.kt` | 팔로우 조회 저장소 | Modify |
+| `src/test/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteServiceTest.kt` | 댓글 생성 검증 | Modify |
+| `src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceTest.kt` | 게시물 생성 검증 | Modify |
+| `src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerFollowIntegrationTest.kt` | 팔로우 통합 검증 | Modify |
+| `src/test/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteServiceTest.kt` | 알림 저장 구조 검증 | Modify |
+
+### Conventions to Follow
+| Convention | Source | Rule |
+|-----------|--------|------|
+| 서비스 중심 트랜잭션 | `CommentWriteService`, `PostWriteService`, `UserFollowService` | 알림 생성은 기존 쓰기 서비스 트랜잭션 안에서 직접 호출한다 |
+| 최소 범위 저장소 추가 | `CommentRepository`, `UserFollowRepository` | 수신자 계산에 필요한 메서드만 추가하고 조합은 서비스에서 수행한다 |
+| 통합 테스트 우선 검증 | 기존 `*ServiceTest`, `*IntegrationTest` | 사용자 시나리오 기준으로 알림 엔티티 저장 결과를 검증한다 |
+| HTML payload 재사용 | `NotificationPayloadService` | payload 포맷팅은 기존 알림 서비스만 사용하고 호출 서비스에서 문자열을 직접 만들지 않는다 |
+
+## Architecture Decisions
+| Decision | Choice | Rationale | Alternatives |
+|----------|--------|-----------|--------------|
+| 알림 연결 방식 | 쓰기 서비스에서 `NotificationWriteService` 직접 호출 | 현재 코드베이스에 이벤트 버스 패턴이 없고 변경 범위가 작다 | Spring event/listener 도입 |
+| 댓글 수신자 계산 | 게시물 작성자 + 부모 체인 작성자 dedupe | 요구사항을 충족하면서 중복 알림을 막는다 | 게시물 작성자만 알림, 부모 작성자만 알림 |
+| 자기 자신 처리 | 수신자 목록에서 제외 | 불필요한 self notification을 막는다 | 자기 자신도 수신 |
+| 글 작성 발송 조건 | `PostStatusEnum.PUBLISHED`만 알림 발송 | 사용자와 합의된 정책이다 | `PRIVATE` 포함 |
+| 팔로우 알림 target | 실제 팔로우 당한 사용자로 저장 | 기존 구현의 의미 오류를 바로잡아 이후 조회 기준을 맞춘다 | actor를 target으로 유지 |
+
+## Data Models
+
+### Notification
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `type` | `NotificationType` | 알림 종류 |
+| `payloadHtml` | `String` | 비어 있을 수 없음 |
+| `targets` | `List<NotificationTarget>` | actor/target 정보 중복 없이 저장 |
+| `recipients` | `List<NotificationRecipient>` | 사용자별 1회 저장 |
+
+## Implementation Todos
+
+### Todo 1: 알림 트리거 회귀 테스트 추가
+- **Priority**: 1
+- **Dependencies**: none
+- **Goal**: 댓글/팔로우/게시물 생성 시 알림이 기대한 수신자와 target으로 저장되는지를 실패 테스트로 고정한다
+- **Work**:
+  - `CommentWriteServiceTest`에 일반 댓글/대댓글 작성 시 알림 생성 검증 추가
+  - `PostWriteServiceTest`에 `PUBLISHED` 글 작성 시 팔로워 알림 생성과 `DRAFT` 미발송 검증 추가
+  - `UserControllerFollowIntegrationTest` 또는 `UserFollowService` 관련 테스트에 팔로우 알림 생성 검증 추가
+  - `NotificationWriteServiceTest`에 follow target user 저장값 검증을 실제 target 기준으로 수정
+- **Convention Notes**: 기존 통합 테스트 스타일을 유지하고 DB에 저장된 `NotificationRecipient`, `NotificationTarget`를 직접 검증한다
+- **Verification**: 관련 테스트만 먼저 실행해 실패를 확인한다
+- **Exit Criteria**: 알림 미연결/오저장으로 인해 테스트가 명확히 실패한다
+- **Status**: completed
+
+### Todo 2: 쓰기 서비스와 알림 서비스 연결
+- **Priority**: 2
+- **Dependencies**: Todo 1
+- **Goal**: 각 쓰기 흐름에서 요구된 수신자에게 알림을 생성하도록 구현한다
+- **Work**:
+  - `CommentWriteService`에 `NotificationWriteService` 주입 및 댓글 수신자 계산 로직 추가
+  - `CommentRepository`에 부모 체인 수집에 필요한 조회 메서드 추가
+  - `UserFollowService`에 follow 성공 시 알림 생성 연결
+  - `UserFollowRepository`에 팔로워 ID 조회 메서드 추가
+  - `PostWriteService`에 `PUBLISHED` 게시물 생성 후 팔로워 알림 연결
+  - `NotificationWriteService`의 follow target 저장값 수정 및 빈 recipient 처리 정리
+- **Convention Notes**: 저장소는 조회만 담당하고 dedupe/self-filter/policy는 서비스에서 처리한다
+- **Verification**: Todo 1에서 추가한 테스트 재실행, 필요 시 기존 notification 테스트도 실행한다
+- **Exit Criteria**: 모든 신규 테스트가 통과하고 자기 자신/중복 수신자가 저장되지 않는다
+- **Status**: completed
+
+### Todo 3: 회귀 검증 및 마무리
+- **Priority**: 3
+- **Dependencies**: Todo 2
+- **Goal**: 변경 범위의 회귀를 확인하고 plan 상태를 완료로 정리한다
+- **Work**:
+  - 변경된 도메인의 서비스/통합 테스트 묶음 실행
+  - 실패/불안정 케이스가 있으면 최소 수정으로 정리
+  - plan 파일의 진행 상태와 change log 갱신
+- **Convention Notes**: 완료 주장은 실제 실행 결과로만 한다
+- **Verification**: 지정 테스트 스위트 실행
+- **Exit Criteria**: 관련 테스트가 통과하고 plan 진행 상태가 최신 상태로 반영된다
+- **Status**: completed
+
+## Verification Strategy
+관련 서비스/통합 테스트를 단계적으로 실행해 red-green을 확인하고, 마지막에 변경 범위를 다시 한 번 묶어서 검증한다.
+- `./gradlew test --tests 'com.techtaurant.mainserver.notification.application.NotificationWriteServiceTest'`
+- `./gradlew test --tests 'com.techtaurant.mainserver.comment.application.CommentWriteServiceTest'`
+- `./gradlew test --tests 'com.techtaurant.mainserver.post.application.PostWriteServiceTest'`
+- `./gradlew test --tests 'com.techtaurant.mainserver.user.infrastructure.in.UserControllerFollowIntegrationTest'`
+
+## Progress Tracking
+- Total Todos: 3
+- Completed: 3
+- Status: Execution complete
+
+## Change Log
+- 2026-04-24: Plan created
+- 2026-04-24: Todo 1 completed — 댓글/팔로우/게시물 알림 트리거 회귀 테스트 추가 및 실패 확인
+- 2026-04-24: Todo 2 completed — 댓글/팔로우/게시물 쓰기 서비스에 알림 생성 연결 및 FOLLOW target 저장 수정
+- 2026-04-24: Todo 3 completed — 관련 서비스/통합 테스트 재실행 및 기존 첨부파일 테스트 회귀 확인

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteService.kt
@@ -9,6 +9,7 @@ import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepository
 import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.common.util.DateUtils
 import com.techtaurant.mainserver.common.util.HtmlSanitizer
+import com.techtaurant.mainserver.notification.application.NotificationWriteService
 import com.techtaurant.mainserver.post.application.PostDailyStatsService
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.enums.PostStatus
@@ -30,6 +31,7 @@ class CommentWriteService(
     private val postRepository: PostRepository,
     private val userRepository: UserRepository,
     private val postDailyStatsService: PostDailyStatsService,
+    private val notificationWriteService: NotificationWriteService,
 ) {
     /**
      * 댓글을 생성합니다.
@@ -66,8 +68,42 @@ class CommentWriteService(
         parent?.id?.let(commentRepository::incrementReplyCount)
         postRepository.incrementCommentCount(request.postId)
         postDailyStatsService.incrementCommentCount(request.postId, statDate)
+        createCommentNotifications(
+            actorUserId = userId,
+            post = post,
+            parent = parent,
+            savedComment = savedComment,
+        )
 
         return CommentResponse.from(savedComment)
+    }
+
+    private fun createCommentNotifications(
+        actorUserId: UUID,
+        post: Post,
+        parent: Comment?,
+        savedComment: Comment,
+    ) {
+        val replyRecipientIds = collectParentAuthorIds(parent, actorUserId)
+        val postAuthorId = post.author.id
+
+        if (postAuthorId != null && postAuthorId != actorUserId && postAuthorId !in replyRecipientIds) {
+            notificationWriteService.createPostCommentNotification(
+                actorUserId = actorUserId,
+                recipientUserId = postAuthorId,
+                postId = post.id!!,
+                commentId = savedComment.id!!,
+            )
+        }
+
+        replyRecipientIds.forEach { recipientUserId ->
+            notificationWriteService.createCommentReplyNotification(
+                actorUserId = actorUserId,
+                recipientUserId = recipientUserId,
+                postId = post.id!!,
+                commentId = savedComment.id!!,
+            )
+        }
     }
 
     /**
@@ -161,5 +197,24 @@ class CommentWriteService(
         }
 
         return parent
+    }
+
+    private fun collectParentAuthorIds(
+        parent: Comment?,
+        actorUserId: UUID,
+    ): List<UUID> {
+        val authorIds = mutableListOf<UUID>()
+        val visitedAuthorIds = mutableSetOf<UUID>()
+        var current = parent
+
+        while (current != null) {
+            val authorId = current.author.id
+            if (authorId != null && authorId != actorUserId && visitedAuthorIds.add(authorId)) {
+                authorIds.add(authorId)
+            }
+            current = current.parent
+        }
+
+        return authorIds
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteService.kt
@@ -124,7 +124,7 @@ class NotificationWriteService(
             targetSpecs =
                 listOf(
                     NotificationTargetSpec(NotificationTargetRole.ACTOR, NotificationTargetType.USER, actor.id!!),
-                    NotificationTargetSpec(NotificationTargetRole.TARGET, NotificationTargetType.USER, actor.id!!),
+                    NotificationTargetSpec(NotificationTargetRole.TARGET, NotificationTargetType.USER, recipientUserId),
                 ),
         )
     }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -5,6 +5,7 @@ import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
 import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.common.lock.DistributedLock
 import com.techtaurant.mainserver.common.util.HtmlSanitizer
+import com.techtaurant.mainserver.notification.application.NotificationWriteService
 import com.techtaurant.mainserver.post.dto.CreatePostRequest
 import com.techtaurant.mainserver.post.dto.PostResponse
 import com.techtaurant.mainserver.post.dto.UpdatePostRequest
@@ -18,6 +19,7 @@ import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.post.infrastructure.out.TagRepository
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.enums.UserStatus
+import com.techtaurant.mainserver.user.infrastructure.out.UserFollowRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -29,8 +31,10 @@ class PostWriteService(
     private val categoryRepository: CategoryRepository,
     private val tagRepository: TagRepository,
     private val userRepository: UserRepository,
+    private val userFollowRepository: UserFollowRepository,
     private val distributedLock: DistributedLock,
     private val attachmentService: AttachmentService,
+    private val notificationWriteService: NotificationWriteService,
 ) {
     companion object {
         private const val MAX_CATEGORY_DEPTH = 5
@@ -103,6 +107,10 @@ class PostWriteService(
                 attachmentIds = attachmentIds,
             )
             savedPost.thumbnailImage = request.thumbnailAttachmentId ?: attachmentIds.firstOrNull()
+        }
+
+        if (status == PostStatusEnum.PUBLISHED) {
+            createFollowerPostNotification(savedPost)
         }
 
         return PostResponse.from(savedPost)
@@ -213,6 +221,20 @@ class PostWriteService(
         return userRepository.findById(userId).orElseThrow {
             ApiException(UserStatus.ID_NOT_FOUND)
         }
+    }
+
+    private fun createFollowerPostNotification(post: Post) {
+        val authorId = post.author.id ?: return
+        val followerIds = userFollowRepository.findFollowerIdsByFollowingId(authorId)
+        if (followerIds.isEmpty()) {
+            return
+        }
+
+        notificationWriteService.createFollowerPostNotification(
+            actorUserId = authorId,
+            recipientUserIds = followerIds,
+            postId = post.id!!,
+        )
     }
 
     private fun filterAttachmentIdsIncludedInContent(

--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserFollowService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserFollowService.kt
@@ -1,6 +1,7 @@
 package com.techtaurant.mainserver.user.application
 
 import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.notification.application.NotificationWriteService
 import com.techtaurant.mainserver.user.dto.UserFollowCountResponse
 import com.techtaurant.mainserver.user.dto.UserFollowListItemResponse
 import com.techtaurant.mainserver.user.dto.UserFollowResponse
@@ -19,6 +20,7 @@ class UserFollowService(
     private val userRepository: UserRepository,
     private val userFollowRepository: UserFollowRepository,
     private val userProfileImageResolver: UserProfileImageResolver,
+    private val notificationWriteService: NotificationWriteService,
 ) {
     @Transactional
     fun follow(
@@ -34,8 +36,10 @@ class UserFollowService(
             return UserFollowResponse.from(it)
         }
 
+        var shouldNotify = false
         val userFollow =
             try {
+                shouldNotify = true
                 userFollowRepository.save(
                     UserFollow(
                         follower = follower,
@@ -45,6 +49,13 @@ class UserFollowService(
             } catch (e: DataIntegrityViolationException) {
                 userFollowRepository.findByFollowerIdAndFollowingId(followerId, targetUserId)!!
             }
+
+        if (shouldNotify) {
+            notificationWriteService.createFollowNotification(
+                actorUserId = followerId,
+                recipientUserId = targetUserId,
+            )
+        }
 
         return UserFollowResponse.from(userFollow)
     }

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserFollowRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserFollowRepository.kt
@@ -22,6 +22,18 @@ interface UserFollowRepository : JpaRepository<UserFollow, UUID> {
 
     fun findAllByFollowingIdOrderByCreatedAtDesc(followingId: UUID): List<UserFollow>
 
+    @Query(
+        """
+        SELECT uf.follower.id
+        FROM UserFollow uf
+        WHERE uf.following.id = :followingId
+        ORDER BY uf.createdAt DESC
+        """,
+    )
+    fun findFollowerIdsByFollowingId(
+        @Param("followingId") followingId: UUID,
+    ): List<UUID>
+
     @Modifying
     @Transactional
     @Query(

--- a/src/test/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteServiceTest.kt
@@ -6,6 +6,9 @@ import com.techtaurant.mainserver.comment.entity.Comment
 import com.techtaurant.mainserver.comment.enums.CommentStatus
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepository
 import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.notification.enums.NotificationType
+import com.techtaurant.mainserver.notification.infrastructure.out.NotificationRecipientRepository
+import com.techtaurant.mainserver.notification.infrastructure.out.NotificationRepository
 import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.enums.PostStatus
@@ -43,6 +46,12 @@ class CommentWriteServiceTest : IntegrationTest() {
 
     @Autowired
     private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var notificationRepository: NotificationRepository
+
+    @Autowired
+    private lateinit var notificationRecipientRepository: NotificationRecipientRepository
 
     @Autowired
     private lateinit var categoryRepository: CategoryRepository
@@ -238,6 +247,63 @@ class CommentWriteServiceTest : IntegrationTest() {
         val dailyStats = postDailyStatsRepository.findAll().single()
         assertThat(dailyStats.post.id).isEqualTo(testPost.id)
         assertThat(dailyStats.commentCount).isEqualTo(1)
+    }
+
+    @Test
+    @DisplayName("일반 댓글 작성 시 게시물 작성자에게 POST_COMMENT 알림이 생성된다")
+    fun createComment_createsPostCommentNotificationForPostAuthor() {
+        val commenter = createUser("댓글 작성자")
+        val request =
+            CreateCommentRequest(
+                postId = testPost.id!!,
+                content = "좋은 글이네요",
+                parentId = null,
+            )
+
+        commentWriteService.createComment(commenter.id!!, request)
+        entityManager.flush()
+        entityManager.clear()
+
+        val savedNotification = notificationRepository.findAll().single()
+
+        assertThat(savedNotification.type).isEqualTo(NotificationType.POST_COMMENT)
+        assertThat(recipientIdsOf(savedNotification.id!!)).containsExactly(testUser.id)
+    }
+
+    @Test
+    @DisplayName("대댓글 작성 시 게시물 작성자와 부모 댓글 작성자에게 각각 알림이 생성된다")
+    fun createReply_createsNotificationsForPostAuthorAndParentAuthor() {
+        val parentAuthor = createUser("부모 작성자")
+        val replyAuthor = createUser("답글 작성자")
+        val parentComment =
+            commentRepository.save(
+                Comment(
+                    content = "부모 댓글",
+                    post = testPost,
+                    author = parentAuthor,
+                    parent = null,
+                    depth = 0,
+                ),
+            )
+        val request =
+            CreateCommentRequest(
+                postId = testPost.id!!,
+                content = "대댓글입니다",
+                parentId = parentComment.id,
+            )
+
+        commentWriteService.createComment(replyAuthor.id!!, request)
+        entityManager.flush()
+        entityManager.clear()
+
+        val notificationsByType = notificationRepository.findAll().associateBy { it.type }
+
+        assertThat(notificationsByType.keys)
+            .containsExactlyInAnyOrder(NotificationType.POST_COMMENT, NotificationType.COMMENT_REPLY)
+        assertThat(recipientIdsOf(notificationsByType.getValue(NotificationType.POST_COMMENT).id!!))
+            .containsExactly(testUser.id)
+        assertThat(recipientIdsOf(notificationsByType.getValue(NotificationType.COMMENT_REPLY).id!!))
+            .containsExactly(parentAuthor.id)
     }
 
     @Test
@@ -450,5 +516,22 @@ class CommentWriteServiceTest : IntegrationTest() {
         // Then
         val updatedPost = postRepository.findById(testPost.id!!).orElseThrow()
         assertThat(updatedPost.commentCount).isEqualTo(initialCount + numberOfComments)
+    }
+
+    private fun recipientIdsOf(notificationId: UUID): List<UUID?> =
+        notificationRecipientRepository.findAllByNotificationIdOrderByCreatedAtAsc(notificationId).map { it.user.id }
+
+    private fun createUser(name: String): User {
+        val uniqueSuffix = UUID.randomUUID().toString().take(8)
+        return userRepository.save(
+            User(
+                name = "$name-$uniqueSuffix",
+                email = "user-$uniqueSuffix@example.com",
+                provider = OAuthProvider.GOOGLE,
+                identifier = "identifier-$uniqueSuffix",
+                role = UserRole.USER,
+                profileImageUrl = "https://example.com/$uniqueSuffix.jpg",
+            ),
+        )
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteServiceTest.kt
@@ -152,7 +152,7 @@ class NotificationWriteServiceTest : IntegrationTest() {
     }
 
     @Test
-    @DisplayName("팔로우 알림 생성 시 actor와 profile target user가 함께 저장된다")
+    @DisplayName("팔로우 알림 생성 시 actor와 팔로우 당한 target user가 함께 저장된다")
     fun createFollowNotification_savesUserTargets() {
         val notificationId =
             notificationWriteService.createFollowNotification(
@@ -172,7 +172,7 @@ class NotificationWriteServiceTest : IntegrationTest() {
             .extracting("role", "targetType", "targetId")
             .containsExactlyInAnyOrder(
                 tuple(NotificationTargetRole.ACTOR, NotificationTargetType.USER, actorUser.id),
-                tuple(NotificationTargetRole.TARGET, NotificationTargetType.USER, actorUser.id),
+                tuple(NotificationTargetRole.TARGET, NotificationTargetType.USER, recipientUser.id),
             )
         assertThat(savedRecipients).singleElement().extracting("user.id").isEqualTo(recipientUser.id)
     }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -3,6 +3,7 @@ package com.techtaurant.mainserver.post.application
 import com.techtaurant.mainserver.attachment.application.AttachmentService
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
 import com.techtaurant.mainserver.common.lock.DistributedLock
+import com.techtaurant.mainserver.notification.application.NotificationWriteService
 import com.techtaurant.mainserver.post.dto.CreatePostRequest
 import com.techtaurant.mainserver.post.dto.UpdatePostRequest
 import com.techtaurant.mainserver.post.entity.Post
@@ -13,6 +14,7 @@ import com.techtaurant.mainserver.post.infrastructure.out.TagRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserFollowRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import io.mockk.every
 import io.mockk.just
@@ -33,8 +35,10 @@ class PostWriteServiceAttachmentTest {
     private val categoryRepository: CategoryRepository = mockk()
     private val tagRepository: TagRepository = mockk()
     private val userRepository: UserRepository = mockk()
+    private val userFollowRepository: UserFollowRepository = mockk()
     private val distributedLock: DistributedLock = mockk()
     private val attachmentService: AttachmentService = mockk()
+    private val notificationWriteService: NotificationWriteService = mockk()
 
     private val postWriteService =
         PostWriteService(
@@ -42,8 +46,10 @@ class PostWriteServiceAttachmentTest {
             categoryRepository = categoryRepository,
             tagRepository = tagRepository,
             userRepository = userRepository,
+            userFollowRepository = userFollowRepository,
             distributedLock = distributedLock,
             attachmentService = attachmentService,
+            notificationWriteService = notificationWriteService,
         )
 
     private lateinit var author: User
@@ -61,6 +67,7 @@ class PostWriteServiceAttachmentTest {
             ).apply { id = UUID.randomUUID() }
 
         every { userRepository.findById(author.id!!) } returns Optional.of(author)
+        every { userFollowRepository.findFollowerIdsByFollowingId(author.id!!) } returns emptyList()
         every { attachmentService.confirmAttachmentsByIds(any(), any(), any()) } just runs
         every { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) } just runs
         every { attachmentService.deleteAttachmentsByReference(any(), any()) } just runs

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceTest.kt
@@ -1,13 +1,18 @@
 package com.techtaurant.mainserver.post.application
 
 import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.notification.enums.NotificationType
+import com.techtaurant.mainserver.notification.infrastructure.out.NotificationRecipientRepository
+import com.techtaurant.mainserver.notification.infrastructure.out.NotificationRepository
 import com.techtaurant.mainserver.post.dto.CreatePostRequest
 import com.techtaurant.mainserver.post.dto.UpdatePostRequest
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.entity.UserFollow
 import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserFollowRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -31,6 +36,15 @@ class PostWriteServiceTest : IntegrationTest() {
     @Autowired
     private lateinit var userRepository: UserRepository
 
+    @Autowired
+    private lateinit var userFollowRepository: UserFollowRepository
+
+    @Autowired
+    private lateinit var notificationRepository: NotificationRepository
+
+    @Autowired
+    private lateinit var notificationRecipientRepository: NotificationRecipientRepository
+
     private lateinit var testUser: User
 
     @BeforeEach
@@ -46,6 +60,45 @@ class PostWriteServiceTest : IntegrationTest() {
                     profileImageUrl = "https://example.com/profile.jpg",
                 ),
             )
+    }
+
+    @Test
+    @DisplayName("PUBLISHED 게시물 작성 시 모든 팔로워에게 FOLLOWER_POST 알림이 생성된다")
+    fun createPost_published_createsFollowerNotifications() {
+        val firstFollower = createUser("팔로워A")
+        val secondFollower = createUser("팔로워B")
+        userFollowRepository.save(UserFollow(follower = firstFollower, following = testUser))
+        userFollowRepository.save(UserFollow(follower = secondFollower, following = testUser))
+
+        postWriteService.createPost(
+            testUser.id!!,
+            CreatePostRequest(
+                title = "새 글",
+                content = "새 글 본문",
+                status = PostStatusEnum.PUBLISHED,
+            ),
+        )
+
+        val savedNotification = notificationRepository.findAll().single()
+
+        assertThat(savedNotification.type).isEqualTo(NotificationType.FOLLOWER_POST)
+        assertThat(recipientIdsOf(savedNotification.id!!)).containsExactlyInAnyOrder(firstFollower.id, secondFollower.id)
+    }
+
+    @Test
+    @DisplayName("DRAFT 게시물 작성 시 팔로워 알림은 생성되지 않는다")
+    fun createPost_draft_doesNotCreateFollowerNotifications() {
+        val follower = createUser("초안팔로워")
+        userFollowRepository.save(UserFollow(follower = follower, following = testUser))
+
+        postWriteService.createPost(
+            testUser.id!!,
+            CreatePostRequest(
+                status = PostStatusEnum.DRAFT,
+            ),
+        )
+
+        assertThat(notificationRepository.findAll()).isEmpty()
     }
 
     @Nested
@@ -240,5 +293,22 @@ class PostWriteServiceTest : IntegrationTest() {
             assertThat(response.content).doesNotContain("<script>")
             assertThat(response.content).doesNotContain("<style>")
         }
+    }
+
+    private fun recipientIdsOf(notificationId: UUID): List<UUID?> =
+        notificationRecipientRepository.findAllByNotificationIdOrderByCreatedAtAsc(notificationId).map { it.user.id }
+
+    private fun createUser(name: String): User {
+        val uniqueSuffix = UUID.randomUUID().toString().take(8)
+        return userRepository.save(
+            User(
+                name = "$name-$uniqueSuffix",
+                email = "$uniqueSuffix@example.com",
+                provider = OAuthProvider.GOOGLE,
+                identifier = "test-id-$uniqueSuffix",
+                role = UserRole.USER,
+                profileImageUrl = "https://example.com/$uniqueSuffix.jpg",
+            ),
+        )
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerFollowIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerFollowIntegrationTest.kt
@@ -1,6 +1,9 @@
 package com.techtaurant.mainserver.user.infrastructure.`in`
 
 import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.notification.enums.NotificationType
+import com.techtaurant.mainserver.notification.infrastructure.out.NotificationRecipientRepository
+import com.techtaurant.mainserver.notification.infrastructure.out.NotificationRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
 import com.techtaurant.mainserver.user.entity.User
@@ -9,6 +12,7 @@ import com.techtaurant.mainserver.user.enums.UserRole
 import com.techtaurant.mainserver.user.infrastructure.out.UserFollowRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import io.restassured.RestAssured.given
+import org.assertj.core.api.Assertions.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasItems
 import org.hamcrest.Matchers.hasSize
@@ -29,6 +33,12 @@ class UserControllerFollowIntegrationTest : IntegrationTest() {
 
     @Autowired
     private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    @Autowired
+    private lateinit var notificationRepository: NotificationRepository
+
+    @Autowired
+    private lateinit var notificationRecipientRepository: NotificationRecipientRepository
 
     private lateinit var testUser: User
     private lateinit var firstTargetUser: User
@@ -58,6 +68,26 @@ class UserControllerFollowIntegrationTest : IntegrationTest() {
             .statusCode(HttpStatus.CREATED.value())
             .body("data.userId", equalTo(firstTargetUser.id.toString()))
             .body("data.name", equalTo(firstTargetUser.name))
+    }
+
+    @Test
+    @DisplayName("사용자 팔로우 시 피팔로우 사용자에게 FOLLOW 알림이 생성된다")
+    fun follow_createsNotificationForTargetUser() {
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .post("/api/users/${firstTargetUser.id}/follow")
+            .then()
+            .statusCode(HttpStatus.CREATED.value())
+
+        val savedNotification = notificationRepository.findAll().single()
+        val recipientIds =
+            notificationRecipientRepository
+                .findAllByNotificationIdOrderByCreatedAtAsc(savedNotification.id!!)
+                .map { it.user.id }
+
+        assertThat(savedNotification.type).isEqualTo(NotificationType.FOLLOW)
+        assertThat(recipientIds).containsExactly(firstTargetUser.id)
     }
 
     @Test


### PR DESCRIPTION
## 관련 자료
- [작업 계획](.claude/plan/notification/2604/24-create-alert-triggers.plan.md)

## 어떤 작업인가요?
- 댓글, 팔로우, 게시물 작성 시 요구된 알림이 누락되지 않도록 notification 저장을 실제 쓰기 흐름에 연결합니다.

## 어떻게 해결했나요?
**알림 트리거 연결**
- 댓글 작성 시 게시물 작성자와 부모 댓글 작성자를 계산해 알림을 생성하도록 연결했습니다.
- 팔로우 생성과 `PUBLISHED` 게시물 작성 시 notification 서비스가 호출되도록 연결했습니다.

**저장 구조와 정책 보정**
- `FOLLOW` 알림의 target user 저장값을 실제 피팔로우 사용자로 수정했습니다.
- 자기 자신 알림과 중복 수신자를 방지하는 정책을 서비스 레벨에 반영했습니다.

**회귀 테스트 보강**
- 댓글, 팔로우, 게시물 작성 시 알림 생성 여부를 통합/서비스 테스트로 검증했습니다.
- `PostWriteService` 생성자 변경에 맞춰 첨부파일 관련 테스트도 함께 보정했습니다.

## 중요한 변경 사항은 무엇인가요?
### 댓글 알림 수신자 계산

**댓글 작성 시 게시물 작성자 알림 연결**
- **변경 이유**: 일반 댓글 작성 시 게시물 작성자에게 알림이 생성돼야 합니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteService.kt`, `src/test/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteServiceTest.kt`

**대댓글 작성 시 부모 체인 작성자 알림 연결**
- **변경 이유**: 부모 댓글 작성자에게 답글 알림이 생성돼야 하고 자기 자신 및 중복 수신자는 제외해야 합니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteService.kt`, `src/test/kotlin/com/techtaurant/mainserver/comment/application/CommentWriteServiceTest.kt`

### 팔로우/게시물 알림 연결

**팔로우 생성 시 피팔로우 사용자 알림 저장**
- **변경 이유**: 팔로우 관계가 실제로 생성된 경우에만 대상 사용자에게 알림이 가야 합니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/user/application/UserFollowService.kt`, `src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserControllerFollowIntegrationTest.kt`

**발행 게시물 작성 시 팔로워 알림 발송**
- **변경 이유**: `PUBLISHED` 게시물 작성 시에만 모든 팔로워에게 알림이 생성돼야 합니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/out/UserFollowRepository.kt`, `src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceTest.kt`

### 알림 저장 구조 보정

**FOLLOW target user 저장값 수정**
- **변경 이유**: 기존에는 actor가 target으로 저장돼 알림 대상 의미가 어긋나 있었습니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteService.kt`, `src/test/kotlin/com/techtaurant/mainserver/notification/application/NotificationWriteServiceTest.kt`

Co-authored-by: Codex <noreply@openai.com>
