### PR TITLE
feat(post): 게시물 생성일시 직접 입력 지원

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -24,6 +24,7 @@ import com.techtaurant.mainserver.user.infrastructure.out.UserFollowRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.util.Date
 import java.util.UUID
 
 @Service
@@ -83,6 +84,7 @@ class PostWriteService(
 
         val category = resolveCategory(request.categoryPath, author)
         val tags = resolveTags(request.tags)
+        val requestedCreatedAt = request.createdAt?.let(Date::from)
 
         val post =
             Post(
@@ -95,6 +97,7 @@ class PostWriteService(
             )
 
         val savedPost = postRepository.save(post)
+        requestedCreatedAt?.let { savedPost.createdAt = it }
 
         if (status != PostStatusEnum.DRAFT) {
             val attachmentIds =

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/CreatePostRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/CreatePostRequest.kt
@@ -3,6 +3,7 @@ package com.techtaurant.mainserver.post.dto
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Size
+import java.time.Instant
 import java.util.UUID
 
 /**
@@ -13,6 +14,7 @@ import java.util.UUID
  * @property categoryPath 카테고리 경로 (선택, 예: "java/spring/deepdive")
  * @property tags 태그 목록 (선택, 여러 개 가능)
  * @property status 게시물 상태 (DRAFT: 임시저장, PUBLISHED: 발행, PRIVATE: 비공개, 기본값: PUBLISHED)
+ * @property createdAt 게시물 생성일시 (선택, 입력하지 않으면 서버 시간이 사용됨)
  */
 @Schema(description = "게시물 생성 요청")
 data class CreatePostRequest(
@@ -31,4 +33,6 @@ data class CreatePostRequest(
     val thumbnailAttachmentId: UUID? = null,
     @field:Schema(description = "게시물 상태 (DRAFT/PUBLISHED/PRIVATE, 기본값: PUBLISHED)", example = "PUBLISHED")
     val status: PostStatusEnum? = null,
+    @field:Schema(description = "게시물 생성일시 (ISO-8601 UTC, 입력하지 않으면 서버 시간이 사용됨)", example = "2026-04-25T10:15:30Z")
+    val createdAt: Instant? = null,
 )

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceTest.kt
@@ -14,6 +14,7 @@ import com.techtaurant.mainserver.user.entity.UserFollow
 import com.techtaurant.mainserver.user.enums.UserRole
 import com.techtaurant.mainserver.user.infrastructure.out.UserFollowRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -22,6 +23,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.util.Date
 import java.util.UUID
 
 @Transactional
@@ -44,6 +47,9 @@ class PostWriteServiceTest : IntegrationTest() {
 
     @Autowired
     private lateinit var notificationRecipientRepository: NotificationRecipientRepository
+
+    @Autowired
+    private lateinit var entityManager: EntityManager
 
     private lateinit var testUser: User
 
@@ -99,6 +105,55 @@ class PostWriteServiceTest : IntegrationTest() {
         )
 
         assertThat(notificationRepository.findAll()).isEmpty()
+    }
+
+    @Test
+    @DisplayName("생성 요청에 createdAt이 있으면 게시물 생성일시로 저장된다")
+    fun createPost_withCreatedAt_savesRequestedCreatedAt() {
+        val requestedCreatedAt = Instant.parse("2026-04-25T10:15:30Z")
+        val expectedCreatedAt = Date.from(requestedCreatedAt)
+
+        val response =
+            postWriteService.createPost(
+                testUser.id!!,
+                CreatePostRequest(
+                    title = "예약 생성일시 글",
+                    content = "생성일시를 직접 입력한 본문",
+                    status = PostStatusEnum.PUBLISHED,
+                    createdAt = requestedCreatedAt,
+                ),
+            )
+
+        entityManager.flush()
+        entityManager.clear()
+        val savedPost = postRepository.findById(response.id).orElseThrow()
+
+        assertThat(response.createdAt).isEqualTo(expectedCreatedAt)
+        assertThat(savedPost.createdAt.time).isEqualTo(expectedCreatedAt.time)
+    }
+
+    @Test
+    @DisplayName("생성 요청에 createdAt이 없으면 현재 시점으로 게시물이 작성된다")
+    fun createPost_withoutCreatedAt_savesCurrentCreatedAt() {
+        val beforeCreate = Date()
+
+        val response =
+            postWriteService.createPost(
+                testUser.id!!,
+                CreatePostRequest(
+                    title = "현재 생성일시 글",
+                    content = "생성일시를 입력하지 않은 본문",
+                    status = PostStatusEnum.PUBLISHED,
+                ),
+            )
+
+        val afterCreate = Date()
+        entityManager.flush()
+        entityManager.clear()
+        val savedPost = postRepository.findById(response.id).orElseThrow()
+
+        assertThat(response.createdAt.time).isBetween(beforeCreate.time, afterCreate.time)
+        assertThat(savedPost.createdAt.time).isBetween(beforeCreate.time, afterCreate.time)
     }
 
     @Nested


### PR DESCRIPTION
## 어떤 작업인가요?
- 게시물 생성 요청에서 `createdAt`을 직접 입력할 수 있도록 지원합니다.

## 어떻게 해결했나요?
**게시물 생성 요청 확장**
- `CreatePostRequest`에 ISO-8601 UTC 형식의 `createdAt` 입력 필드를 추가했습니다.
- 값이 없으면 기존처럼 서버 생성 시점이 사용되도록 기본 동작을 유지했습니다.

**생성일시 저장 처리**
- 게시물 생성 시 요청된 `createdAt`이 있으면 엔티티의 `createdAt`에 반영하도록 처리했습니다.
- 요청값이 없는 경우 현재 시점으로 생성일시가 저장되는 동작을 테스트로 보장했습니다.

## 중요한 변경 사항은 무엇인가요?
### 게시물 생성일시 입력 지원

**요청 DTO 확장**
- **변경 이유**: 게시물 작성 시 클라이언트가 원하는 생성일시를 전달할 수 있어야 합니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/post/dto/CreatePostRequest.kt`

**생성 서비스 반영**
- **변경 이유**: DTO 입력값이 실제 저장되는 게시물 생성일시에 반영되어야 합니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt`

**생성일시 저장 테스트 추가**
- **변경 이유**: `createdAt` 입력/미입력 양쪽 경로의 저장 동작을 검증해야 합니다.
- **수정 파일**: `src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceTest.kt`
