### PR TITLE
feat(link): 로그인 사용자 상태 조회 API 추가

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkViewerStateReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkViewerStateReadService.kt
@@ -1,0 +1,52 @@
+package com.techtaurant.mainserver.link.application
+
+import com.techtaurant.mainserver.link.dto.LinkViewerStateResponse
+import com.techtaurant.mainserver.link.infrastructure.out.LinkReadLogRepository
+import com.techtaurant.mainserver.link.infrastructure.out.LinkRepository
+import com.techtaurant.mainserver.link.infrastructure.out.UserLinkRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+@Transactional(readOnly = true)
+class LinkViewerStateReadService(
+    private val linkRepository: LinkRepository,
+    private val userLinkRepository: UserLinkRepository,
+    private val linkReadLogRepository: LinkReadLogRepository,
+) {
+    fun getLinkViewerStates(
+        userId: UUID,
+        linkIds: List<UUID>,
+    ): List<LinkViewerStateResponse> {
+        val normalizedLinkIds = linkIds.distinct()
+        if (normalizedLinkIds.isEmpty()) {
+            return emptyList()
+        }
+
+        val linkById = linkRepository.findAllById(normalizedLinkIds).associateBy { it.id!! }
+        val loadedLinkIds = normalizedLinkIds.filter { linkById.containsKey(it) }
+        if (loadedLinkIds.isEmpty()) {
+            return emptyList()
+        }
+
+        val savedLinkIds =
+            userLinkRepository
+                .findByUserIdAndLinkIdIn(userId = userId, linkIds = loadedLinkIds)
+                .map { it.link.id!! }
+                .toSet()
+        val readLinkIds =
+            linkReadLogRepository
+                .findByUserIdAndLinkIdIn(userId = userId, linkIds = loadedLinkIds)
+                .map { it.link.id!! }
+                .toSet()
+
+        return loadedLinkIds.map { linkId ->
+            LinkViewerStateResponse(
+                linkId = linkId,
+                isSaved = linkId in savedLinkIds,
+                isRead = linkId in readLinkIds,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/link/dto/LinkViewerStateResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/dto/LinkViewerStateResponse.kt
@@ -1,0 +1,14 @@
+package com.techtaurant.mainserver.link.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+@Schema(description = "링크 로그인 사용자 상태 응답")
+data class LinkViewerStateResponse(
+    @field:Schema(description = "링크 ID")
+    val linkId: UUID,
+    @field:Schema(description = "로그인한 사용자의 저장 여부")
+    val isSaved: Boolean,
+    @field:Schema(description = "로그인한 사용자의 읽음 여부")
+    val isRead: Boolean,
+)

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkViewerStateController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkViewerStateController.kt
@@ -1,0 +1,31 @@
+package com.techtaurant.mainserver.link.infrastructure.`in`
+
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.swagger.ApiErrorResponses
+import com.techtaurant.mainserver.link.application.LinkViewerStateReadService
+import com.techtaurant.mainserver.link.dto.LinkViewerStateResponse
+import com.techtaurant.mainserver.security.SecurityConstants
+import jakarta.validation.constraints.Size
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("${SecurityConstants.API_PREFIX}/links")
+@Validated
+class LinkViewerStateController(
+    private val linkViewerStateReadService: LinkViewerStateReadService,
+) : LinkViewerStateControllerDocs {
+    @ApiErrorResponses(includeAuthenticationErrors = true, includeValidationError = true)
+    @GetMapping("/me/states")
+    override fun getLinkViewerStates(
+        @AuthenticationPrincipal userId: UUID,
+        @RequestParam @Size(max = 100) linkIds: List<UUID>,
+    ): ApiResponse<List<LinkViewerStateResponse>> {
+        return ApiResponse.ok(linkViewerStateReadService.getLinkViewerStates(userId, linkIds))
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkViewerStateControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkViewerStateControllerDocs.kt
@@ -1,0 +1,41 @@
+package com.techtaurant.mainserver.link.infrastructure.`in`
+
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.status.DefaultStatus
+import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponse
+import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponses
+import com.techtaurant.mainserver.link.dto.LinkViewerStateResponse
+import com.techtaurant.mainserver.security.jwt.JwtStatus
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Size
+import java.util.UUID
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "링크", description = "회사 링크 조회 및 사용자 상호작용 API")
+interface LinkViewerStateControllerDocs {
+    @Operation(
+        summary = "링크 로그인 사용자 상태 목록 조회",
+        description =
+            "linkIds에 해당하는 링크에 대해 현재 로그인 사용자의 저장 여부와 읽음 여부를 batch로 조회합니다. " +
+                "인증된 사용자만 호출할 수 있습니다.",
+    )
+    @SwaggerApiResponse(
+        responseCode = "200",
+        description = "조회 성공",
+    )
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["BAD_REQUEST"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun getLinkViewerStates(
+        userId: UUID,
+        @Parameter(description = "조회할 링크 ID 목록 (최대 100개)", required = true)
+        @Size(max = 100)
+        linkIds: List<UUID>,
+    ): ApiResponse<List<LinkViewerStateResponse>>
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/UserLinkRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/UserLinkRepository.kt
@@ -10,11 +10,6 @@ interface UserLinkRepository : JpaRepository<UserLink, UUID> {
         linkId: UUID,
     ): UserLink?
 
-    fun existsByUserIdAndLinkId(
-        userId: UUID,
-        linkId: UUID,
-    ): Boolean
-
     fun findByUserIdAndLinkIdIn(
         userId: UUID,
         linkIds: List<UUID>,

--- a/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkViewerStateReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkViewerStateReadServiceTest.kt
@@ -1,0 +1,110 @@
+package com.techtaurant.mainserver.link.application
+
+import com.techtaurant.mainserver.link.entity.Link
+import com.techtaurant.mainserver.link.entity.LinkReadLog
+import com.techtaurant.mainserver.link.entity.UserLink
+import com.techtaurant.mainserver.link.infrastructure.out.LinkReadLogRepository
+import com.techtaurant.mainserver.link.infrastructure.out.LinkRepository
+import com.techtaurant.mainserver.link.infrastructure.out.UserLinkRepository
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class LinkViewerStateReadServiceTest {
+    private val linkRepository: LinkRepository = mockk()
+    private val userLinkRepository: UserLinkRepository = mockk()
+    private val linkReadLogRepository: LinkReadLogRepository = mockk()
+
+    private val linkViewerStateReadService =
+        LinkViewerStateReadService(
+            linkRepository = linkRepository,
+            userLinkRepository = userLinkRepository,
+            linkReadLogRepository = linkReadLogRepository,
+        )
+
+    @Test
+    @DisplayName("로그인 사용자별 저장과 읽음 상태를 링크 ID 순서대로 반환한다")
+    fun getLinkViewerStates_returnsSavedAndReadStatesInRequestOrder() {
+        // given
+        val viewer = createUser("조회자", UserRole.USER)
+        val companyUser = createUser("회사", UserRole.COMPANY)
+        val readLink = createLink(companyUser)
+        val savedLink = createLink(companyUser)
+        val missingLinkId = UUID.randomUUID()
+
+        every { linkRepository.findAllById(listOf(readLink.id!!, savedLink.id!!, missingLinkId)) } returns listOf(savedLink, readLink)
+        every { userLinkRepository.findByUserIdAndLinkIdIn(viewer.id!!, listOf(readLink.id!!, savedLink.id!!)) } returns
+            listOf(UserLink(user = viewer, link = savedLink))
+        every { linkReadLogRepository.findByUserIdAndLinkIdIn(viewer.id!!, listOf(readLink.id!!, savedLink.id!!)) } returns
+            listOf(LinkReadLog(user = viewer, link = readLink))
+
+        // when
+        val result =
+            linkViewerStateReadService.getLinkViewerStates(
+                userId = viewer.id!!,
+                linkIds = listOf(readLink.id!!, savedLink.id!!, readLink.id!!, missingLinkId),
+            )
+
+        // then
+        assertThat(result.map { it.linkId }).containsExactly(readLink.id, savedLink.id)
+        assertThat(result[0].isSaved).isFalse()
+        assertThat(result[0].isRead).isTrue()
+        assertThat(result[1].isSaved).isTrue()
+        assertThat(result[1].isRead).isFalse()
+    }
+
+    @Test
+    @DisplayName("링크 ID 목록이 비어 있으면 빈 목록을 반환한다")
+    fun getLinkViewerStates_emptyLinkIds_returnsEmptyList() {
+        // given
+        val viewerId = UUID.randomUUID()
+
+        // when
+        val result = linkViewerStateReadService.getLinkViewerStates(userId = viewerId, linkIds = emptyList())
+
+        // then
+        assertThat(result).isEmpty()
+    }
+
+    @Test
+    @DisplayName("요청한 링크가 존재하지 않으면 빈 목록을 반환한다")
+    fun getLinkViewerStates_missingLinks_returnsEmptyList() {
+        // given
+        val viewerId = UUID.randomUUID()
+        val missingLinkId = UUID.randomUUID()
+        every { linkRepository.findAllById(listOf(missingLinkId)) } returns emptyList()
+
+        // when
+        val result = linkViewerStateReadService.getLinkViewerStates(userId = viewerId, linkIds = listOf(missingLinkId))
+
+        // then
+        assertThat(result).isEmpty()
+    }
+
+    private fun createUser(
+        name: String,
+        role: UserRole,
+    ): User =
+        User(
+            name = name,
+            email = "${UUID.randomUUID()}@example.com",
+            provider = OAuthProvider.GOOGLE,
+            identifier = UUID.randomUUID().toString(),
+            role = role,
+            profileImageUrl = "https://example.com/profile.jpg",
+        ).apply { id = UUID.randomUUID() }
+
+    private fun createLink(sourceCompanyUser: User): Link =
+        Link(
+            title = "링크",
+            url = "https://example.com/${UUID.randomUUID()}",
+            summary = "요약",
+            sourceCompanyUser = sourceCompanyUser,
+        ).apply { id = UUID.randomUUID() }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkViewerStateControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkViewerStateControllerIntegrationTest.kt
@@ -1,0 +1,119 @@
+package com.techtaurant.mainserver.link.infrastructure.`in`
+
+import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.link.entity.Link
+import com.techtaurant.mainserver.link.entity.LinkReadLog
+import com.techtaurant.mainserver.link.entity.UserLink
+import com.techtaurant.mainserver.link.infrastructure.out.LinkReadLogRepository
+import com.techtaurant.mainserver.link.infrastructure.out.LinkRepository
+import com.techtaurant.mainserver.link.infrastructure.out.UserLinkRepository
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import io.restassured.RestAssured.given
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+@DisplayName("LinkViewerStateController 통합 테스트")
+class LinkViewerStateControllerIntegrationTest : IntegrationTest() {
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    @Autowired
+    private lateinit var linkRepository: LinkRepository
+
+    @Autowired
+    private lateinit var userLinkRepository: UserLinkRepository
+
+    @Autowired
+    private lateinit var linkReadLogRepository: LinkReadLogRepository
+
+    @Autowired
+    private lateinit var jwtTokenProvider: JwtTokenProvider
+
+    private lateinit var companyUser: User
+    private lateinit var normalUser: User
+    private lateinit var accessToken: String
+    private lateinit var savedLink: Link
+    private lateinit var readLink: Link
+
+    @BeforeEach
+    fun setUpTestData() {
+        companyUser = createUser("회사", UserRole.COMPANY)
+        normalUser = createUser("일반사용자", UserRole.USER)
+        accessToken = jwtTokenProvider.createAccessToken(normalUser.id!!, normalUser.role)
+
+        savedLink = createLink("저장한 링크")
+        readLink = createLink("읽은 링크")
+    }
+
+    @Test
+    @DisplayName("비로그인 사용자는 링크 사용자 상태를 조회할 수 없다")
+    fun getLinkViewerStates_anonymous_returnsUnauthorized() {
+        // given
+        val link = savedLink
+
+        // when & then
+        given()
+            .queryParam("linkIds", link.id)
+            .`when`()
+            .get("/api/links/me/states")
+            .then()
+            .statusCode(HttpStatus.UNAUTHORIZED.value())
+    }
+
+    @Test
+    @DisplayName("로그인 사용자는 링크별 저장과 읽음 상태를 조회한다")
+    fun getLinkViewerStates_authenticated_returnsViewerStates() {
+        // given
+        userLinkRepository.save(UserLink(user = normalUser, link = savedLink))
+        linkReadLogRepository.save(LinkReadLog(user = normalUser, link = readLink))
+
+        // when & then
+        given()
+            .header("Authorization", "Bearer $accessToken")
+            .queryParam("linkIds", readLink.id, savedLink.id)
+            .`when`()
+            .get("/api/links/me/states")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data[0].linkId", equalTo(readLink.id.toString()))
+            .body("data[0].isSaved", equalTo(false))
+            .body("data[0].isRead", equalTo(true))
+            .body("data[1].linkId", equalTo(savedLink.id.toString()))
+            .body("data[1].isSaved", equalTo(true))
+            .body("data[1].isRead", equalTo(false))
+    }
+
+    private fun createUser(
+        name: String,
+        role: UserRole,
+    ): User =
+        userRepository.save(
+            User(
+                name = name,
+                email = "${UUID.randomUUID()}@example.com",
+                provider = OAuthProvider.GOOGLE,
+                identifier = UUID.randomUUID().toString(),
+                role = role,
+                profileImageUrl = "https://example.com/profile.jpg",
+            ),
+        )
+
+    private fun createLink(title: String): Link =
+        linkRepository.save(
+            Link(
+                title = title,
+                url = "https://example.com/${UUID.randomUUID()}",
+                summary = "요약",
+                sourceCompanyUser = companyUser,
+            ),
+        )
+}


### PR DESCRIPTION
## 어떤 작업인가요?
- 링크 목록 외부에서도 클라이언트가 여러 링크에 대한 현재 로그인 사용자의 저장 여부와 읽음 여부를 한 번에 조회할 수 있도록 API를 추가했습니다.

## 어떻게 해결했나요?
**링크 사용자 상태 조회 API 추가**
- `GET /api/links/me/states` endpoint를 추가했습니다.
- `linkIds` query parameter를 최대 100개까지 받아 인증 사용자의 링크 상태를 조회합니다.
- 존재하는 링크만 요청 순서대로 반환하도록 서비스 로직을 구성했습니다.

**응답 DTO와 Swagger Docs 추가**
- `LinkViewerStateResponse`에 `linkId`, `isSaved`, `isRead` 필드를 정의했습니다.
- 기존 컨트롤러 패턴에 맞춰 Swagger 어노테이션은 `LinkViewerStateControllerDocs`에 분리했습니다.

**테스트 추가**
- 서비스 단위 테스트로 저장/읽음 상태, 요청 순서, 빈 요청과 미존재 링크 응답을 검증했습니다.
- 통합 테스트로 비로그인 401과 인증 사용자 상태 조회 응답을 검증했습니다.

## 중요한 변경 사항은 무엇인가요?
### 링크 사용자 상태 조회

**Batch 상태 조회 서비스 추가**
- **변경 이유**: 목록 API와 별개로 링크 ID 목록의 사용자 상태를 조회할 수 있어야 합니다.
- **수정 파일**: `LinkViewerStateReadService.kt`, `LinkViewerStateResponse.kt`

**인증 사용자 endpoint 추가**
- **변경 이유**: 프론트엔드가 로그인 사용자 기준 링크 상태를 독립적으로 조회할 수 있어야 합니다.
- **수정 파일**: `LinkViewerStateController.kt`, `LinkViewerStateControllerDocs.kt`

**테스트 커버리지 추가**
- **변경 이유**: 요청 순서 보존, 인증 요구, 저장/읽음 상태 조합을 검증해야 합니다.
- **수정 파일**: `LinkViewerStateReadServiceTest.kt`, `LinkViewerStateControllerIntegrationTest.kt`

Co-Authored-By: OpenAI Codex <codex@openai.com>