### PR TITLE
modify(config): prod 환경에서 개발용 도구 비활성화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,7 +43,7 @@ COOKIE_PATH=/
 SWAGGER_BASE_URL=http://localhost:8080
 
 # Monitoring
-# prod로 설정하면 Swagger UI/API docs와 p6spy SQL logging이 비활성화됩니다.
+# prod로 설정하면 Swagger UI/API docs, p6spy SQL logging, 개발용 테스트 인증 API가 비활성화됩니다.
 APP_ENVIRONMENT=dev
 MONITORING_METRICS_USERNAME=prometheus
 MONITORING_METRICS_PASSWORD=change-me-prometheus-password

--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,7 @@ COOKIE_PATH=/
 SWAGGER_BASE_URL=http://localhost:8080
 
 # Monitoring
+# prod로 설정하면 Swagger UI/API docs와 p6spy SQL logging이 비활성화됩니다.
 APP_ENVIRONMENT=dev
 MONITORING_METRICS_USERNAME=prometheus
 MONITORING_METRICS_PASSWORD=change-me-prometheus-password

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentMetadataOpenApiControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentMetadataOpenApiControllerDocs.kt
@@ -16,7 +16,7 @@ interface CommentMetadataOpenApiControllerDocs {
         summary = "댓글 공개 메타데이터 목록 조회",
         description =
             "commentIds에 해당하는 댓글의 공개 동적 메타데이터를 batch로 조회합니다. " +
-            "좋아요수, 대댓글수, 삭제 여부를 반환합니다. 존재하지 않는 댓글은 응답에서 제외됩니다.",
+                "좋아요수, 대댓글수, 삭제 여부를 반환합니다. 존재하지 않는 댓글은 응답에서 제외됩니다.",
     )
     @SwaggerApiResponse(
         responseCode = "200",

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadOpenApiV2ControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadOpenApiV2ControllerDocs.kt
@@ -18,7 +18,7 @@ interface CommentReadOpenApiV2ControllerDocs {
     @Operation(
         summary = "부모 댓글 공개 콘텐츠 목록 조회",
         description =
-                "SSG/ISR 캐싱에 적합한 부모 댓글 공개 콘텐츠 목록을 조회합니다. " +
+            "SSG/ISR 캐싱에 적합한 부모 댓글 공개 콘텐츠 목록을 조회합니다. " +
                 "좋아요수, 대댓글수, 삭제 여부는 GET /open-api/comments/metadatas?commentIds=... API로 분리되었습니다. " +
                 "작성자 이름과 프로필 이미지는 GET /open-api/users/profile-images?userIds=... API를 사용하세요. " +
                 "로그인 사용자의 좋아요/차단 상태는 GET /api/comments/me/states?commentIds=... API를 사용하세요.",
@@ -38,7 +38,7 @@ interface CommentReadOpenApiV2ControllerDocs {
     @Operation(
         summary = "대댓글 공개 콘텐츠 목록 조회",
         description =
-                "SSG/ISR 캐싱에 적합한 대댓글 공개 콘텐츠 목록을 조회합니다. " +
+            "SSG/ISR 캐싱에 적합한 대댓글 공개 콘텐츠 목록을 조회합니다. " +
                 "좋아요수, 대댓글수, 삭제 여부는 GET /open-api/comments/metadatas?commentIds=... API로 분리되었습니다. " +
                 "작성자 이름과 프로필 이미지는 GET /open-api/users/profile-images?userIds=... API를 사용하세요. " +
                 "로그인 사용자의 좋아요/차단 상태는 GET /api/comments/me/states?commentIds=... API를 사용하세요.",

--- a/src/main/kotlin/com/techtaurant/mainserver/config/ProductionToolingDisableEnvironmentPostProcessor.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/config/ProductionToolingDisableEnvironmentPostProcessor.kt
@@ -1,0 +1,39 @@
+package com.techtaurant.mainserver.config
+
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.env.EnvironmentPostProcessor
+import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.core.env.MapPropertySource
+
+class ProductionToolingDisableEnvironmentPostProcessor : EnvironmentPostProcessor {
+    override fun postProcessEnvironment(
+        environment: ConfigurableEnvironment,
+        application: SpringApplication,
+    ) {
+        val appEnvironment = environment.getProperty(APP_ENVIRONMENT_PROPERTY)?.trim()
+        if (!appEnvironment.equals(PROD_ENVIRONMENT, ignoreCase = true)) {
+            return
+        }
+
+        environment.propertySources.addFirst(
+            MapPropertySource(
+                PROPERTY_SOURCE_NAME,
+                mapOf(
+                    SPRINGDOC_API_DOCS_ENABLED_PROPERTY to FALSE_VALUE,
+                    SPRINGDOC_SWAGGER_UI_ENABLED_PROPERTY to FALSE_VALUE,
+                    P6SPY_ENABLE_LOGGING_PROPERTY to FALSE_VALUE,
+                ),
+            ),
+        )
+    }
+
+    companion object {
+        private const val PROPERTY_SOURCE_NAME = "productionToolingDisableOverrides"
+        private const val APP_ENVIRONMENT_PROPERTY = "app.environment"
+        private const val PROD_ENVIRONMENT = "prod"
+        private const val SPRINGDOC_API_DOCS_ENABLED_PROPERTY = "springdoc.api-docs.enabled"
+        private const val SPRINGDOC_SWAGGER_UI_ENABLED_PROPERTY = "springdoc.swagger-ui.enabled"
+        private const val P6SPY_ENABLE_LOGGING_PROPERTY = "decorator.datasource.p6spy.enable-logging"
+        private const val FALSE_VALUE = "false"
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/security/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/config/SwaggerConfig.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
 import org.springdoc.core.customizers.OpenApiCustomizer
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -21,6 +22,7 @@ import org.springframework.context.annotation.Configuration
  * baseUrl은 환경 변수 SWAGGER_BASE_URL에서 로드되며, 기본값은 http://localhost:8080
  */
 @Configuration
+@ConditionalOnProperty(name = ["springdoc.api-docs.enabled"], havingValue = "true", matchIfMissing = true)
 class SwaggerConfig(
     @param:Value("\${swagger.base-url}")
     private val swaggerBaseUrl: String,

--- a/src/main/kotlin/com/techtaurant/mainserver/security/infrastructure/in/DevTestAuthController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/infrastructure/in/DevTestAuthController.kt
@@ -9,6 +9,7 @@ import com.techtaurant.mainserver.security.dto.DevTestLoginResponse
 import com.techtaurant.mainserver.security.service.DevTestAuthService
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.context.annotation.Profile
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -18,10 +19,11 @@ import org.springframework.web.bind.annotation.RestController
 /**
  * 개발 환경 전용 테스트 인증 컨트롤러
  *
- * prod 프로파일이 아닌 환경에서 테스트 사용자로 JWT 토큰을 발급받을 수 있다.
+ * prod 프로파일과 app.environment=prod가 아닌 환경에서 테스트 사용자로 JWT 토큰을 발급받을 수 있다.
  */
 @RestController
 @Profile("!prod")
+@ConditionalOnExpression("!'\${app.environment:dev}'.trim().equalsIgnoreCase('prod')")
 @RequestMapping("${SecurityConstants.OPEN_API_PREFIX}/dev/auth")
 class DevTestAuthController(
     private val devTestAuthService: DevTestAuthService,

--- a/src/main/kotlin/com/techtaurant/mainserver/security/service/DevTestAuthService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/service/DevTestAuthService.kt
@@ -14,6 +14,7 @@ import com.techtaurant.mainserver.user.application.UserUniqueNameService
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.context.annotation.Profile
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.stereotype.Service
@@ -23,10 +24,11 @@ import org.springframework.transaction.annotation.Transactional
  * 개발 환경 전용 테스트 인증 서비스
  *
  * 테스트 사용자를 조회하거나 생성하고 JWT 토큰을 쿠키로 발급한다.
- * prod 프로파일이 아닌 환경에서만 빈이 등록된다.
+ * prod 프로파일과 app.environment=prod가 아닌 환경에서만 빈이 등록된다.
  */
 @Service
 @Profile("!prod")
+@ConditionalOnExpression("!'\${app.environment:dev}'.trim().equalsIgnoreCase('prod')")
 class DevTestAuthService(
     private val userRepository: UserRepository,
     private val jwtTokenProvider: JwtTokenProvider,

--- a/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserPostOpenApiV2ControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/infrastructure/in/UserPostOpenApiV2ControllerDocs.kt
@@ -19,7 +19,7 @@ interface UserPostOpenApiV2ControllerDocs {
     @Operation(
         summary = "사용자 게시물 정적 콘텐츠 목록 조회",
         description =
-                "특정 사용자의 PUBLISHED 게시물 정적 콘텐츠 목록을 커서 기반 페이지네이션으로 조회합니다. " +
+            "특정 사용자의 PUBLISHED 게시물 정적 콘텐츠 목록을 커서 기반 페이지네이션으로 조회합니다. " +
                 "조회수, 좋아요수, 댓글수, 상태, 썸네일/첨부 presigned URL은 " +
                 "GET /open-api/posts/metadatas?postIds=... API로, 작성자 이름과 프로필 이미지는 " +
                 "GET /open-api/users/profile-images?userIds=... API로 분리되었습니다. " +

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.env.EnvironmentPostProcessor=\
-com.techtaurant.mainserver.config.LocalOtelDisableEnvironmentPostProcessor
+com.techtaurant.mainserver.config.LocalOtelDisableEnvironmentPostProcessor,\
+com.techtaurant.mainserver.config.ProductionToolingDisableEnvironmentPostProcessor

--- a/src/test/kotlin/com/techtaurant/mainserver/config/LocalOtelDisableEnvironmentPostProcessorTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/config/LocalOtelDisableEnvironmentPostProcessorTest.kt
@@ -52,7 +52,10 @@ class LocalOtelDisableEnvironmentPostProcessorTest {
     fun springApplication_localEnvironment_disablesOtelThroughRegisteredPostProcessor() {
         val context =
             SpringApplicationBuilder(TestApplication::class.java)
-                .properties("app.environment=local")
+                .properties(
+                    "spring.config.location=optional:classpath:/empty-application.yml",
+                    "app.environment=local",
+                )
                 .web(WebApplicationType.NONE)
                 .run()
 

--- a/src/test/kotlin/com/techtaurant/mainserver/config/ProductionToolingDisableEnvironmentPostProcessorTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/config/ProductionToolingDisableEnvironmentPostProcessorTest.kt
@@ -1,0 +1,73 @@
+package com.techtaurant.mainserver.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.WebApplicationType
+import org.springframework.boot.builder.SpringApplicationBuilder
+import org.springframework.context.annotation.Configuration
+import org.springframework.mock.env.MockEnvironment
+
+class ProductionToolingDisableEnvironmentPostProcessorTest {
+    private val postProcessor = ProductionToolingDisableEnvironmentPostProcessor()
+
+    @Test
+    @DisplayName("app.environment가 prod이면 Swagger와 p6spy SQL logging을 비활성화한다")
+    fun postProcessEnvironment_prodEnvironment_disablesSwaggerAndP6spyLogging() {
+        // given
+        val environment = MockEnvironment().withProperty("app.environment", " prod ")
+
+        // when
+        postProcessor.postProcessEnvironment(environment, SpringApplication())
+
+        // then
+        assertThat(environment.getProperty("springdoc.api-docs.enabled")).isEqualTo("false")
+        assertThat(environment.getProperty("springdoc.swagger-ui.enabled")).isEqualTo("false")
+        assertThat(environment.getProperty("decorator.datasource.p6spy.enable-logging")).isEqualTo("false")
+    }
+
+    @Test
+    @DisplayName("app.environment가 prod가 아니면 기존 Swagger와 p6spy 설정을 유지한다")
+    fun postProcessEnvironment_nonProdEnvironment_keepsExistingToolingConfiguration() {
+        // given
+        val environment =
+            MockEnvironment()
+                .withProperty("app.environment", "dev")
+                .withProperty("springdoc.api-docs.enabled", "true")
+                .withProperty("springdoc.swagger-ui.enabled", "true")
+                .withProperty("decorator.datasource.p6spy.enable-logging", "true")
+
+        // when
+        postProcessor.postProcessEnvironment(environment, SpringApplication())
+
+        // then
+        assertThat(environment.getProperty("springdoc.api-docs.enabled")).isEqualTo("true")
+        assertThat(environment.getProperty("springdoc.swagger-ui.enabled")).isEqualTo("true")
+        assertThat(environment.getProperty("decorator.datasource.p6spy.enable-logging")).isEqualTo("true")
+    }
+
+    @Test
+    @DisplayName("spring.factories에 등록된 후처리기가 prod 환경에서 자동으로 Swagger와 p6spy SQL logging을 비활성화한다")
+    fun springApplication_prodEnvironment_disablesSwaggerAndP6spyLoggingThroughRegisteredPostProcessor() {
+        val context =
+            SpringApplicationBuilder(TestApplication::class.java)
+                .properties(
+                    "spring.config.location=optional:classpath:/empty-application.yml",
+                    "app.environment=prod",
+                )
+                .web(WebApplicationType.NONE)
+                .run()
+
+        try {
+            assertThat(context.environment.getProperty("springdoc.api-docs.enabled")).isEqualTo("false")
+            assertThat(context.environment.getProperty("springdoc.swagger-ui.enabled")).isEqualTo("false")
+            assertThat(context.environment.getProperty("decorator.datasource.p6spy.enable-logging")).isEqualTo("false")
+        } finally {
+            context.close()
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    private class TestApplication
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/security/infrastructure/in/DevTestAuthControllerConditionTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/infrastructure/in/DevTestAuthControllerConditionTest.kt
@@ -1,0 +1,73 @@
+package com.techtaurant.mainserver.security.infrastructure.`in`
+
+import com.techtaurant.mainserver.security.cache.TokenCachePort
+import com.techtaurant.mainserver.security.helper.CookieHelper
+import com.techtaurant.mainserver.security.jwt.JwtProperties
+import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
+import com.techtaurant.mainserver.security.service.DevTestAuthService
+import com.techtaurant.mainserver.user.application.UserUniqueNameService
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+
+class DevTestAuthControllerConditionTest {
+    private val contextRunner =
+        ApplicationContextRunner()
+            .withUserConfiguration(TestConfiguration::class.java)
+
+    @Test
+    @DisplayName("app.environment가 prod이면 개발 테스트 인증 빈을 등록하지 않는다")
+    fun appEnvironmentProd_doesNotRegisterDevTestAuthBeans() {
+        contextRunner
+            .withPropertyValues("app.environment=prod")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(DevTestAuthController::class.java)
+                assertThat(context).doesNotHaveBean(DevTestAuthService::class.java)
+            }
+    }
+
+    @Test
+    @DisplayName("app.environment가 prod가 아니면 개발 테스트 인증 빈을 등록한다")
+    fun appEnvironmentNonProd_registersDevTestAuthBeans() {
+        contextRunner
+            .withPropertyValues("app.environment=dev")
+            .run { context ->
+                assertThat(context).hasSingleBean(DevTestAuthController::class.java)
+                assertThat(context).hasSingleBean(DevTestAuthService::class.java)
+            }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @Import(DevTestAuthController::class, DevTestAuthService::class)
+    private class TestConfiguration {
+        @Bean
+        fun userRepository(): UserRepository = mockk(relaxed = true)
+
+        @Bean
+        fun jwtTokenProvider(): JwtTokenProvider = mockk(relaxed = true)
+
+        @Bean
+        fun jwtProperties(): JwtProperties {
+            return JwtProperties(
+                secret = "test-secret",
+                accessTokenExpireMs = 3600000,
+                refreshTokenExpireMs = 604800000,
+            )
+        }
+
+        @Bean
+        fun cookieHelper(): CookieHelper = mockk(relaxed = true)
+
+        @Bean
+        fun tokenCacheManager(): TokenCachePort = mockk(relaxed = true)
+
+        @Bean
+        fun userUniqueNameService(): UserUniqueNameService = mockk(relaxed = true)
+    }
+}


### PR DESCRIPTION
## 어떤 작업인가요?
- `APP_ENVIRONMENT=prod` 환경에서 운영에 노출되면 안 되는 개발용 도구와 개발용 테스트 인증 API를 비활성화합니다.

## 어떻게 해결했나요?
**prod 환경 후처리기 추가**
- `app.environment`가 `prod`이면 Springdoc API docs, Swagger UI, p6spy SQL logging 설정을 `false`로 우선 적용합니다.
- 후처리기를 `spring.factories`에 등록해 애플리케이션 환경 준비 단계에서 적용되도록 했습니다.

**Swagger 설정 조건화**
- `springdoc.api-docs.enabled=false`이면 프로젝트의 `SwaggerConfig` bean이 생성되지 않도록 조건을 추가했습니다.

**개발용 테스트 인증 API 차단**
- `DevTestAuthController`와 `DevTestAuthService`가 기존 Spring profile `!prod` 조건뿐 아니라 `app.environment=prod`에서도 등록되지 않도록 했습니다.
- 운영자가 `SPRING_PROFILES_ACTIVE=prod`를 누락하고 `APP_ENVIRONMENT=prod`만 설정해도 `/open-api/dev/auth/login` 경로가 열리지 않도록 했습니다.

**회귀 테스트 추가**
- prod 환경에서 개발용 도구 설정이 비활성화되는지 검증했습니다.
- prod가 아닌 환경에서는 기존 설정을 유지하는지 검증했습니다.
- `app.environment=prod`일 때 개발 테스트 인증 controller/service bean이 등록되지 않는지 검증했습니다.
- 후처리기 등록 경로 테스트가 기본 `application.yml` 플레이스홀더에 영향받지 않도록 빈 config location을 지정했습니다.

## 중요한 변경 사항은 무엇인가요?
### prod 환경 개발용 도구 비활성화

**환경값 기반 설정 override**
- **변경 이유**: 운영 환경에서 Swagger 문서와 SQL query logging을 노출하지 않기 위함입니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/config/ProductionToolingDisableEnvironmentPostProcessor.kt`, `src/main/resources/META-INF/spring.factories`

**Swagger bean 생성 조건 추가**
- **변경 이유**: Springdoc endpoint 비활성화와 프로젝트 Swagger bean 설정을 같은 조건으로 맞추기 위함입니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/security/config/SwaggerConfig.kt`

### prod 환경 개발용 테스트 인증 차단

**DevTest 인증 bean 등록 조건 추가**
- **변경 이유**: `APP_ENVIRONMENT=prod`만 설정한 운영 배포에서도 개발용 테스트 로그인 endpoint가 등록되지 않게 하기 위함입니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/security/infrastructure/in/DevTestAuthController.kt`, `src/main/kotlin/com/techtaurant/mainserver/security/service/DevTestAuthService.kt`

**환경 예시와 테스트 보강**
- **변경 이유**: `.env` 사용자가 `prod` 동작을 알 수 있고, 후처리기 및 개발 인증 차단 동작을 회귀 검증하기 위함입니다.
- **수정 파일**: `.env.example`, `src/test/kotlin/com/techtaurant/mainserver/config/ProductionToolingDisableEnvironmentPostProcessorTest.kt`, `src/test/kotlin/com/techtaurant/mainserver/config/LocalOtelDisableEnvironmentPostProcessorTest.kt`, `src/test/kotlin/com/techtaurant/mainserver/security/infrastructure/in/DevTestAuthControllerConditionTest.kt`

Co-Authored-By: Codex <codex@openai.com>
