### PR TITLE
feat(api): SSG용 v2 public 조회 API 분리

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentReadService.kt
@@ -2,12 +2,18 @@ package com.techtaurant.mainserver.comment.application
 
 import com.techtaurant.mainserver.comment.dto.CommentCursor
 import com.techtaurant.mainserver.comment.dto.CommentListResponse
+import com.techtaurant.mainserver.comment.dto.CommentListV2Response
+import com.techtaurant.mainserver.comment.dto.CommentUserDataResponse
 import com.techtaurant.mainserver.comment.entity.Comment
 import com.techtaurant.mainserver.comment.enums.CommentSortType
+import com.techtaurant.mainserver.comment.enums.CommentStatus
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentLikeLogRepository
+import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepository
 import com.techtaurant.mainserver.comment.infrastructure.out.CommentRepositoryCustom
 import com.techtaurant.mainserver.common.dto.CursorPageResponse
 import com.techtaurant.mainserver.common.enums.LikeStatus
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.user.application.UserBanService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -20,8 +26,10 @@ import java.util.UUID
 @Transactional(readOnly = true)
 class CommentReadService(
     private val commentRepository: CommentRepositoryCustom,
+    private val commentJpaRepository: CommentRepository,
     private val commentLikeLogRepository: CommentLikeLogRepository,
     private val commentResponseAssembler: CommentResponseAssembler,
+    private val userBanService: UserBanService,
 ) {
     /**
      * 부모 댓글 목록을 커서 기반 페이지네이션으로 조회합니다.
@@ -126,6 +134,114 @@ class CommentReadService(
             nextCursor = nextCursor,
             hasNext = hasNext,
             size = content.size,
+        )
+    }
+
+    fun getPublicParentCommentsV2(
+        postId: UUID,
+        cursor: String?,
+        size: Int,
+        sortType: CommentSortType = CommentSortType.LATEST,
+    ): CursorPageResponse<CommentListV2Response> {
+        val commentCursor = cursor?.let { CommentCursor.decode(it) }
+
+        if (cursor != null && commentCursor == null) {
+            return CursorPageResponse(
+                content = emptyList(),
+                nextCursor = null,
+                hasNext = false,
+                size = 0,
+            )
+        }
+
+        val comments =
+            commentRepository.findParentCommentsWithConditions(
+                postId = postId,
+                cursor = commentCursor,
+                size = size + 1,
+                sortType = sortType,
+            )
+
+        val hasNext = comments.size > size
+        val content = comments.take(size)
+
+        val nextCursor =
+            if (hasNext && content.isNotEmpty()) {
+                CommentCursor.from(content.last(), sortType).encode()
+            } else {
+                null
+            }
+
+        return CursorPageResponse(
+            content = commentResponseAssembler.assemblePublicV2(content),
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+            size = content.size,
+        )
+    }
+
+    fun getPublicRepliesV2(
+        parentId: UUID,
+        cursor: String?,
+        size: Int,
+        sortType: CommentSortType = CommentSortType.LATEST,
+    ): CursorPageResponse<CommentListV2Response> {
+        val commentCursor = cursor?.let { CommentCursor.decode(it) }
+
+        if (cursor != null && commentCursor == null) {
+            return CursorPageResponse(
+                content = emptyList(),
+                nextCursor = null,
+                hasNext = false,
+                size = 0,
+            )
+        }
+
+        val comments =
+            commentRepository.findRepliesWithConditions(
+                parentId = parentId,
+                cursor = commentCursor,
+                size = size + 1,
+                sortType = sortType,
+            )
+
+        val hasNext = comments.size > size
+        val content = comments.take(size)
+
+        val nextCursor =
+            if (hasNext && content.isNotEmpty()) {
+                CommentCursor.from(content.last(), sortType).encode()
+            } else {
+                null
+            }
+
+        return CursorPageResponse(
+            content = commentResponseAssembler.assemblePublicV2(content),
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+            size = content.size,
+        )
+    }
+
+    fun getCommentUserData(
+        commentId: UUID,
+        userId: UUID,
+    ): CommentUserDataResponse {
+        val comment =
+            commentJpaRepository.findById(commentId).orElseThrow {
+                ApiException(CommentStatus.COMMENT_NOT_FOUND)
+            }
+        val likeStatus =
+            commentLikeLogRepository.findByCommentIdAndUserId(commentId, userId)
+                ?.let { log ->
+                    if (log.isLiked) LikeStatus.LIKE else LikeStatus.DISLIKE
+                } ?: LikeStatus.NONE
+        val isBannedAuthor = userBanService.getBannedUserIds(userId).contains(comment.author.id)
+
+        return CommentUserDataResponse(
+            commentId = commentId,
+            likeStatus = likeStatus,
+            isBannedAuthor = isBannedAuthor,
         )
     }
 

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentResponseAssembler.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentResponseAssembler.kt
@@ -1,5 +1,6 @@
 package com.techtaurant.mainserver.comment.application
 
+import com.techtaurant.mainserver.comment.dto.CommentListV2Response
 import com.techtaurant.mainserver.comment.dto.CommentListResponse
 import com.techtaurant.mainserver.comment.entity.Comment
 import com.techtaurant.mainserver.common.enums.LikeStatus
@@ -50,6 +51,26 @@ class CommentResponseAssembler(
                     maskedContent = bannedUserMaskingService.maskCommentContent(comment.id!!),
                 )
             }
+        }
+    }
+
+    fun assemblePublicV2(comments: List<Comment>): List<CommentListV2Response> {
+        if (comments.isEmpty()) {
+            return emptyList()
+        }
+
+        val authorProfileImageUrlByUserId =
+            userProfileImageResolver.resolve(
+                comments
+                    .map { it.author }
+                    .distinctBy { it.id },
+            )
+
+        return comments.map { comment ->
+            CommentListV2Response.from(
+                comment = comment,
+                authorProfileImageUrl = authorProfileImageUrlByUserId[comment.author.id] ?: comment.author.getFallbackProfileImageUrl(),
+            )
         }
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentListV2Response.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentListV2Response.kt
@@ -1,0 +1,58 @@
+package com.techtaurant.mainserver.comment.dto
+
+import com.techtaurant.mainserver.comment.entity.Comment
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.Date
+import java.util.UUID
+
+@Schema(description = "댓글 목록 응답 v2 - 사용자별 필드 제외")
+data class CommentListV2Response(
+    @field:Schema(description = "댓글 ID")
+    val id: UUID,
+    @field:Schema(description = "댓글 내용")
+    val content: String,
+    @field:Schema(description = "게시물 ID")
+    val postId: UUID,
+    @field:Schema(description = "작성자 ID")
+    val authorId: UUID,
+    @field:Schema(description = "작성자 이름")
+    val authorName: String,
+    @field:Schema(description = "작성자 프로필 이미지 URL", nullable = true)
+    val authorProfileImageUrl: String?,
+    @field:Schema(description = "부모 댓글 ID", nullable = true)
+    val parentId: UUID?,
+    @field:Schema(description = "댓글 깊이 (0: 댓글, 1: 대댓글)")
+    val depth: Int,
+    @field:Schema(description = "좋아요 수")
+    val likeCount: Long,
+    @field:Schema(description = "대댓글 수")
+    val replyCount: Long,
+    @field:Schema(description = "삭제 여부")
+    val isDeleted: Boolean,
+    @field:Schema(description = "생성 시각")
+    val createdAt: Date,
+    @field:Schema(description = "수정 시각")
+    val updatedAt: Date,
+) {
+    companion object {
+        fun from(
+            comment: Comment,
+            authorProfileImageUrl: String,
+        ): CommentListV2Response =
+            CommentListV2Response(
+                id = comment.id!!,
+                content = comment.content,
+                postId = comment.post.id!!,
+                authorId = comment.author.id!!,
+                authorName = comment.author.name,
+                authorProfileImageUrl = authorProfileImageUrl,
+                parentId = comment.parent?.id,
+                depth = comment.depth,
+                likeCount = comment.likeCount,
+                replyCount = comment.replyCount,
+                isDeleted = comment.deletedAt != null,
+                createdAt = comment.createdAt,
+                updatedAt = comment.updatedAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentUserDataResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentUserDataResponse.kt
@@ -1,0 +1,15 @@
+package com.techtaurant.mainserver.comment.dto
+
+import com.techtaurant.mainserver.common.enums.LikeStatus
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+@Schema(description = "댓글 사용자 데이터 응답")
+data class CommentUserDataResponse(
+    @field:Schema(description = "댓글 ID")
+    val commentId: UUID,
+    @field:Schema(description = "현재 사용자의 좋아요 상태")
+    val likeStatus: LikeStatus,
+    @field:Schema(description = "현재 사용자가 댓글 작성자를 차단했는지 여부")
+    val isBannedAuthor: Boolean,
+)

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadV2OpenApiController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadV2OpenApiController.kt
@@ -1,0 +1,46 @@
+package com.techtaurant.mainserver.comment.infrastructure.`in`
+
+import com.techtaurant.mainserver.comment.application.CommentReadService
+import com.techtaurant.mainserver.comment.dto.CommentListV2Response
+import com.techtaurant.mainserver.comment.enums.CommentSortType
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.dto.CursorPageResponse
+import com.techtaurant.mainserver.common.swagger.ApiErrorResponses
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/open-api/v2/comments")
+@Validated
+class CommentReadV2OpenApiController(
+    private val commentReadService: CommentReadService,
+) : CommentReadV2OpenApiControllerDocs {
+    @ApiErrorResponses(includeValidationError = true)
+    @GetMapping("/posts/{postId}")
+    override fun getParentComments(
+        @PathVariable postId: UUID,
+        @RequestParam(required = false) cursor: String?,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(100) size: Int,
+        @RequestParam(defaultValue = "LATEST") sort: CommentSortType,
+    ): ApiResponse<CursorPageResponse<CommentListV2Response>> {
+        return ApiResponse.ok(commentReadService.getPublicParentCommentsV2(postId, cursor, size, sort))
+    }
+
+    @ApiErrorResponses(includeValidationError = true)
+    @GetMapping("/{commentId}/replies")
+    override fun getReplies(
+        @PathVariable commentId: UUID,
+        @RequestParam(required = false) cursor: String?,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(100) size: Int,
+        @RequestParam(defaultValue = "LATEST") sort: CommentSortType,
+    ): ApiResponse<CursorPageResponse<CommentListV2Response>> {
+        return ApiResponse.ok(commentReadService.getPublicRepliesV2(commentId, cursor, size, sort))
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadV2OpenApiControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadV2OpenApiControllerDocs.kt
@@ -1,0 +1,49 @@
+package com.techtaurant.mainserver.comment.infrastructure.`in`
+
+import com.techtaurant.mainserver.comment.dto.CommentListV2Response
+import com.techtaurant.mainserver.comment.enums.CommentSortType
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.dto.CursorPageResponse
+import com.techtaurant.mainserver.common.swagger.ApiCommonBadRequestAndUnknown
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import java.util.UUID
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "댓글 v2", description = "SSG/ISR용 댓글 public API")
+interface CommentReadV2OpenApiControllerDocs {
+    @Operation(
+        summary = "부모 댓글 목록 조회 v2",
+        description = "SSG/ISR에 사용할 수 있도록 로그인 사용자별 필드(likeStatus, isBanned)와 차단 마스킹을 제외한 부모 댓글 목록을 조회합니다.",
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+    )
+    @ApiCommonBadRequestAndUnknown
+    fun getParentComments(
+        @Parameter(description = "게시물 ID") postId: UUID,
+        @Parameter(description = "이전 응답의 nextCursor (첫 페이지는 생략)") cursor: String?,
+        @Parameter(description = "페이지 크기 (1-100, 기본값 20)") @Min(1) @Max(100) size: Int,
+        @Parameter(description = "정렬 기준 (LATEST: 최신순, LIKE: 추천순, REPLY: 답글순)") sort: CommentSortType,
+    ): ApiResponse<CursorPageResponse<CommentListV2Response>>
+
+    @Operation(
+        summary = "대댓글 목록 조회 v2",
+        description = "SSG/ISR에 사용할 수 있도록 로그인 사용자별 필드(likeStatus, isBanned)와 차단 마스킹을 제외한 대댓글 목록을 조회합니다.",
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+    )
+    @ApiCommonBadRequestAndUnknown
+    fun getReplies(
+        @Parameter(description = "부모 댓글 ID") commentId: UUID,
+        @Parameter(description = "이전 응답의 nextCursor (첫 페이지는 생략)") cursor: String?,
+        @Parameter(description = "페이지 크기 (1-100, 기본값 20)") @Min(1) @Max(100) size: Int,
+        @Parameter(description = "정렬 기준 (LATEST: 최신순, LIKE: 추천순, REPLY: 답글순)") sort: CommentSortType,
+    ): ApiResponse<CursorPageResponse<CommentListV2Response>>
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentUserDataController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentUserDataController.kt
@@ -1,0 +1,30 @@
+package com.techtaurant.mainserver.comment.infrastructure.`in`
+
+import com.techtaurant.mainserver.comment.application.CommentReadService
+import com.techtaurant.mainserver.comment.dto.CommentUserDataResponse
+import com.techtaurant.mainserver.comment.enums.CommentStatus
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.swagger.ApiErrorResponses
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/comments")
+@Validated
+class CommentUserDataController(
+    private val commentReadService: CommentReadService,
+) : CommentUserDataControllerDocs {
+    @ApiErrorResponses(comments = [CommentStatus.COMMENT_NOT_FOUND], includeAuthenticationErrors = true)
+    @GetMapping("/{commentId}/user-data")
+    override fun getCommentUserData(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable commentId: UUID,
+    ): ApiResponse<CommentUserDataResponse> {
+        return ApiResponse.ok(commentReadService.getCommentUserData(commentId, userId))
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentUserDataControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentUserDataControllerDocs.kt
@@ -1,0 +1,37 @@
+package com.techtaurant.mainserver.comment.infrastructure.`in`
+
+import com.techtaurant.mainserver.comment.dto.CommentUserDataResponse
+import com.techtaurant.mainserver.comment.enums.CommentStatus
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.status.DefaultStatus
+import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponse
+import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponses
+import com.techtaurant.mainserver.security.jwt.JwtStatus
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import java.util.UUID
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "댓글 사용자 데이터", description = "댓글 인증 사용자별 데이터 API")
+interface CommentUserDataControllerDocs {
+    @Operation(
+        summary = "댓글 사용자 데이터 조회",
+        description = "로그인 사용자 기준 댓글 likeStatus와 isBannedAuthor를 조회합니다. SSG/ISR용 댓글 public API와 분리해서 호출합니다.",
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+    )
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED"]),
+            ApiErrorCodeResponse(CommentStatus::class, ["COMMENT_NOT_FOUND"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun getCommentUserData(
+        userId: UUID,
+        @Parameter(description = "댓글 ID") commentId: UUID,
+    ): ApiResponse<CommentUserDataResponse>
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDetailReadService.kt
@@ -6,6 +6,8 @@ import com.techtaurant.mainserver.common.enums.LikeStatus
 import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.post.dto.PostDetailAttachmentPresignedUrlResponse
 import com.techtaurant.mainserver.post.dto.PostDetailResponse
+import com.techtaurant.mainserver.post.dto.PostDetailV2Response
+import com.techtaurant.mainserver.post.dto.PostUserDataResponse
 import com.techtaurant.mainserver.post.enums.PostStatus
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostLikeLogRepository
@@ -94,6 +96,65 @@ class PostDetailReadService(
             isRead = isRead,
             authorProfileImageUrl = authorProfileImageUrl,
             attachmentPresignedUrls = attachmentPresignedUrls,
+        )
+    }
+
+    @Transactional
+    fun getPublicPostDetailV2(
+        postId: UUID,
+        ipAddress: String?,
+        userAgent: String?,
+    ): PostDetailV2Response {
+        val post =
+            postRepository.findVisiblePostDetailById(postId, null)
+                ?.takeIf { it.status == PostStatusEnum.PUBLISHED }
+                ?: throw ApiException(PostStatus.POST_NOT_FOUND)
+
+        postViewLogService.recordView(
+            postId = postId,
+            userId = null,
+            ipAddress = ipAddress,
+            userAgent = userAgent,
+        )
+
+        val attachmentPresignedUrls =
+            attachmentService.generatePresignedDownloadUrlMapByReference(postId, AttachmentReferenceType.POST)
+                .map { (attachmentId, presignedUrl) ->
+                    PostDetailAttachmentPresignedUrlResponse.from(attachmentId, presignedUrl)
+                }
+        val authorProfileImageUrl = userProfileImageResolver.resolve(post.author)
+
+        return PostDetailV2Response.from(
+            post = post,
+            authorProfileImageUrl = authorProfileImageUrl,
+            attachmentPresignedUrls = attachmentPresignedUrls,
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getPostUserData(
+        postId: UUID,
+        userId: UUID,
+    ): PostUserDataResponse {
+        val post =
+            postRepository.findVisiblePostDetailById(postId, userId)
+                ?: throw ApiException(PostStatus.POST_NOT_FOUND)
+
+        if (post.status != PostStatusEnum.PUBLISHED && post.author.id != userId) {
+            throw ApiException(PostStatus.POST_NOT_FOUND)
+        }
+
+        val likeStatus =
+            postLikeLogRepository.findByPostIdAndUserId(postId, userId)
+                ?.let { log ->
+                    if (log.isLiked) LikeStatus.LIKE else LikeStatus.DISLIKE
+                } ?: LikeStatus.NONE
+        val isRead = postReadLogRepository.existsByPostIdAndUserId(postId, userId)
+
+        return PostUserDataResponse(
+            postId = postId,
+            likeStatus = likeStatus,
+            isRead = isRead,
         )
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -8,6 +8,7 @@ import com.techtaurant.mainserver.post.dto.CategoryResponse
 import com.techtaurant.mainserver.post.dto.DraftListItemResponse
 import com.techtaurant.mainserver.post.dto.PostCursor
 import com.techtaurant.mainserver.post.dto.PostListItemResponse
+import com.techtaurant.mainserver.post.dto.PostListItemV2Response
 import com.techtaurant.mainserver.post.dto.PostListTagResponse
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
@@ -161,6 +162,94 @@ class PostListReadService(
         )
     }
 
+    fun getPublicPostsV2(
+        cursor: String?,
+        size: Int,
+        period: PostPeriod = PostPeriod.ALL,
+        sortType: PostSortType = PostSortType.LATEST,
+        authorId: UUID? = null,
+        categoryId: UUID? = null,
+        tagIds: List<UUID>? = null,
+    ): CursorPageResponse<PostListItemV2Response> {
+        val postCursor = cursor?.let { PostCursor.decode(it) }
+        val normalizedTagIds = normalizeTagIds(tagIds)
+
+        if (cursor != null && postCursor == null) {
+            return CursorPageResponse(
+                content = emptyList(),
+                nextCursor = null,
+                hasNext = false,
+                size = 0,
+            )
+        }
+
+        val postListQueryCriteria =
+            PostListQueryCriteria(
+                cursor = postCursor,
+                size = size,
+                period = period,
+                sortType = sortType,
+                currentUserId = null,
+                authorId = authorId,
+                categoryId = categoryId,
+                tagIds = normalizedTagIds,
+            )
+        val posts = selectPostListQueryStrategy(postListQueryCriteria).findPosts(postListQueryCriteria)
+
+        val hasNext = posts.size > size
+        val content = posts.take(size)
+
+        val nextCursor =
+            if (hasNext && content.isNotEmpty()) {
+                PostCursor.from(content.last(), sortType).encode()
+            } else {
+                null
+            }
+
+        val postIds = content.mapNotNull { it.id }
+        val attachmentsByPostId =
+            if (postIds.isNotEmpty()) {
+                attachmentService.getConfirmedAttachmentsByReferenceIds(postIds, AttachmentReferenceType.POST)
+            } else {
+                emptyMap()
+            }
+        val thumbnailAttachmentByPostId =
+            content.associate { post ->
+                val thumbnailAttachment =
+                    attachmentsByPostId[post.id]
+                        .orEmpty()
+                        .let { attachments ->
+                            post.thumbnailImage?.let { thumbnailAttachmentId ->
+                                attachments.firstOrNull { it.id == thumbnailAttachmentId }
+                            } ?: attachments.minByOrNull { it.createdAt }
+                        }
+                post.id!! to thumbnailAttachment
+            }
+        val presignedThumbnailUrlByAttachmentId =
+            thumbnailAttachmentByPostId
+                .values
+                .filterNotNull()
+                .takeIf { it.isNotEmpty() }
+                ?.let { attachmentService.generatePresignedDownloadUrlMapByAttachments(it) }
+                ?: emptyMap()
+        val authorProfileImageUrlByUserId = userProfileImageResolver.resolve(content.map { it.author }.distinctBy { it.id })
+
+        return CursorPageResponse(
+            content =
+                content.map { post ->
+                    convertToV2Response(
+                        post,
+                        thumbnailAttachmentByPostId[post.id],
+                        authorProfileImageUrlByUserId[post.author.id] ?: post.author.getFallbackProfileImageUrl(),
+                        presignedThumbnailUrlByAttachmentId,
+                    )
+                },
+            nextCursor = nextCursor,
+            hasNext = hasNext,
+            size = content.size,
+        )
+    }
+
     private fun normalizeTagIds(tagIds: List<UUID>?): List<UUID>? {
         val normalizedTagIds = tagIds?.distinct()
 
@@ -290,6 +379,33 @@ class PostListReadService(
             thumbnailUrl = thumbnailUrl,
             category = post.category?.let(CategoryResponse::from),
             isRead = isRead,
+            tags = post.tags.map { PostListTagResponse.from(it) },
+            viewCount = post.viewCount,
+            likeCount = post.likeCount,
+            commentCount = post.commentCount,
+            status = post.status,
+            createdAt = post.createdAt,
+            updatedAt = post.updatedAt,
+        )
+    }
+
+    private fun convertToV2Response(
+        post: Post,
+        thumbnailAttachment: Attachment?,
+        authorProfileImageUrl: String,
+        presignedThumbnailUrlByAttachmentId: Map<UUID, String>,
+    ): PostListItemV2Response {
+        val thumbnailUrl = thumbnailAttachment?.id?.let { presignedThumbnailUrlByAttachmentId[it] } ?: "$baseUrl$defaultThumbnailUrl"
+
+        return PostListItemV2Response(
+            id = post.id!!,
+            title = post.title,
+            content = post.content.take(POST_LIST_CONTENT_MAX_LENGTH),
+            authorId = post.author.id!!,
+            authorName = post.author.name,
+            authorProfileImageUrl = authorProfileImageUrl,
+            thumbnailUrl = thumbnailUrl,
+            category = post.category?.let(CategoryResponse::from),
             tags = post.tags.map { PostListTagResponse.from(it) },
             viewCount = post.viewCount,
             likeCount = post.likeCount,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostDetailV2Response.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostDetailV2Response.kt
@@ -1,0 +1,60 @@
+package com.techtaurant.mainserver.post.dto
+
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.Date
+import java.util.UUID
+
+@Schema(description = "게시물 상세 응답 v2 - 사용자별 필드 제외")
+data class PostDetailV2Response(
+    @field:Schema(description = "게시물 ID")
+    val id: UUID,
+    @field:Schema(description = "게시물 제목")
+    val title: String,
+    @field:Schema(description = "게시물 본문")
+    val content: String,
+    @field:Schema(description = "작성자 정보")
+    val author: AuthorResponse,
+    @field:Schema(description = "카테고리 정보")
+    val category: CategoryResponse?,
+    @field:Schema(description = "태그 목록")
+    val tags: List<PostListTagResponse>,
+    @field:Schema(description = "조회수")
+    val viewCount: Long,
+    @field:Schema(description = "좋아요수")
+    val likeCount: Long,
+    @field:Schema(description = "댓글수")
+    val commentCount: Long,
+    @field:Schema(description = "게시물 상태")
+    val status: PostStatusEnum,
+    @field:Schema(description = "attachmentId와 presigned URL 매핑 목록")
+    val attachmentPresignedUrls: List<PostDetailAttachmentPresignedUrlResponse>,
+    @field:Schema(description = "작성일")
+    val createdAt: Date,
+    @field:Schema(description = "수정일")
+    val updatedAt: Date,
+) {
+    companion object {
+        fun from(
+            post: Post,
+            authorProfileImageUrl: String,
+            attachmentPresignedUrls: List<PostDetailAttachmentPresignedUrlResponse> = emptyList(),
+        ): PostDetailV2Response =
+            PostDetailV2Response(
+                id = post.id!!,
+                title = post.title,
+                content = post.content,
+                author = AuthorResponse.from(post.author, authorProfileImageUrl),
+                category = post.category?.let { CategoryResponse.from(it) },
+                tags = post.tags.map { PostListTagResponse.from(it) },
+                viewCount = post.viewCount,
+                likeCount = post.likeCount,
+                commentCount = post.commentCount,
+                status = post.status,
+                attachmentPresignedUrls = attachmentPresignedUrls,
+                createdAt = post.createdAt,
+                updatedAt = post.updatedAt,
+            )
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostListItemV2Response.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostListItemV2Response.kt
@@ -1,0 +1,40 @@
+package com.techtaurant.mainserver.post.dto
+
+import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.Date
+import java.util.UUID
+
+@Schema(description = "게시물 목록 아이템 v2 - 사용자별 필드 제외")
+data class PostListItemV2Response(
+    @field:Schema(description = "게시물 ID")
+    val id: UUID,
+    @field:Schema(description = "게시물 제목")
+    val title: String,
+    @field:Schema(description = "게시물 내용 일부 (최대 2000자)")
+    val content: String,
+    @field:Schema(description = "작성자 ID")
+    val authorId: UUID,
+    @field:Schema(description = "작성자 이름")
+    val authorName: String,
+    @field:Schema(description = "작성자 프로필 이미지 URL")
+    val authorProfileImageUrl: String,
+    @field:Schema(description = "게시물 썸네일 이미지 URL")
+    val thumbnailUrl: String,
+    @field:Schema(description = "게시물 카테고리")
+    val category: CategoryResponse?,
+    @field:Schema(description = "태그 목록")
+    val tags: List<PostListTagResponse>,
+    @field:Schema(description = "조회수")
+    val viewCount: Long,
+    @field:Schema(description = "좋아요수")
+    val likeCount: Long,
+    @field:Schema(description = "댓글수")
+    val commentCount: Long,
+    @field:Schema(description = "게시물 상태")
+    val status: PostStatusEnum,
+    @field:Schema(description = "작성일")
+    val createdAt: Date,
+    @field:Schema(description = "최종 수정일")
+    val updatedAt: Date,
+)

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostUserDataResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostUserDataResponse.kt
@@ -1,0 +1,15 @@
+package com.techtaurant.mainserver.post.dto
+
+import com.techtaurant.mainserver.common.enums.LikeStatus
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+@Schema(description = "게시물 사용자 데이터 응답")
+data class PostUserDataResponse(
+    @field:Schema(description = "게시물 ID")
+    val postId: UUID,
+    @field:Schema(description = "현재 사용자의 좋아요 상태")
+    val likeStatus: LikeStatus,
+    @field:Schema(description = "현재 사용자가 읽음 표시한 게시물인지 여부")
+    val isRead: Boolean,
+)

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadV2OpenApiController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadV2OpenApiController.kt
@@ -1,0 +1,73 @@
+package com.techtaurant.mainserver.post.infrastructure.`in`
+
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.dto.CursorPageResponse
+import com.techtaurant.mainserver.common.swagger.ApiErrorResponses
+import com.techtaurant.mainserver.common.util.HttpRequestUtils
+import com.techtaurant.mainserver.post.application.PostDetailReadService
+import com.techtaurant.mainserver.post.application.PostListReadService
+import com.techtaurant.mainserver.post.dto.PostDetailV2Response
+import com.techtaurant.mainserver.post.dto.PostListItemV2Response
+import com.techtaurant.mainserver.post.entity.PostPeriod
+import com.techtaurant.mainserver.post.entity.PostSortType
+import com.techtaurant.mainserver.post.enums.PostStatus
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/open-api/v2/posts")
+@Validated
+class PostReadV2OpenApiController(
+    private val postListReadService: PostListReadService,
+    private val postDetailReadService: PostDetailReadService,
+) : PostReadV2OpenApiControllerDocs {
+    @ApiErrorResponses(includeValidationError = true)
+    @GetMapping
+    override fun getPosts(
+        @RequestParam(required = false) cursor: String?,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(100) size: Int,
+        @RequestParam(defaultValue = "ALL") period: PostPeriod,
+        @RequestParam(defaultValue = "LATEST") sort: PostSortType,
+        @RequestParam(required = false) authorId: UUID?,
+        @RequestParam(required = false) categoryId: UUID?,
+        @RequestParam(required = false) tagIds: List<UUID>?,
+    ): ApiResponse<CursorPageResponse<PostListItemV2Response>> {
+        return ApiResponse.ok(
+            postListReadService.getPublicPostsV2(
+                cursor = cursor,
+                size = size,
+                period = period,
+                sortType = sort,
+                authorId = authorId,
+                categoryId = categoryId,
+                tagIds = tagIds,
+            ),
+        )
+    }
+
+    @ApiErrorResponses(posts = [PostStatus.POST_NOT_FOUND])
+    @GetMapping("/{postId}")
+    override fun getPostDetail(
+        @PathVariable postId: UUID,
+        request: HttpServletRequest,
+    ): ApiResponse<PostDetailV2Response> {
+        val ipAddress = HttpRequestUtils.extractIpAddress(request)
+        val userAgent = request.getHeader("User-Agent")
+
+        return ApiResponse.ok(
+            postDetailReadService.getPublicPostDetailV2(
+                postId = postId,
+                ipAddress = ipAddress,
+                userAgent = userAgent,
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadV2OpenApiControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadV2OpenApiControllerDocs.kt
@@ -1,0 +1,62 @@
+package com.techtaurant.mainserver.post.infrastructure.`in`
+
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.dto.CursorPageResponse
+import com.techtaurant.mainserver.common.status.DefaultStatus
+import com.techtaurant.mainserver.common.swagger.ApiCommonBadRequestAndUnknown
+import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponse
+import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponses
+import com.techtaurant.mainserver.post.dto.PostDetailV2Response
+import com.techtaurant.mainserver.post.dto.PostListItemV2Response
+import com.techtaurant.mainserver.post.entity.PostPeriod
+import com.techtaurant.mainserver.post.entity.PostSortType
+import com.techtaurant.mainserver.post.enums.PostStatus
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import java.util.UUID
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "게시물 v2", description = "SSG/ISR용 게시물 public API")
+interface PostReadV2OpenApiControllerDocs {
+    @Operation(
+        summary = "게시물 목록 조회 v2",
+        description = "SSG/ISR에 사용할 수 있도록 로그인 사용자별 필드(isRead)를 제외한 공개 게시물 목록을 조회합니다.",
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+    )
+    @ApiCommonBadRequestAndUnknown
+    fun getPosts(
+        @Parameter(description = "이전 응답의 nextCursor (첫 페이지는 생략)") cursor: String?,
+        @Parameter(description = "페이지 크기 (1-100, 기본값 20)") @Min(1) @Max(100) size: Int,
+        @Parameter(description = "기간 필터 (WEEK: 7일, MONTH: 30일, YEAR: 365일, ALL: 전체)") period: PostPeriod,
+        @Parameter(description = "정렬 기준 (LATEST: 최신순, VIEW: 조회순, LIKE: 추천순, COMMENT: 댓글순)") sort: PostSortType,
+        @Parameter(description = "작성자 ID 필터 (생략 시 전체 조회)") authorId: UUID?,
+        @Parameter(description = "카테고리 ID 필터 (authorId 지정 시에만 적용, 생략 시 전체)") categoryId: UUID?,
+        @Parameter(description = "태그 UUID 필터 (여러 개 전달 시 OR 조건으로 조회)") tagIds: List<UUID>?,
+    ): ApiResponse<CursorPageResponse<PostListItemV2Response>>
+
+    @Operation(
+        summary = "게시물 상세 조회 v2",
+        description = "SSG/ISR에 사용할 수 있도록 로그인 사용자별 필드(likeStatus, isRead)를 제외한 공개 게시물 상세를 조회합니다.",
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+    )
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(PostStatus::class, ["POST_NOT_FOUND"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun getPostDetail(
+        @Parameter(description = "게시물 ID") postId: UUID,
+        request: HttpServletRequest,
+    ): ApiResponse<PostDetailV2Response>
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostUserDataController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostUserDataController.kt
@@ -1,0 +1,30 @@
+package com.techtaurant.mainserver.post.infrastructure.`in`
+
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.swagger.ApiErrorResponses
+import com.techtaurant.mainserver.post.application.PostDetailReadService
+import com.techtaurant.mainserver.post.dto.PostUserDataResponse
+import com.techtaurant.mainserver.post.enums.PostStatus
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/posts")
+@Validated
+class PostUserDataController(
+    private val postDetailReadService: PostDetailReadService,
+) : PostUserDataControllerDocs {
+    @ApiErrorResponses(posts = [PostStatus.POST_NOT_FOUND], includeAuthenticationErrors = true)
+    @GetMapping("/{postId}/user-data")
+    override fun getPostUserData(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable postId: UUID,
+    ): ApiResponse<PostUserDataResponse> {
+        return ApiResponse.ok(postDetailReadService.getPostUserData(postId, userId))
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostUserDataControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostUserDataControllerDocs.kt
@@ -1,0 +1,37 @@
+package com.techtaurant.mainserver.post.infrastructure.`in`
+
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.status.DefaultStatus
+import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponse
+import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponses
+import com.techtaurant.mainserver.post.dto.PostUserDataResponse
+import com.techtaurant.mainserver.post.enums.PostStatus
+import com.techtaurant.mainserver.security.jwt.JwtStatus
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import java.util.UUID
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "게시물 사용자 데이터", description = "게시물 인증 사용자별 데이터 API")
+interface PostUserDataControllerDocs {
+    @Operation(
+        summary = "게시물 사용자 데이터 조회",
+        description = "로그인 사용자 기준 게시물 likeStatus와 isRead를 조회합니다. SSG/ISR용 게시물 public API와 분리해서 호출합니다.",
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+    )
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED"]),
+            ApiErrorCodeResponse(PostStatus::class, ["POST_NOT_FOUND"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun getPostUserData(
+        userId: UUID,
+        @Parameter(description = "게시물 ID") postId: UUID,
+    ): ApiResponse<PostUserDataResponse>
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentLikeControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentLikeControllerIntegrationTest.kt
@@ -14,11 +14,14 @@ import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
 import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import io.restassured.RestAssured.given
 import io.restassured.http.ContentType
 import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -35,6 +38,9 @@ import java.util.UUID
 class CommentLikeControllerIntegrationTest : IntegrationTest() {
     @Autowired
     private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var userBanRepository: UserBanRepository
 
     @Autowired
     private lateinit var postRepository: PostRepository
@@ -138,6 +144,57 @@ class CommentLikeControllerIntegrationTest : IntegrationTest() {
         val log = commentLikeLogRepository.findByCommentIdAndUserId(testComment.id!!, testUser.id!!)
         assertThat(log).isNotNull
         assertThat(log?.isLiked).isTrue()
+    }
+
+    @Test
+    @DisplayName("댓글 사용자 데이터 조회 성공 - likeStatus와 isBannedAuthor를 반환한다")
+    fun getCommentUserData_withAuthentication_shouldReturnUserData() {
+        // Given
+        val blockedUser =
+            userRepository.save(
+                User(
+                    name = "차단된사용자",
+                    email = "blocked@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "blocked-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/blocked-profile.jpg",
+                ),
+            )
+        val blockedComment =
+            commentRepository.save(
+                Comment(
+                    content = "차단된 작성자의 댓글",
+                    post = testPost,
+                    author = blockedUser,
+                    parent = null,
+                    depth = 0,
+                ),
+            )
+        userBanRepository.save(UserBan(user = testUser, bannedUser = blockedUser))
+        commentLikeLogService.recordLike(blockedComment.id!!, testUser.id!!, LikeStatus.LIKE)
+
+        // When & Then
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .get("/api/comments/${blockedComment.id}/user-data")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.commentId", equalTo(blockedComment.id.toString()))
+            .body("data.likeStatus", equalTo("LIKE"))
+            .body("data.isBannedAuthor", equalTo(true))
+    }
+
+    @Test
+    @DisplayName("댓글 사용자 데이터 조회 실패 - 인증되지 않은 사용자")
+    fun getCommentUserData_withoutAuthentication_shouldReturnUnauthorized() {
+        // When & Then
+        given()
+            .`when`()
+            .get("/api/comments/${testComment.id}/user-data")
+            .then()
+            .statusCode(HttpStatus.UNAUTHORIZED.value())
     }
 
     @Test

--- a/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadControllerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadControllerTest.kt
@@ -17,6 +17,8 @@ import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import io.restassured.RestAssured
 import io.restassured.common.mapper.TypeRef
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -374,6 +376,60 @@ class CommentReadControllerTest : IntegrationTest() {
         assertEquals(13, maskedComment.content.length)
         assertEquals(null, maskedComment.authorProfileImageUrl)
         assertTrue(maskedComment.authorId != blockedUser.id)
+    }
+
+    @Test
+    @DisplayName("v2 부모 댓글 목록은 사용자별 likeStatus/isBanned와 차단 마스킹을 포함하지 않는다")
+    fun getParentCommentsV2_returnsOnlyPublicFields() {
+        // Given
+        val blockedComment =
+            commentRepository.save(
+                Comment(
+                    content = "차단된 댓글 내용",
+                    post = testPost,
+                    author = blockedUser,
+                    parent = null,
+                    depth = 0,
+                ),
+            )
+        userBanRepository.save(UserBan(user = testUser, bannedUser = blockedUser))
+
+        // When & Then
+        RestAssured
+            .given()
+            .header("Authorization", "Bearer $accessToken")
+            .queryParam("sort", "LATEST")
+            .queryParam("size", 10)
+            .`when`()
+            .get("/open-api/v2/comments/posts/${testPost.id}")
+            .then()
+            .statusCode(200)
+            .body("data.content.find { it.id == '${blockedComment.id}' }.likeStatus", nullValue())
+            .body("data.content.find { it.id == '${blockedComment.id}' }.isBanned", nullValue())
+            .body("data.content.find { it.id == '${blockedComment.id}' }.authorName", equalTo("Blocked User"))
+            .body("data.content.find { it.id == '${blockedComment.id}' }.content", equalTo("차단된 댓글 내용"))
+            .body("data.content.find { it.id == '${blockedComment.id}' }.authorId", equalTo(blockedUser.id.toString()))
+    }
+
+    @Test
+    @DisplayName("v2 대댓글 목록은 사용자별 likeStatus/isBanned를 포함하지 않는다")
+    fun getRepliesV2_returnsOnlyPublicFields() {
+        // Given
+        val parentComment = parentComments[0]
+        val reply = createTestReplies(parentComment).first()
+
+        // When & Then
+        RestAssured
+            .given()
+            .header("Authorization", "Bearer $accessToken")
+            .queryParam("sort", "LATEST")
+            .queryParam("size", 10)
+            .`when`()
+            .get("/open-api/v2/comments/${parentComment.id}/replies")
+            .then()
+            .statusCode(200)
+            .body("data.content.find { it.id == '${reply.id}' }.likeStatus", nullValue())
+            .body("data.content.find { it.id == '${reply.id}' }.isBanned", nullValue())
     }
 
     @Nested

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostLikeControllerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostLikeControllerTest.kt
@@ -7,9 +7,11 @@ import com.techtaurant.mainserver.post.dto.RecordPostLikeRequest
 import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostLikeLog
+import com.techtaurant.mainserver.post.entity.PostReadLog
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.CategoryRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostLikeLogRepository
+import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
@@ -19,6 +21,7 @@ import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import io.restassured.RestAssured
 import io.restassured.common.mapper.TypeRef
 import io.restassured.http.ContentType
+import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -32,6 +35,9 @@ import kotlin.test.assertNotNull
 class PostLikeControllerTest : IntegrationTest() {
     @Autowired
     private lateinit var postLikeLogRepository: PostLikeLogRepository
+
+    @Autowired
+    private lateinit var postReadLogRepository: PostReadLogRepository
 
     @Autowired
     private lateinit var postRepository: PostRepository
@@ -52,6 +58,7 @@ class PostLikeControllerTest : IntegrationTest() {
     @BeforeEach
     fun setup() {
         // Cleanup in correct order (foreign key constraints)
+        postReadLogRepository.deleteAllInBatch()
         postLikeLogRepository.deleteAllInBatch()
         postRepository.deleteAllInBatch()
         categoryRepository.deleteAllInBatch()
@@ -133,6 +140,38 @@ class PostLikeControllerTest : IntegrationTest() {
         // Then: DB에서 좋아요 로그가 삭제되었는지 확인
         val deletedLog = postLikeLogRepository.findById(likeLogId)
         assertFalse(deletedLog.isPresent, "좋아요 로그가 DB에서 삭제되어야 함")
+    }
+
+    @Test
+    @DisplayName("게시물 사용자 데이터 조회 성공 - likeStatus와 isRead를 반환한다")
+    fun getPostUserData_withAuthentication_shouldReturnUserData() {
+        // Given
+        postLikeLogRepository.save(PostLikeLog(post = testPost, user = testUser, isLiked = true))
+        postReadLogRepository.save(PostReadLog(postId = testPost.id!!, user = testUser))
+
+        // When & Then
+        RestAssured
+            .given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .get("/api/posts/${testPost.id}/user-data")
+            .then()
+            .statusCode(200)
+            .body("data.postId", equalTo(testPost.id.toString()))
+            .body("data.likeStatus", equalTo("LIKE"))
+            .body("data.isRead", equalTo(true))
+    }
+
+    @Test
+    @DisplayName("게시물 사용자 데이터 조회 실패 - JWT 토큰 없이 요청하면 401 UNAUTHORIZED 반환")
+    fun getPostUserData_withoutAuthentication_shouldReturn401() {
+        // When & Then
+        RestAssured
+            .given()
+            .`when`()
+            .get("/api/posts/${testPost.id}/user-data")
+            .then()
+            .statusCode(401)
     }
 
     @Test

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
@@ -3,6 +3,8 @@ package com.techtaurant.mainserver.post.infrastructure.`in`
 import com.techtaurant.mainserver.base.IntegrationTest
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import com.techtaurant.mainserver.post.entity.PostLikeLog
+import com.techtaurant.mainserver.post.infrastructure.out.PostLikeLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
@@ -14,6 +16,7 @@ import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import io.restassured.RestAssured.given
 import org.hamcrest.Matchers.hasItem
 import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -30,6 +33,9 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
     private lateinit var postRepository: PostRepository
 
     @Autowired
+    private lateinit var postLikeLogRepository: PostLikeLogRepository
+
+    @Autowired
     private lateinit var jwtTokenProvider: JwtTokenProvider
 
     @Autowired
@@ -42,6 +48,7 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
     @BeforeEach
     fun setUpTestData() {
         userBanRepository.deleteAllInBatch()
+        postLikeLogRepository.deleteAllInBatch()
         postRepository.deleteAllInBatch()
         userRepository.deleteAllInBatch()
         testUser =
@@ -113,6 +120,68 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
             .body("data.content.id", hasItem(myPrivatePost.id.toString()))
             .body("data.content.id", hasItem(myPublishedPost.id.toString()))
             .body("data.content.id", not(hasItem(otherPrivatePost.id.toString())))
+    }
+
+    @Test
+    @DisplayName("v2 게시물 목록은 인증 헤더가 있어도 공개 게시물만 반환하고 isRead를 포함하지 않는다")
+    fun getPostsV2_withAuthentication_returnsOnlyPublicFields() {
+        // given
+        val myPrivatePost =
+            postRepository.save(
+                Post(
+                    title = "내 비공개 게시물",
+                    content = "비공개 내용",
+                    author = testUser,
+                    status = PostStatusEnum.PRIVATE,
+                ),
+            )
+        val myPublishedPost =
+            postRepository.save(
+                Post(
+                    title = "내 공개 게시물",
+                    content = "공개 내용",
+                    author = testUser,
+                    status = PostStatusEnum.PUBLISHED,
+                ),
+            )
+
+        // when & then
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .get("/open-api/v2/posts")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.content.id", hasItem(myPublishedPost.id.toString()))
+            .body("data.content.id", not(hasItem(myPrivatePost.id.toString())))
+            .body("data.content[0].isRead", nullValue())
+    }
+
+    @Test
+    @DisplayName("v2 게시물 상세는 likeStatus와 isRead를 포함하지 않는다")
+    fun getPostDetailV2_returnsOnlyPublicFields() {
+        // given
+        val post =
+            postRepository.save(
+                Post(
+                    title = "공개 게시물",
+                    content = "공개 내용",
+                    author = testUser,
+                    status = PostStatusEnum.PUBLISHED,
+                ),
+            )
+        postLikeLogRepository.save(PostLikeLog(post = post, user = testUser, isLiked = true))
+
+        // when & then
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .`when`()
+            .get("/open-api/v2/posts/${post.id}")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.id", org.hamcrest.Matchers.`is`(post.id.toString()))
+            .body("data.likeStatus", nullValue())
+            .body("data.isRead", nullValue())
     }
 
     @Test


### PR DESCRIPTION
## 어떤 작업인가요?
- SSG/ISR 캐시 오염을 막기 위해 게시물/댓글 조회 응답에서 사용자별 상태를 분리한 v2 API를 추가합니다.

## 어떻게 해결했나요?
**public v2 조회 API 추가**
- 게시물 목록/상세와 댓글 목록에 `/open-api/v2/**` 경로를 추가했습니다.
- public v2 응답에서는 로그인 사용자별 필드인 `isRead`, `likeStatus`, `isBanned`를 제거했습니다.
- 댓글 v2 목록은 사용자별 차단 상태에 따른 마스킹을 적용하지 않도록 분리했습니다.

**인증 사용자 데이터 API 추가**
- 게시물 사용자 데이터 조회 API `GET /api/posts/{postId}/user-data`를 추가했습니다.
- 댓글 사용자 데이터 조회 API `GET /api/comments/{commentId}/user-data`를 추가했습니다.
- 사용자별 상태는 인증 API에서만 계산하도록 서비스 메서드와 응답 DTO를 분리했습니다.

**회귀 테스트 추가**
- v2 public API가 사용자별 필드를 포함하지 않는지 검증하는 테스트를 추가했습니다.
- user-data API가 인증 사용자 기준 상태를 반환하고 비인증 요청을 거부하는지 검증했습니다.

## 중요한 변경 사항은 무엇인가요?
### public 응답과 사용자 데이터 분리

**게시물 목록 v2에서 `isRead` 제거**
- **변경 이유**: 읽음 여부는 로그인 사용자별 데이터라 SSG/ISR 대상 응답에 포함되면 URL 캐시 결과가 사용자마다 달라질 수 있습니다.
- **수정 파일**: `PostListItemV2Response.kt`, `PostListReadService.kt`, `PostReadV2OpenApiController.kt`

**게시물 상세 v2에서 `likeStatus`, `isRead` 제거**
- **변경 이유**: 좋아요 상태와 읽음 여부는 로그인 사용자별 상태이므로 별도 인증 API로 분리해야 합니다.
- **수정 파일**: `PostDetailV2Response.kt`, `PostDetailReadService.kt`, `PostReadV2OpenApiController.kt`

**댓글 목록 v2에서 `likeStatus`, `isBanned`, 차단 마스킹 제거**
- **변경 이유**: 댓글 좋아요 상태와 차단 마스킹은 조회 사용자별로 달라져 public 캐시 응답에 적합하지 않습니다.
- **수정 파일**: `CommentListV2Response.kt`, `CommentReadService.kt`, `CommentResponseAssembler.kt`, `CommentReadV2OpenApiController.kt`

### 인증 사용자 데이터 API 추가

**게시물 사용자 데이터 API**
- **변경 이유**: public 게시물 응답에서 제거한 사용자별 상태를 CSR 또는 동적 컴포넌트에서 별도로 조회할 수 있어야 합니다.
- **수정 파일**: `PostUserDataResponse.kt`, `PostUserDataController.kt`, `PostUserDataControllerDocs.kt`

**댓글 사용자 데이터 API**
- **변경 이유**: public 댓글 응답과 별도로 로그인 사용자 기준 좋아요 상태와 작성자 차단 여부를 조회할 수 있어야 합니다.
- **수정 파일**: `CommentUserDataResponse.kt`, `CommentUserDataController.kt`, `CommentUserDataControllerDocs.kt`

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.

Co-authored-by: OpenAI Codex <codex@openai.com>
