### PR TITLE
feat: 관리자 전용 사용자 역할 변경 API 추가

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/user/application/UserWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/application/UserWriteService.kt
@@ -5,6 +5,8 @@ import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
 import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.common.status.DefaultStatus
 import com.techtaurant.mainserver.user.dto.UpdateUserRequest
+import com.techtaurant.mainserver.user.dto.UpdateUserRoleResponse
+import com.techtaurant.mainserver.user.enums.UserRole
 import com.techtaurant.mainserver.user.dto.UserResponse
 import com.techtaurant.mainserver.user.enums.UserStatus
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
@@ -70,6 +72,21 @@ class UserWriteService(
         }
 
         return userResponseAssembler.assemble(user)
+    }
+
+    @Transactional
+    fun updateUserRole(
+        targetUserId: UUID,
+        role: UserRole,
+    ): UpdateUserRoleResponse {
+        val user =
+            userRepository.findById(targetUserId).orElseThrow {
+                ApiException(UserStatus.USER_NOT_FOUND)
+            }
+
+        user.role = role
+
+        return UpdateUserRoleResponse.from(user)
     }
 
     private fun isUserNameUniqueConstraintViolation(exception: DataIntegrityViolationException): Boolean {

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UpdateUserRoleRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UpdateUserRoleRequest.kt
@@ -1,0 +1,10 @@
+package com.techtaurant.mainserver.user.dto
+
+import com.techtaurant.mainserver.user.enums.UserRole
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "사용자 역할 변경 요청")
+data class UpdateUserRoleRequest(
+    @field:Schema(description = "변경할 사용자 역할", example = "ADMIN", allowableValues = ["USER", "ADMIN"])
+    val role: UserRole,
+)

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UpdateUserRoleResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UpdateUserRoleResponse.kt
@@ -1,0 +1,24 @@
+package com.techtaurant.mainserver.user.dto
+
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.enums.UserStatus
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+@Schema(description = "사용자 역할 변경 응답")
+data class UpdateUserRoleResponse(
+    @field:Schema(description = "역할이 변경된 사용자 ID")
+    val userId: UUID,
+    @field:Schema(description = "변경된 사용자 역할", example = "ADMIN", allowableValues = ["USER", "ADMIN"])
+    val role: UserRole,
+) {
+    companion object {
+        fun from(user: User): UpdateUserRoleResponse =
+            UpdateUserRoleResponse(
+                userId = user.id ?: throw ApiException(UserStatus.ID_NOT_FOUND),
+                role = user.role,
+            )
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/AdminUserRoleController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/AdminUserRoleController.kt
@@ -1,0 +1,30 @@
+package com.techtaurant.mainserver.user.infrastructure.`in`
+
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.swagger.ApiErrorResponses
+import com.techtaurant.mainserver.security.SecurityConstants
+import com.techtaurant.mainserver.user.application.UserWriteService
+import com.techtaurant.mainserver.user.dto.UpdateUserRoleRequest
+import com.techtaurant.mainserver.user.dto.UpdateUserRoleResponse
+import jakarta.validation.Valid
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("${SecurityConstants.ADMIN_API_PREFIX}/users")
+class AdminUserRoleController(
+    private val userWriteService: UserWriteService,
+) : AdminUserRoleControllerDocs {
+    @ApiErrorResponses(includeAuthenticationErrors = true, includeValidationError = true)
+    @PatchMapping("/{targetUserId}/role")
+    override fun updateUserRole(
+        @PathVariable targetUserId: UUID,
+        @Valid @RequestBody request: UpdateUserRoleRequest,
+    ): ApiResponse<UpdateUserRoleResponse> {
+        return ApiResponse.ok(userWriteService.updateUserRole(targetUserId, request.role))
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/AdminUserRoleControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/AdminUserRoleControllerDocs.kt
@@ -1,0 +1,36 @@
+package com.techtaurant.mainserver.user.infrastructure.`in`
+
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.status.DefaultStatus
+import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponse
+import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponses
+import com.techtaurant.mainserver.security.jwt.JwtStatus
+import com.techtaurant.mainserver.user.dto.UpdateUserRoleRequest
+import com.techtaurant.mainserver.user.dto.UpdateUserRoleResponse
+import com.techtaurant.mainserver.user.enums.UserStatus
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import java.util.UUID
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "관리자 사용자", description = "관리자 전용 사용자 관리 API")
+interface AdminUserRoleControllerDocs {
+    @Operation(summary = "사용자 역할 변경", description = "ADMIN 권한을 가진 사용자가 특정 사용자의 역할을 변경합니다")
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "역할 변경 성공",
+    )
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED", "ACCESS_DENIED"]),
+            ApiErrorCodeResponse(UserStatus::class, ["USER_NOT_FOUND"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["BAD_REQUEST", "UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun updateUserRole(
+        @Parameter(description = "역할을 변경할 대상 사용자 ID") targetUserId: UUID,
+        @Valid request: UpdateUserRoleRequest,
+    ): ApiResponse<UpdateUserRoleResponse>
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/user/application/UserWriteServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/application/UserWriteServiceTest.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.dao.DataIntegrityViolationException
 import java.util.Optional
 import java.util.UUID
+import kotlin.reflect.full.memberFunctions
 
 class UserWriteServiceTest {
     private val userRepository: UserRepository = mockk()
@@ -156,5 +157,36 @@ class UserWriteServiceTest {
             .isInstanceOf(ApiException::class.java)
             .extracting { (it as ApiException).status }
             .isEqualTo(UserStatus.USER_NAME_ALREADY_EXISTS)
+    }
+
+    @Test
+    @DisplayName("역할 변경 메서드는 대상 사용자를 ADMIN으로 변경한다")
+    fun updateUserRole_updatesRole() {
+        val method =
+            UserWriteService::class.memberFunctions.firstOrNull { function ->
+                function.name == "updateUserRole"
+            } ?: error("updateUserRole 메서드가 없습니다")
+
+        method.call(userWriteService, user.id!!, UserRole.ADMIN)
+
+        assertThat(user.role).isEqualTo(UserRole.ADMIN)
+    }
+
+    @Test
+    @DisplayName("역할 변경 대상 사용자가 없으면 USER_NOT_FOUND 예외를 던진다")
+    fun updateUserRole_missingUser_throwsUserNotFound() {
+        val method =
+            UserWriteService::class.memberFunctions.firstOrNull { function ->
+                function.name == "updateUserRole"
+            } ?: error("updateUserRole 메서드가 없습니다")
+        val missingUserId = UUID.randomUUID()
+        every { userRepository.findById(missingUserId) } returns Optional.empty()
+
+        assertThatThrownBy {
+            method.call(userWriteService, missingUserId, UserRole.ADMIN)
+        }
+            .hasCauseInstanceOf(ApiException::class.java)
+            .extracting { (it.cause as ApiException).status }
+            .isEqualTo(UserStatus.USER_NOT_FOUND)
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/AdminUserRoleControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/AdminUserRoleControllerIntegrationTest.kt
@@ -1,0 +1,105 @@
+package com.techtaurant.mainserver.user.infrastructure.`in`
+
+import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import io.restassured.RestAssured.given
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import kotlin.test.assertEquals
+import java.util.UUID
+
+@DisplayName("AdminUserRoleController 통합 테스트")
+class AdminUserRoleControllerIntegrationTest : IntegrationTest() {
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    private lateinit var adminUser: User
+    private lateinit var targetUser: User
+    private lateinit var normalUser: User
+    private lateinit var adminAccessToken: String
+    private lateinit var userAccessToken: String
+
+    @BeforeEach
+    fun setUpTestData() {
+        userRepository.deleteAllInBatch()
+
+        adminUser =
+            userRepository.save(
+                User(
+                    name = "관리자",
+                    email = "admin-${UUID.randomUUID()}@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "admin-id-${UUID.randomUUID()}",
+                    role = UserRole.ADMIN,
+                    profileImageUrl = "https://example.com/admin-profile.jpg",
+                ),
+            )
+        targetUser =
+            userRepository.save(
+                User(
+                    name = "대상사용자",
+                    email = "target-${UUID.randomUUID()}@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "target-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/target-profile.jpg",
+                ),
+            )
+        normalUser =
+            userRepository.save(
+                User(
+                    name = "일반사용자",
+                    email = "user-${UUID.randomUUID()}@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "user-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/user-profile.jpg",
+                ),
+            )
+
+        adminAccessToken = jwtTokenProvider.createAccessToken(adminUser.id!!, adminUser.role)
+        userAccessToken = jwtTokenProvider.createAccessToken(normalUser.id!!, normalUser.role)
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한은 다른 사용자를 ADMIN으로 승격할 수 있다")
+    fun adminCanPromoteUserToAdmin() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", "Bearer $adminAccessToken")
+            .body("""{"role":"ADMIN"}""")
+            .`when`()
+            .patch("/admin/users/${targetUser.id}/role")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.userId", equalTo(targetUser.id.toString()))
+            .body("data.role", equalTo(UserRole.ADMIN.name))
+
+        val updatedUser = userRepository.findById(targetUser.id!!).orElseThrow()
+        assertEquals(UserRole.ADMIN, updatedUser.role)
+    }
+
+    @Test
+    @DisplayName("USER 권한은 관리자 역할 변경 API를 호출할 수 없다")
+    fun userCannotUpdateUserRole() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", "Bearer $userAccessToken")
+            .body("""{"role":"ADMIN"}""")
+            .`when`()
+            .patch("/admin/users/${targetUser.id}/role")
+            .then()
+            .statusCode(HttpStatus.FORBIDDEN.value())
+    }
+}


### PR DESCRIPTION
## 관련 자료
- 이슈 : 없음

## 어떤 작업인가요?
- 관리자가 `/admin` prefix 아래에서만 다른 사용자의 역할을 변경할 수 있도록 사용자 역할 변경 API를 추가합니다.

## 어떻게 해결했나요?
**관리자 전용 역할 변경 API**
- `PATCH /admin/users/{targetUserId}/role` 엔드포인트를 추가했습니다.
- 요청/응답 DTO와 Swagger docs 인터페이스를 분리해 기존 컨트롤러 패턴에 맞췄습니다.

**역할 변경 서비스**
- `UserWriteService`에 대상 사용자 역할 변경 로직을 추가했습니다.
- 대상 사용자가 없으면 `USER_NOT_FOUND` 예외를 반환하도록 처리했습니다.

**권한 및 회귀 테스트**
- 관리자만 역할 변경 API를 호출할 수 있는지 통합 테스트를 추가했습니다.
- 역할 변경 성공/대상 사용자 없음 케이스를 서비스 테스트로 보강했습니다.

## 중요한 변경 사항은 무엇인가요?
### 관리자 역할 관리 API

**관리자 전용 사용자 역할 변경 엔드포인트 추가**
- **변경 이유**: `admin` prefix API에서만 권한 변경을 허용하기 위해
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/AdminUserRoleController.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/AdminUserRoleControllerDocs.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/dto/UpdateUserRoleRequest.kt`, `src/main/kotlin/com/techtaurant/mainserver/user/dto/UpdateUserRoleResponse.kt`

**UserWriteService에 역할 변경 로직 추가**
- **변경 이유**: 사용자 쓰기 책임을 유지하면서 역할 변경을 도메인 서비스에서 처리하기 위해
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/user/application/UserWriteService.kt`

### 검증 보강

**관리자/일반 사용자 접근 시나리오 통합 테스트 추가**
- **변경 이유**: 관리자 전용 API 접근 제어와 역할 변경 결과를 회귀 테스트로 고정하기 위해
- **수정 파일**: `src/test/kotlin/com/techtaurant/mainserver/user/infrastructure/in/AdminUserRoleControllerIntegrationTest.kt`

**서비스 단위 테스트 추가**
- **변경 이유**: 역할 변경 성공과 대상 사용자 없음 케이스를 빠르게 검증하기 위해
- **수정 파일**: `src/test/kotlin/com/techtaurant/mainserver/user/application/UserWriteServiceTest.kt`

Co-Authored-By: OpenAI Codex <codex@openai.com>
