### PR TITLE
modify(oauth): 리다이렉트 URI를 프론트 전달값으로 처리

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2FailureHandler.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2FailureHandler.kt
@@ -37,7 +37,7 @@ class OAuth2FailureHandler(
         )
 
         val status = OAuthStatus.OAUTH_AUTHENTICATION_FAILED
-        val baseUrl = redirectResolver.resolve(request, OAuth2RedirectResolver.FAILURE_PATH)
+        val baseUrl = redirectResolver.resolveFailureRedirectUrl(request)
 
         val redirectUrl =
             UriComponentsBuilder.fromUriString(baseUrl)

--- a/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2RedirectResolver.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2RedirectResolver.kt
@@ -6,15 +6,11 @@ import com.techtaurant.mainserver.security.oauth.repository.HttpCookieOAuth2Auth
 import jakarta.servlet.http.HttpServletRequest
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import java.net.URI
 
 /**
  * OAuth2 인증 완료 후 리다이렉트할 URL을 결정한다.
- * 쿠키에 저장된 요청 origin을 기반으로 리다이렉트 URL을 생성하며,
- * CORS 허용 목록에 포함된 origin만 허용하여 오픈 리다이렉트 공격을 방지한다.
- *
- * @param request 현재 HTTP 요청
- * @param path 리다이렉트 경로 (예: /oauth/callback)
- * @return 완성된 리다이렉트 URL
+ * 프론트가 전달한 성공/실패 URI를 우선 사용하고, 허용 origin만 통과시켜 오픈 리다이렉트 공격을 방지한다.
  */
 @Component
 class OAuth2RedirectResolver(
@@ -24,50 +20,132 @@ class OAuth2RedirectResolver(
     private val logger = LoggerFactory.getLogger(OAuth2RedirectResolver::class.java)
 
     companion object {
-        const val SUCCESS_PATH = "/oauth/callback"
-        const val FAILURE_PATH = "/oauth/error"
+        const val DEFAULT_SUCCESS_REDIRECT_URI = "/oauth/callback"
+        const val DEFAULT_FAILURE_REDIRECT_URI = "/oauth/error"
+        private const val DEFAULT_ORIGIN = "http://localhost:3000"
     }
 
-    fun resolve(
-        request: HttpServletRequest,
-        path: String,
-    ): String {
-        val origin =
-            cookieHelper.getCookie(
-                request,
-                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_ORIGIN_COOKIE,
-            )
+    fun resolveSuccessRedirectUrl(request: HttpServletRequest): String =
+        resolve(
+            request = request,
+            redirectUriCookieName = HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_SUCCESS_REDIRECT_URI_COOKIE,
+            fallbackRedirectUri = DEFAULT_SUCCESS_REDIRECT_URI,
+        )
 
+    fun resolveFailureRedirectUrl(request: HttpServletRequest): String =
+        resolve(
+            request = request,
+            redirectUriCookieName = HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_FAILURE_REDIRECT_URI_COOKIE,
+            fallbackRedirectUri = DEFAULT_FAILURE_REDIRECT_URI,
+        )
+
+    private fun resolve(
+        request: HttpServletRequest,
+        redirectUriCookieName: String,
+        fallbackRedirectUri: String,
+    ): String {
+        val origin = getOriginCookie(request)
+        val redirectUri = cookieHelper.getCookie(request, redirectUriCookieName)
         val allowedOrigins =
             corsProperties.allowedOrigins
                 .split(",")
-                .map { it.trim() }
+                .map { it.trim().trimEnd('/') }
                 .filter { it.isNotEmpty() }
 
         logger.info(
-            "resolve: originCookie={}, allowedOrigins={}, path={}",
+            "resolve: originCookie={}, allowedOrigins={}, redirectUriCookieName={}, redirectUriPresent={}",
             origin,
             allowedOrigins,
-            path,
+            redirectUriCookieName,
+            !redirectUri.isNullOrBlank(),
         )
 
-        val allCookieNames = request.cookies?.map { it.name } ?: emptyList()
-        logger.info("resolve: allCookies={}", allCookieNames)
+        val validOrigin = resolveValidOrigin(origin, allowedOrigins)
+        val redirectUrl =
+            resolveRedirectUrl(
+                redirectUri = redirectUri,
+                validOrigin = validOrigin,
+                allowedOrigins = allowedOrigins,
+            ) ?: buildRedirectUrl(validOrigin, fallbackRedirectUri)
 
-        val validOrigin =
+        logger.info("resolve: redirectUrl={}", redirectUrl)
+        return redirectUrl
+    }
+
+    private fun getOriginCookie(request: HttpServletRequest): String? {
+        return cookieHelper.getCookie(
+            request,
+            HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_ORIGIN_COOKIE,
+        )?.trim()?.trimEnd('/')
+    }
+
+    private fun resolveValidOrigin(
+        origin: String?,
+        allowedOrigins: List<String>,
+    ): String {
+        if (origin != null && origin in allowedOrigins) {
+            return origin
+        }
+
+        logger.warn(
+            "resolve: origin not in allowedOrigins, falling back. origin={}, allowedOrigins={}",
+            origin,
+            allowedOrigins,
+        )
+        return allowedOrigins.firstOrNull() ?: DEFAULT_ORIGIN
+    }
+
+    private fun resolveRedirectUrl(
+        redirectUri: String?,
+        validOrigin: String,
+        allowedOrigins: List<String>,
+    ): String? {
+        val targetUri = redirectUri?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        if (isInternalPath(targetUri)) {
+            return buildRedirectUrl(validOrigin, targetUri)
+        }
+
+        return resolveAllowedAbsoluteUrl(targetUri, allowedOrigins)
+    }
+
+    private fun isInternalPath(redirectUri: String): Boolean {
+        return redirectUri.startsWith("/") && !redirectUri.startsWith("//")
+    }
+
+    private fun buildRedirectUrl(
+        origin: String,
+        path: String,
+    ): String {
+        return "${origin.trimEnd('/')}$path"
+    }
+
+    private fun resolveAllowedAbsoluteUrl(
+        redirectUri: String,
+        allowedOrigins: List<String>,
+    ): String? {
+        return try {
+            val uri = URI(redirectUri)
+            val origin = uri.toOrigin()
             if (origin != null && origin in allowedOrigins) {
-                origin
+                redirectUri
             } else {
                 logger.warn(
-                    "resolve: origin not in allowedOrigins, falling back. origin={}, allowedOrigins={}",
+                    "resolve: redirectUri origin not allowed. redirectOrigin={}, allowedOrigins={}",
                     origin,
                     allowedOrigins,
                 )
-                allowedOrigins.firstOrNull() ?: "http://localhost:3000"
+                null
             }
+        } catch (e: Exception) {
+            logger.warn("resolve: invalid redirectUri={}", redirectUri)
+            null
+        }
+    }
 
-        val redirectUrl = "$validOrigin$path"
-        logger.info("resolve: redirectUrl={}", redirectUrl)
-        return redirectUrl
+    private fun URI.toOrigin(): String? {
+        val scheme = this.scheme ?: return null
+        val host = this.host ?: return null
+        val port = if (this.port != -1) ":${this.port}" else ""
+        return "$scheme://$host$port".trimEnd('/')
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2SuccessHandler.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2SuccessHandler.kt
@@ -58,7 +58,7 @@ class OAuth2SuccessHandler(
         // OAuth2 인증 완료 후 authorization request 쿠키 정리
         cookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(response)
 
-        val redirectUrl = redirectResolver.resolve(request, OAuth2RedirectResolver.SUCCESS_PATH)
+        val redirectUrl = redirectResolver.resolveSuccessRedirectUrl(request)
         response.sendRedirect(redirectUrl)
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepository.kt
@@ -29,6 +29,10 @@ class HttpCookieOAuth2AuthorizationRequestRepository(
     companion object {
         const val OAUTH2_AUTHORIZATION_REQUEST_COOKIE = "oauth2_auth_request"
         const val OAUTH2_ORIGIN_COOKIE = "oauth2_origin"
+        const val OAUTH2_SUCCESS_REDIRECT_URI_COOKIE = "oauth2_success_redirect_uri"
+        const val OAUTH2_FAILURE_REDIRECT_URI_COOKIE = "oauth2_failure_redirect_uri"
+        const val SUCCESS_REDIRECT_URI_PARAMETER = "redirect-uri"
+        const val FAILURE_REDIRECT_URI_PARAMETER = "failure-redirect-uri"
         private const val COOKIE_EXPIRE_SECONDS = 180
     }
 
@@ -82,6 +86,19 @@ class HttpCookieOAuth2AuthorizationRequestRepository(
         } else {
             logger.warn("saveAuthorizationRequest: origin is null, oauth2_origin cookie NOT set")
         }
+
+        saveRedirectUriCookie(
+            request = request,
+            response = response,
+            parameterName = SUCCESS_REDIRECT_URI_PARAMETER,
+            cookieName = OAUTH2_SUCCESS_REDIRECT_URI_COOKIE,
+        )
+        saveRedirectUriCookie(
+            request = request,
+            response = response,
+            parameterName = FAILURE_REDIRECT_URI_PARAMETER,
+            cookieName = OAUTH2_FAILURE_REDIRECT_URI_COOKIE,
+        )
     }
 
     override fun removeAuthorizationRequest(
@@ -94,6 +111,27 @@ class HttpCookieOAuth2AuthorizationRequestRepository(
     fun removeAuthorizationRequestCookies(response: HttpServletResponse) {
         cookieHelper.deleteCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE)
         cookieHelper.deleteCookie(response, OAUTH2_ORIGIN_COOKIE)
+        cookieHelper.deleteCookie(response, OAUTH2_SUCCESS_REDIRECT_URI_COOKIE)
+        cookieHelper.deleteCookie(response, OAUTH2_FAILURE_REDIRECT_URI_COOKIE)
+    }
+
+    private fun saveRedirectUriCookie(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        parameterName: String,
+        cookieName: String,
+    ) {
+        val redirectUri = request.getParameter(parameterName)?.trim()
+        if (redirectUri.isNullOrBlank()) {
+            return
+        }
+
+        cookieHelper.addCookie(
+            response,
+            cookieName,
+            redirectUri,
+            COOKIE_EXPIRE_SECONDS,
+        )
     }
 
     /**

--- a/src/test/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2RedirectResolverTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2RedirectResolverTest.kt
@@ -1,0 +1,153 @@
+package com.techtaurant.mainserver.security.oauth.handler
+
+import com.techtaurant.mainserver.security.config.CorsProperties
+import com.techtaurant.mainserver.security.helper.CookieHelper
+import com.techtaurant.mainserver.security.oauth.repository.HttpCookieOAuth2AuthorizationRequestRepository
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+
+class OAuth2RedirectResolverTest {
+    private val cookieHelper: CookieHelper = mockk()
+    private lateinit var resolver: OAuth2RedirectResolver
+    private lateinit var request: MockHttpServletRequest
+
+    @BeforeEach
+    fun setUp() {
+        resolver =
+            OAuth2RedirectResolver(
+                cookieHelper = cookieHelper,
+                corsProperties =
+                    CorsProperties(
+                        allowedOrigins = "https://techtaurant.com,http://localhost:3000",
+                    ),
+            )
+        request = MockHttpServletRequest()
+    }
+
+    @Test
+    @DisplayName("성공 redirect-uri가 내부 path이면 허용된 origin과 결합한다")
+    fun `resolve success redirect with internal path`() {
+        // given
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_ORIGIN_COOKIE,
+            )
+        } returns "https://techtaurant.com"
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_SUCCESS_REDIRECT_URI_COOKIE,
+            )
+        } returns "/ko/oauth/callback?redirect=%2Fko%2Fpost%2Fwrite"
+
+        // when
+        val redirectUrl = resolver.resolveSuccessRedirectUrl(request)
+
+        // then
+        assertThat(redirectUrl).isEqualTo(
+            "https://techtaurant.com/ko/oauth/callback?redirect=%2Fko%2Fpost%2Fwrite",
+        )
+    }
+
+    @Test
+    @DisplayName("실패 redirect-uri가 허용된 absolute URL이면 그대로 사용한다")
+    fun `resolve failure redirect with allowed absolute url`() {
+        // given
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_ORIGIN_COOKIE,
+            )
+        } returns "https://techtaurant.com"
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_FAILURE_REDIRECT_URI_COOKIE,
+            )
+        } returns "http://localhost:3000/ko/oauth/error"
+
+        // when
+        val redirectUrl = resolver.resolveFailureRedirectUrl(request)
+
+        // then
+        assertThat(redirectUrl).isEqualTo("http://localhost:3000/ko/oauth/error")
+    }
+
+    @Test
+    @DisplayName("redirect-uri absolute URL의 origin이 허용되지 않으면 기본 실패 경로로 fallback한다")
+    fun `fallback failure redirect when absolute url origin is not allowed`() {
+        // given
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_ORIGIN_COOKIE,
+            )
+        } returns "https://techtaurant.com"
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_FAILURE_REDIRECT_URI_COOKIE,
+            )
+        } returns "https://evil.example/ko/oauth/error"
+
+        // when
+        val redirectUrl = resolver.resolveFailureRedirectUrl(request)
+
+        // then
+        assertThat(redirectUrl).isEqualTo("https://techtaurant.com/oauth/error")
+    }
+
+    @Test
+    @DisplayName("origin 쿠키가 허용되지 않으면 첫 번째 허용 origin으로 내부 path를 결합한다")
+    fun `fallback origin when origin cookie is not allowed`() {
+        // given
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_ORIGIN_COOKIE,
+            )
+        } returns "https://evil.example"
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_SUCCESS_REDIRECT_URI_COOKIE,
+            )
+        } returns "/en/oauth/callback"
+
+        // when
+        val redirectUrl = resolver.resolveSuccessRedirectUrl(request)
+
+        // then
+        assertThat(redirectUrl).isEqualTo("https://techtaurant.com/en/oauth/callback")
+    }
+
+    @Test
+    @DisplayName("성공 redirect-uri가 없으면 기본 성공 경로로 fallback한다")
+    fun `fallback success redirect when redirect uri is missing`() {
+        // given
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_ORIGIN_COOKIE,
+            )
+        } returns "https://techtaurant.com"
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_SUCCESS_REDIRECT_URI_COOKIE,
+            )
+        } returns null
+
+        // when
+        val redirectUrl = resolver.resolveSuccessRedirectUrl(request)
+
+        // then
+        assertThat(redirectUrl).isEqualTo("https://techtaurant.com/oauth/callback")
+    }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepositoryTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepositoryTest.kt
@@ -1,0 +1,88 @@
+package com.techtaurant.mainserver.security.oauth.repository
+
+import com.techtaurant.mainserver.security.helper.CookieHelper
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
+
+class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
+    private val cookieHelper: CookieHelper = mockk(relaxed = true)
+    private val repository = HttpCookieOAuth2AuthorizationRequestRepository(cookieHelper)
+
+    @Test
+    @DisplayName("OAuth 시작 요청의 성공/실패 redirect-uri를 쿠키에 저장한다")
+    fun `save success and failure redirect uri cookies`() {
+        // given
+        val request =
+            MockHttpServletRequest().apply {
+                addParameter("origin", "https://techtaurant.com")
+                addParameter("redirect-uri", "/ko/oauth/callback?redirect=%2Fko%2Fpost%2Fwrite")
+                addParameter("failure-redirect-uri", "/ko/oauth/error")
+            }
+        val response = MockHttpServletResponse()
+        val authorizationRequest = createAuthorizationRequest()
+
+        every { cookieHelper.addCookie(any(), any(), any(), any()) } returns Unit
+
+        // when
+        repository.saveAuthorizationRequest(authorizationRequest, request, response)
+
+        // then
+        verify {
+            cookieHelper.addCookie(
+                response,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_SUCCESS_REDIRECT_URI_COOKIE,
+                "/ko/oauth/callback?redirect=%2Fko%2Fpost%2Fwrite",
+                any(),
+            )
+        }
+        verify {
+            cookieHelper.addCookie(
+                response,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_FAILURE_REDIRECT_URI_COOKIE,
+                "/ko/oauth/error",
+                any(),
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("OAuth authorization request 쿠키를 지울 때 redirect-uri 쿠키도 함께 지운다")
+    fun `remove redirect uri cookies`() {
+        // given
+        val response = MockHttpServletResponse()
+
+        every { cookieHelper.deleteCookie(any(), any()) } returns Unit
+
+        // when
+        repository.removeAuthorizationRequestCookies(response)
+
+        // then
+        verify {
+            cookieHelper.deleteCookie(
+                response,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_SUCCESS_REDIRECT_URI_COOKIE,
+            )
+        }
+        verify {
+            cookieHelper.deleteCookie(
+                response,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_FAILURE_REDIRECT_URI_COOKIE,
+            )
+        }
+    }
+
+    private fun createAuthorizationRequest(): OAuth2AuthorizationRequest {
+        return OAuth2AuthorizationRequest.authorizationCode()
+            .authorizationUri("https://accounts.google.com/o/oauth2/v2/auth")
+            .clientId("client-id")
+            .redirectUri("https://api.techtaurant.com/login/oauth2/code/google")
+            .state("state")
+            .build()
+    }
+}


### PR DESCRIPTION
## 관련 자료

- 관련 프론트 PR: https://github.com/Techtaurant/fe/pull/146

## 어떤 작업인가요?
- OAuth 로그인 완료 후 백엔드에 하드코딩된 callback/error 경로 대신 프론트가 전달한 성공/실패 리다이렉트 URI를 사용하도록 변경합니다.

## 어떻게 해결했나요?
**OAuth redirect URI 보존**
- OAuth 시작 요청의 `redirect-uri`, `failure-redirect-uri` 파라미터를 authorization request 쿠키와 같은 생명주기의 쿠키로 저장합니다.
- OAuth 요청 쿠키 정리 시 신규 redirect URI 쿠키도 함께 삭제합니다.

**리다이렉트 URL 검증 및 적용**
- 성공/실패 redirect resolver를 분리하고, 내부 path 또는 `cors.allowed-origins`에 포함된 absolute URL만 허용합니다.
- 성공/실패 핸들러가 각각 동적 redirect URL을 사용하도록 연결합니다.

## 중요한 변경 사항은 무엇인가요?
### OAuth redirect 처리

**프론트 전달 URI 우선 적용**
- **변경 이유**: locale 기반 OAuth callback/error 경로를 프론트가 결정할 수 있어야 합니다.
- **수정 파일**: `OAuth2RedirectResolver.kt`, `OAuth2SuccessHandler.kt`, `OAuth2FailureHandler.kt`

**redirect URI 쿠키 저장**
- **변경 이유**: Google callback 시 OAuth 시작 요청 query가 사라지므로, 성공/실패 URI를 OAuth 플로우 동안 보존해야 합니다.
- **수정 파일**: `HttpCookieOAuth2AuthorizationRequestRepository.kt`

**오픈 리다이렉트 방어**
- **변경 이유**: 외부 absolute URL은 허용된 origin으로만 제한해야 합니다.
- **수정 파일**: `OAuth2RedirectResolverTest.kt`, `HttpCookieOAuth2AuthorizationRequestRepositoryTest.kt`
