### PR TITLE
feat(post): 30일 집계 기준 인기 게시물 순위 조회

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/AllVisiblePostsQueryStrategy.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/AllVisiblePostsQueryStrategy.kt
@@ -1,6 +1,5 @@
 package com.techtaurant.mainserver.post.application
 
-import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import org.springframework.stereotype.Component
 
@@ -10,7 +9,7 @@ internal class AllVisiblePostsQueryStrategy(
 ) : PostListQueryStrategy {
     override val queryType: PostListQueryType = PostListQueryType.ALL_VISIBLE
 
-    override fun findPosts(criteria: PostListQueryCriteria): List<Post> =
+    override fun findPosts(criteria: PostListQueryCriteria): List<PostWithSortValue> =
         postRepository.findPostsWithConditions(
             cursor = criteria.cursor,
             size = criteria.querySize,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/AuthorPublicPostsQueryStrategy.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/AuthorPublicPostsQueryStrategy.kt
@@ -1,6 +1,5 @@
 package com.techtaurant.mainserver.post.application
 
-import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import org.springframework.stereotype.Component
@@ -11,7 +10,7 @@ internal class AuthorPublicPostsQueryStrategy(
 ) : PostListQueryStrategy {
     override val queryType: PostListQueryType = PostListQueryType.AUTHOR_PUBLIC
 
-    override fun findPosts(criteria: PostListQueryCriteria): List<Post> =
+    override fun findPosts(criteria: PostListQueryCriteria): List<PostWithSortValue> =
         postRepository.findPostsWithConditions(
             cursor = criteria.cursor,
             size = criteria.querySize,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/OwnVisiblePostsQueryStrategy.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/OwnVisiblePostsQueryStrategy.kt
@@ -1,6 +1,5 @@
 package com.techtaurant.mainserver.post.application
 
-import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import org.springframework.stereotype.Component
@@ -11,7 +10,7 @@ internal class OwnVisiblePostsQueryStrategy(
 ) : PostListQueryStrategy {
     override val queryType: PostListQueryType = PostListQueryType.OWN_VISIBLE
 
-    override fun findPosts(criteria: PostListQueryCriteria): List<Post> =
+    override fun findPosts(criteria: PostListQueryCriteria): List<PostWithSortValue> =
         postRepository.findPostsWithConditions(
             cursor = criteria.cursor,
             size = criteria.querySize,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListQueryStrategy.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListQueryStrategy.kt
@@ -1,9 +1,7 @@
 package com.techtaurant.mainserver.post.application
 
-import com.techtaurant.mainserver.post.entity.Post
-
 interface PostListQueryStrategy {
     val queryType: PostListQueryType
 
-    fun findPosts(criteria: PostListQueryCriteria): List<Post>
+    fun findPosts(criteria: PostListQueryCriteria): List<PostWithSortValue>
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -184,7 +184,7 @@ class PostListReadService(
 
         val nextCursor =
             if (hasNext && content.isNotEmpty()) {
-                createPostCursor(content.last(), period, sortType).encode()
+                createPostCursor(createPostWithSortValue(content.last(), period, sortType), sortType).encode()
             } else {
                 null
             }
@@ -198,34 +198,52 @@ class PostListReadService(
     }
 
     private fun createPostCursor(
-        post: Post,
-        period: PostPeriod,
+        sortedPost: PostWithSortValue,
         sortType: PostSortType,
     ): PostCursor {
         return PostCursor.from(
-            post = post,
+            post = sortedPost.post,
             sortType = sortType,
-            sortValueOverride = resolvePeriodSortValue(post, period, sortType),
+            sortValue = sortedPost.sortValue,
         )
     }
 
-    private fun resolvePeriodSortValue(
+    private fun createPostWithSortValue(
         post: Post,
         period: PostPeriod,
         sortType: PostSortType,
-    ): Long? {
-        val days = period.days ?: return null
-        if (sortType == PostSortType.LATEST) {
-            return null
+    ): PostWithSortValue = PostWithSortValue(post = post, sortValue = resolveCursorSortValue(post, period, sortType))
+
+    private fun resolveCursorSortValue(
+        post: Post,
+        period: PostPeriod,
+        sortType: PostSortType,
+    ): Long {
+        val days = period.days
+        if (days != null && sortType != PostSortType.LATEST) {
+            return resolveDailyStatsSortValue(post, days, sortType)
         }
 
-        val postId = post.id ?: return null
+        return when (sortType) {
+            PostSortType.LATEST -> 0L
+            PostSortType.VIEW -> post.viewCount
+            PostSortType.LIKE -> post.likeCount
+            PostSortType.COMMENT -> post.commentCount
+        }
+    }
+
+    private fun resolveDailyStatsSortValue(
+        post: Post,
+        days: Int,
+        sortType: PostSortType,
+    ): Long {
+        val postId = post.id ?: return 0L
         val cutoffDate = dailyStatsCutoffDate(days)
         return when (sortType) {
             PostSortType.VIEW -> postDailyStatsRepository.sumViewCountSince(postId, cutoffDate)
             PostSortType.LIKE -> postDailyStatsRepository.sumLikeCountSince(postId, cutoffDate)
             PostSortType.COMMENT -> postDailyStatsRepository.sumCommentCountSince(postId, cutoffDate)
-            PostSortType.LATEST -> null
+            PostSortType.LATEST -> 0L
         }
     }
 

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -225,7 +225,7 @@ class PostListReadService(
         }
 
         return when (sortType) {
-            PostSortType.LATEST -> 0L
+            PostSortType.LATEST -> post.updatedAt.time
             PostSortType.VIEW -> post.viewCount
             PostSortType.LIKE -> post.likeCount
             PostSortType.COMMENT -> post.commentCount

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -14,13 +14,17 @@ import com.techtaurant.mainserver.post.dto.PostViewerStateResponse
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
+import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.user.application.UserProfileImageResolver
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.Calendar
 import java.util.Date
 import java.util.UUID
+import java.sql.Date as SqlDate
 
 /**
  * 게시물 목록 조회 서비스
@@ -29,6 +33,7 @@ import java.util.UUID
 @Transactional(readOnly = true)
 class PostListReadService(
     private val postRepository: PostRepository,
+    private val postDailyStatsRepository: PostDailyStatsRepository,
     private val attachmentService: AttachmentService,
     private val postMetadataReadService: PostMetadataReadService,
     private val postViewerStateReadService: PostViewerStateReadService,
@@ -179,7 +184,7 @@ class PostListReadService(
 
         val nextCursor =
             if (hasNext && content.isNotEmpty()) {
-                PostCursor.from(content.last(), sortType).encode()
+                createPostCursor(content.last(), period, sortType).encode()
             } else {
                 null
             }
@@ -191,6 +196,40 @@ class PostListReadService(
             size = content.size,
         )
     }
+
+    private fun createPostCursor(
+        post: Post,
+        period: PostPeriod,
+        sortType: PostSortType,
+    ): PostCursor {
+        return PostCursor.from(
+            post = post,
+            sortType = sortType,
+            sortValueOverride = resolvePeriodSortValue(post, period, sortType),
+        )
+    }
+
+    private fun resolvePeriodSortValue(
+        post: Post,
+        period: PostPeriod,
+        sortType: PostSortType,
+    ): Long? {
+        val days = period.days ?: return null
+        if (sortType == PostSortType.LATEST) {
+            return null
+        }
+
+        val postId = post.id ?: return null
+        val cutoffDate = dailyStatsCutoffDate(days)
+        return when (sortType) {
+            PostSortType.VIEW -> postDailyStatsRepository.sumViewCountSince(postId, cutoffDate)
+            PostSortType.LIKE -> postDailyStatsRepository.sumLikeCountSince(postId, cutoffDate)
+            PostSortType.COMMENT -> postDailyStatsRepository.sumCommentCountSince(postId, cutoffDate)
+            PostSortType.LATEST -> null
+        }
+    }
+
+    private fun dailyStatsCutoffDate(days: Int): SqlDate = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC).minusDays(days.toLong()))
 
     private fun emptyPostPage(): CursorPageResponse<Post> =
         CursorPageResponse(

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -14,17 +14,13 @@ import com.techtaurant.mainserver.post.dto.PostViewerStateResponse
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
-import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.user.application.UserProfileImageResolver
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
-import java.time.ZoneOffset
 import java.util.Calendar
 import java.util.Date
 import java.util.UUID
-import java.sql.Date as SqlDate
 
 /**
  * 게시물 목록 조회 서비스
@@ -33,7 +29,6 @@ import java.sql.Date as SqlDate
 @Transactional(readOnly = true)
 class PostListReadService(
     private val postRepository: PostRepository,
-    private val postDailyStatsRepository: PostDailyStatsRepository,
     private val attachmentService: AttachmentService,
     private val postMetadataReadService: PostMetadataReadService,
     private val postViewerStateReadService: PostViewerStateReadService,
@@ -178,13 +173,14 @@ class PostListReadService(
                 categoryId = categoryId,
                 tagIds = normalizedTagIds,
             )
-        val posts = selectPostListQueryStrategy(postListQueryCriteria).findPosts(postListQueryCriteria)
-        val hasNext = posts.size > size
-        val content = posts.take(size)
+        val sortedPosts = selectPostListQueryStrategy(postListQueryCriteria).findPosts(postListQueryCriteria)
+        val hasNext = sortedPosts.size > size
+        val contentWithSortValues = sortedPosts.take(size)
+        val content = contentWithSortValues.map { it.post }
 
         val nextCursor =
-            if (hasNext && content.isNotEmpty()) {
-                createPostCursor(createPostWithSortValue(content.last(), period, sortType), sortType).encode()
+            if (hasNext && contentWithSortValues.isNotEmpty()) {
+                createPostCursor(contentWithSortValues.last(), sortType).encode()
             } else {
                 null
             }
@@ -207,47 +203,6 @@ class PostListReadService(
             sortValue = sortedPost.sortValue,
         )
     }
-
-    private fun createPostWithSortValue(
-        post: Post,
-        period: PostPeriod,
-        sortType: PostSortType,
-    ): PostWithSortValue = PostWithSortValue(post = post, sortValue = resolveCursorSortValue(post, period, sortType))
-
-    private fun resolveCursorSortValue(
-        post: Post,
-        period: PostPeriod,
-        sortType: PostSortType,
-    ): Long {
-        val days = period.days
-        if (days != null && sortType != PostSortType.LATEST) {
-            return resolveDailyStatsSortValue(post, days, sortType)
-        }
-
-        return when (sortType) {
-            PostSortType.LATEST -> post.updatedAt.time
-            PostSortType.VIEW -> post.viewCount
-            PostSortType.LIKE -> post.likeCount
-            PostSortType.COMMENT -> post.commentCount
-        }
-    }
-
-    private fun resolveDailyStatsSortValue(
-        post: Post,
-        days: Int,
-        sortType: PostSortType,
-    ): Long {
-        val postId = post.id ?: return 0L
-        val cutoffDate = dailyStatsCutoffDate(days)
-        return when (sortType) {
-            PostSortType.VIEW -> postDailyStatsRepository.sumViewCountSince(postId, cutoffDate)
-            PostSortType.LIKE -> postDailyStatsRepository.sumLikeCountSince(postId, cutoffDate)
-            PostSortType.COMMENT -> postDailyStatsRepository.sumCommentCountSince(postId, cutoffDate)
-            PostSortType.LATEST -> 0L
-        }
-    }
-
-    private fun dailyStatsCutoffDate(days: Int): SqlDate = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC).minusDays(days.toLong()))
 
     private fun emptyPostPage(): CursorPageResponse<Post> =
         CursorPageResponse(

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWithSortValue.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWithSortValue.kt
@@ -2,7 +2,10 @@ package com.techtaurant.mainserver.post.application
 
 import com.techtaurant.mainserver.post.entity.Post
 
-internal data class PostWithSortValue(
+data class PostWithSortValue(
     val post: Post,
     val sortValue: Long,
-)
+) {
+    val id
+        get() = post.id
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWithSortValue.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWithSortValue.kt
@@ -1,0 +1,8 @@
+package com.techtaurant.mainserver.post.application
+
+import com.techtaurant.mainserver.post.entity.Post
+
+internal data class PostWithSortValue(
+    val post: Post,
+    val sortValue: Long,
+)

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
@@ -64,13 +64,14 @@ data class PostCursor(
         fun from(
             post: com.techtaurant.mainserver.post.entity.Post,
             sortType: PostSortType,
+            sortValueOverride: Long? = null,
         ): PostCursor {
             val sortValue =
                 when (sortType) {
                     PostSortType.LATEST -> 0L
-                    PostSortType.VIEW -> post.viewCount
-                    PostSortType.LIKE -> post.likeCount
-                    PostSortType.COMMENT -> post.commentCount
+                    PostSortType.VIEW -> sortValueOverride ?: post.viewCount
+                    PostSortType.LIKE -> sortValueOverride ?: post.likeCount
+                    PostSortType.COMMENT -> sortValueOverride ?: post.commentCount
                 }
             // LATEST 정렬은 updatedAt 기준이므로 커서에 updatedAt을 저장합니다.
             val cursorDate = if (sortType == PostSortType.LATEST) post.updatedAt else post.createdAt

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
@@ -13,7 +13,7 @@ import java.util.UUID
  * - LATEST: updatedAt(최신 수정 시간), id
  * - VIEW/LIKE/COMMENT: sortValue(해당 count), createdAt, id
  *
- * @property sortValue 정렬 기준 값 (조회수, 좋아요수, 댓글수)
+ * @property sortValue 정렬 기준 값 (LATEST는 updatedAt epoch milliseconds, 그 외는 조회수/좋아요수/댓글수)
  * @property createdAt LATEST 정렬 시 updatedAt, 그 외 정렬 시 createdAt을 담는 보조 정렬 시간 필드
  * @property id 게시물 ID
  * @property sortType 정렬 타입
@@ -68,7 +68,7 @@ data class PostCursor(
         ): PostCursor {
             val sortValue =
                 when (sortType) {
-                    PostSortType.LATEST -> 0L
+                    PostSortType.LATEST -> post.updatedAt.time
                     PostSortType.VIEW -> post.viewCount
                     PostSortType.LIKE -> post.likeCount
                     PostSortType.COMMENT -> post.commentCount

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
@@ -1,5 +1,6 @@
 package com.techtaurant.mainserver.post.dto
 
+import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostSortType
 import java.util.Base64
 import java.util.Date
@@ -56,24 +57,37 @@ data class PostCursor(
         }
 
         /**
-         * Post 엔티티에서 커서 생성
+         * Post 엔티티의 누적 정렬값으로 커서를 생성합니다.
          *
          * @param post 게시물 엔티티
          * @param sortType 정렬 타입
          */
         fun from(
-            post: com.techtaurant.mainserver.post.entity.Post,
+            post: Post,
             sortType: PostSortType,
-            sortValueOverride: Long? = null,
         ): PostCursor {
             val sortValue =
                 when (sortType) {
                     PostSortType.LATEST -> 0L
-                    PostSortType.VIEW -> sortValueOverride ?: post.viewCount
-                    PostSortType.LIKE -> sortValueOverride ?: post.likeCount
-                    PostSortType.COMMENT -> sortValueOverride ?: post.commentCount
+                    PostSortType.VIEW -> post.viewCount
+                    PostSortType.LIKE -> post.likeCount
+                    PostSortType.COMMENT -> post.commentCount
                 }
-            // LATEST 정렬은 updatedAt 기준이므로 커서에 updatedAt을 저장합니다.
+            return from(post, sortType, sortValue)
+        }
+
+        /**
+         * 쿼리에서 실제 정렬에 사용한 값으로 커서를 생성합니다.
+         *
+         * @param post 게시물 엔티티
+         * @param sortType 정렬 타입
+         * @param sortValue 정렬에 사용된 값
+         */
+        fun from(
+            post: Post,
+            sortType: PostSortType,
+            sortValue: Long,
+        ): PostCursor {
             val cursorDate = if (sortType == PostSortType.LATEST) post.updatedAt else post.createdAt
             return PostCursor(sortValue, cursorDate, post.id!!, sortType)
         }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostDailyStatsRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostDailyStatsRepository.kt
@@ -9,42 +9,6 @@ import java.sql.Date
 import java.util.UUID
 
 interface PostDailyStatsRepository : JpaRepository<PostDailyStats, UUID> {
-    @Query(
-        """
-        SELECT COALESCE(SUM(stats.viewCount), 0)
-        FROM PostDailyStats stats
-        WHERE stats.post.id = :postId AND stats.statDate >= :cutoffDate
-        """,
-    )
-    fun sumViewCountSince(
-        @Param("postId") postId: UUID,
-        @Param("cutoffDate") cutoffDate: Date,
-    ): Long
-
-    @Query(
-        """
-        SELECT COALESCE(SUM(stats.likeCount), 0)
-        FROM PostDailyStats stats
-        WHERE stats.post.id = :postId AND stats.statDate >= :cutoffDate
-        """,
-    )
-    fun sumLikeCountSince(
-        @Param("postId") postId: UUID,
-        @Param("cutoffDate") cutoffDate: Date,
-    ): Long
-
-    @Query(
-        """
-        SELECT COALESCE(SUM(stats.commentCount), 0)
-        FROM PostDailyStats stats
-        WHERE stats.post.id = :postId AND stats.statDate >= :cutoffDate
-        """,
-    )
-    fun sumCommentCountSince(
-        @Param("postId") postId: UUID,
-        @Param("cutoffDate") cutoffDate: Date,
-    ): Long
-
     /**
      * 특정 게시물의 일별 조회수를 원자적으로 1 증가시킵니다.
      *

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostDailyStatsRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostDailyStatsRepository.kt
@@ -9,6 +9,42 @@ import java.sql.Date
 import java.util.UUID
 
 interface PostDailyStatsRepository : JpaRepository<PostDailyStats, UUID> {
+    @Query(
+        """
+        SELECT COALESCE(SUM(stats.viewCount), 0)
+        FROM PostDailyStats stats
+        WHERE stats.post.id = :postId AND stats.statDate >= :cutoffDate
+        """,
+    )
+    fun sumViewCountSince(
+        @Param("postId") postId: UUID,
+        @Param("cutoffDate") cutoffDate: Date,
+    ): Long
+
+    @Query(
+        """
+        SELECT COALESCE(SUM(stats.likeCount), 0)
+        FROM PostDailyStats stats
+        WHERE stats.post.id = :postId AND stats.statDate >= :cutoffDate
+        """,
+    )
+    fun sumLikeCountSince(
+        @Param("postId") postId: UUID,
+        @Param("cutoffDate") cutoffDate: Date,
+    ): Long
+
+    @Query(
+        """
+        SELECT COALESCE(SUM(stats.commentCount), 0)
+        FROM PostDailyStats stats
+        WHERE stats.post.id = :postId AND stats.statDate >= :cutoffDate
+        """,
+    )
+    fun sumCommentCountSince(
+        @Param("postId") postId: UUID,
+        @Param("cutoffDate") cutoffDate: Date,
+    ): Long
+
     /**
      * 특정 게시물의 일별 조회수를 원자적으로 1 증가시킵니다.
      *

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
@@ -1,5 +1,6 @@
 package com.techtaurant.mainserver.post.infrastructure.out
 
+import com.techtaurant.mainserver.post.application.PostWithSortValue
 import com.techtaurant.mainserver.post.dto.PostCursor
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
@@ -23,7 +24,7 @@ interface PostRepositoryCustom {
      * @param categoryId 카테고리 ID 필터 (null이면 미적용)
      * @param visibleToUserId PUBLISHED + 해당 사용자의 PRIVATE 게시물 조회 (null이면 미적용, statuses보다 우선)
      * @param tagIds 태그 UUID 필터 (여러 개 전달 시 OR 조건)
-     * @return 게시물 목록
+     * @return 실제 정렬값을 포함한 게시물 목록
      */
     fun findPostsWithConditions(
         cursor: PostCursor?,
@@ -36,7 +37,7 @@ interface PostRepositoryCustom {
         visibleToUserId: UUID? = null,
         tagIds: List<UUID>? = null,
         viewerId: UUID? = null,
-    ): List<Post>
+    ): List<PostWithSortValue>
 
     fun findVisiblePostDetailById(
         postId: UUID,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -5,6 +5,8 @@ import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.post.dto.PostCursor
 import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.entity.PostDailyStats
+import com.techtaurant.mainserver.post.entity.PostDailyStats_
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.post.entity.Post_
@@ -16,14 +18,22 @@ import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.entity.UserBan_
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
+import jakarta.persistence.criteria.CommonAbstractCriteria
 import jakarta.persistence.criteria.CriteriaBuilder
 import jakarta.persistence.criteria.CriteriaQuery
+import jakarta.persistence.criteria.Expression
 import jakarta.persistence.criteria.JoinType
+import jakarta.persistence.criteria.Path
 import jakarta.persistence.criteria.Predicate
 import jakarta.persistence.criteria.Root
 import org.springframework.stereotype.Repository
-import java.util.Calendar
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import java.util.UUID
+import java.sql.Date as SqlDate
+import java.util.Date as UtilDate
 
 /**
  * 게시물 동적 쿼리 구현체
@@ -52,6 +62,21 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         tagIds: List<UUID>?,
         viewerId: UUID?,
     ): List<Post> {
+        if (usesDailyStatsPeriodRanking(period, sortType)) {
+            return findPostsWithDailyStatsPeriodRanking(
+                cursor = cursor,
+                size = size,
+                period = period,
+                sortType = sortType,
+                authorId = authorId,
+                statuses = statuses,
+                categoryId = categoryId,
+                visibleToUserId = visibleToUserId,
+                tagIds = tagIds,
+                viewerId = viewerId,
+            )
+        }
+
         val cb = entityManager.criteriaBuilder
         val cq = cb.createQuery(Post::class.java)
         val root = cq.from(Post::class.java)
@@ -62,42 +87,99 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         root.fetch<Post, Tag>(Post_.TAGS, JoinType.LEFT)
 
         val predicates = mutableListOf<Predicate>()
-
-        if (visibleToUserId != null) {
-            val publishedPredicate = cb.equal(root.get(Post_.status), PostStatusEnum.PUBLISHED)
-            val ownPrivatePostPredicate =
-                cb.and(
-                    cb.equal(root.get(Post_.author).get(EntityBase_.id), visibleToUserId),
-                    cb.equal(root.get(Post_.status), PostStatusEnum.PRIVATE),
-                )
-            predicates.add(cb.or(publishedPredicate, ownPrivatePostPredicate))
-        } else if (statuses != null) {
-            predicates.add(root.get(Post_.status).`in`(statuses))
-        } else {
-            predicates.add(cb.equal(root.get(Post_.status), PostStatusEnum.PUBLISHED))
-        }
-
-        authorId?.let { predicates.add(cb.equal(root.get(Post_.author).get(EntityBase_.id), it)) }
-        categoryId?.let { predicates.add(cb.equal(root.get(Post_.category).get(EntityBase_.id), it)) }
-        tagIds?.let { ids ->
-            val tagJoin = root.join<Post, Tag>(Post_.TAGS, JoinType.LEFT)
-            predicates.add(tagJoin.get<UUID>("id").`in`(ids))
-        }
-        addViewerBanCondition(cb, cq, root, viewerId, predicates)
-
-        addPeriodCondition(cb, root, period, predicates)
-        addCursorCondition(cb, root, cursor, sortType, predicates)
+        addBaseConditions(
+            cb = cb,
+            query = cq,
+            root = root,
+            authorId = authorId,
+            statuses = statuses,
+            categoryId = categoryId,
+            visibleToUserId = visibleToUserId,
+            tagIds = tagIds,
+            viewerId = viewerId,
+            predicates = predicates,
+        )
+        addPeriodCondition(cb, cq, root, period, sortType, predicates)
+        addCursorCondition(cb, cq, root, cursor, period, sortType, predicates)
 
         if (predicates.isNotEmpty()) {
             cq.where(*predicates.toTypedArray())
         }
 
-        applyOrdering(cb, cq, root, sortType)
+        applyOrdering(cb, cq, root, period, sortType)
 
         return entityManager.createQuery(cq)
             .setMaxResults(size)
             .resultList
             .distinctBy { it.id }
+    }
+
+    private fun findPostsWithDailyStatsPeriodRanking(
+        cursor: PostCursor?,
+        size: Int,
+        period: PostPeriod,
+        sortType: PostSortType,
+        authorId: UUID?,
+        statuses: List<PostStatusEnum>?,
+        categoryId: UUID?,
+        visibleToUserId: UUID?,
+        tagIds: List<UUID>?,
+        viewerId: UUID?,
+    ): List<Post> {
+        val cb = entityManager.criteriaBuilder
+        val cq = cb.createQuery(UUID::class.java)
+        val root = cq.from(Post::class.java)
+        val predicates = mutableListOf<Predicate>()
+
+        addBaseConditions(
+            cb = cb,
+            query = cq,
+            root = root,
+            authorId = authorId,
+            statuses = statuses,
+            categoryId = categoryId,
+            visibleToUserId = visibleToUserId,
+            tagIds = tagIds,
+            viewerId = viewerId,
+            predicates = predicates,
+        )
+        addPeriodCondition(cb, cq, root, period, sortType, predicates)
+        addCursorCondition(cb, cq, root, cursor, period, sortType, predicates)
+
+        cq.select(root.get(EntityBase_.id))
+        if (predicates.isNotEmpty()) {
+            cq.where(*predicates.toTypedArray())
+        }
+        applyOrdering(cb, cq, root, period, sortType)
+
+        val postIds =
+            entityManager.createQuery(cq)
+                .setMaxResults(size)
+                .resultList
+
+        return findPostsByIdsInOrder(postIds)
+    }
+
+    private fun findPostsByIdsInOrder(postIds: List<UUID>): List<Post> {
+        if (postIds.isEmpty()) {
+            return emptyList()
+        }
+
+        val cb = entityManager.criteriaBuilder
+        val cq = cb.createQuery(Post::class.java)
+        val root = cq.from(Post::class.java)
+        cq.distinct(true)
+
+        root.fetch<Post, User>(Post_.AUTHOR)
+        root.fetch<Post, Category>(Post_.CATEGORY, JoinType.LEFT)
+        root.fetch<Post, Tag>(Post_.TAGS, JoinType.LEFT)
+        cq.where(root.get<UUID>(EntityBase_.id).`in`(postIds))
+
+        val orderByPostId = postIds.withIndex().associate { (index, postId) -> postId to index }
+        return entityManager.createQuery(cq)
+            .resultList
+            .distinctBy { it.id }
+            .sortedBy { orderByPostId.getValue(it.id!!) }
     }
 
     override fun findVisiblePostDetailById(
@@ -124,24 +206,113 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         return entityManager.createQuery(cq).resultList.firstOrNull()
     }
 
+    private fun addBaseConditions(
+        cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
+        root: Root<Post>,
+        authorId: UUID?,
+        statuses: List<PostStatusEnum>?,
+        categoryId: UUID?,
+        visibleToUserId: UUID?,
+        tagIds: List<UUID>?,
+        viewerId: UUID?,
+        predicates: MutableList<Predicate>,
+    ) {
+        if (visibleToUserId != null) {
+            val publishedPredicate = cb.equal(root.get(Post_.status), PostStatusEnum.PUBLISHED)
+            val ownPrivatePostPredicate =
+                cb.and(
+                    cb.equal(root.get(Post_.author).get(EntityBase_.id), visibleToUserId),
+                    cb.equal(root.get(Post_.status), PostStatusEnum.PRIVATE),
+                )
+            predicates.add(cb.or(publishedPredicate, ownPrivatePostPredicate))
+        } else if (statuses != null) {
+            predicates.add(root.get(Post_.status).`in`(statuses))
+        } else {
+            predicates.add(cb.equal(root.get(Post_.status), PostStatusEnum.PUBLISHED))
+        }
+
+        authorId?.let { predicates.add(cb.equal(root.get(Post_.author).get(EntityBase_.id), it)) }
+        categoryId?.let { predicates.add(cb.equal(root.get(Post_.category).get(EntityBase_.id), it)) }
+        tagIds?.let { addTagIdsCondition(cb, query, root, it, predicates) }
+        addViewerBanCondition(cb, query, root, viewerId, predicates)
+    }
+
+    private fun addTagIdsCondition(
+        cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
+        root: Root<Post>,
+        tagIds: List<UUID>,
+        predicates: MutableList<Predicate>,
+    ) {
+        val tagSubquery = query.subquery(Long::class.java)
+        val tagPostRoot = tagSubquery.from(Post::class.java)
+        val tagJoin = tagPostRoot.join<Post, Tag>(Post_.TAGS, JoinType.INNER)
+
+        tagSubquery.select(cb.literal(1L))
+        tagSubquery.where(
+            cb.equal(tagPostRoot.get(EntityBase_.id), root.get(EntityBase_.id)),
+            tagJoin.get<UUID>("id").`in`(tagIds),
+        )
+        predicates.add(cb.exists(tagSubquery))
+    }
+
     /**
-     * 지정된 기간 이내의 게시물만 조회하도록 필터 추가
+     * 지정된 기간 조건을 적용합니다.
      *
-     * period가 ALL이면 필터 미적용, WEEK/MONTH/YEAR면 해당 일수만큼 이전부터 조회
+     * LATEST 정렬은 기존처럼 게시물 작성일 기준으로 필터링하고,
+     * VIEW/LIKE/COMMENT 정렬은 게시물 작성일이 아니라 기간 내 일별 통계 존재 여부로 필터링합니다.
      */
     private fun addPeriodCondition(
+        cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
+        root: Root<Post>,
+        period: PostPeriod,
+        sortType: PostSortType,
+        predicates: MutableList<Predicate>,
+    ) {
+        if (sortType == PostSortType.LATEST) {
+            addPostCreatedAtPeriodCondition(cb, root, period, predicates)
+            return
+        }
+        addDailyStatsPeriodCondition(cb, query, root, period, predicates)
+    }
+
+    /**
+     * LATEST 정렬의 기간 필터는 게시물 작성일 기준을 유지합니다.
+     */
+    private fun addPostCreatedAtPeriodCondition(
         cb: CriteriaBuilder,
         root: Root<Post>,
         period: PostPeriod,
         predicates: MutableList<Predicate>,
     ) {
         period.days?.let { days ->
-            val cutoffDate =
-                Calendar.getInstance().apply {
-                    add(Calendar.DAY_OF_YEAR, -days)
-                }.time
+            val cutoffDate = UtilDate.from(Instant.now().minus(days.toLong(), ChronoUnit.DAYS))
             predicates.add(cb.greaterThanOrEqualTo(root.get(EntityBase_.createdAt), cutoffDate))
         }
+    }
+
+    /**
+     * count 기반 기간 랭킹은 게시물 작성일이 아니라 일별 통계 테이블의 최근 데이터 존재 여부로 필터링합니다.
+     */
+    private fun addDailyStatsPeriodCondition(
+        cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
+        root: Root<Post>,
+        period: PostPeriod,
+        predicates: MutableList<Predicate>,
+    ) {
+        val days = period.days ?: return
+        val statsExistsSubquery = query.subquery(Long::class.java)
+        val statsRoot = statsExistsSubquery.from(PostDailyStats::class.java)
+
+        statsExistsSubquery.select(cb.literal(1L))
+        statsExistsSubquery.where(
+            cb.equal(statsRoot.get(PostDailyStats_.post).get(EntityBase_.id), root.get(EntityBase_.id)),
+            cb.greaterThanOrEqualTo(statsRoot.get(PostDailyStats_.statDate), statsCutoffDate(days)),
+        )
+        predicates.add(cb.exists(statsExistsSubquery))
     }
 
     /**
@@ -151,8 +322,10 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
      */
     private fun addCursorCondition(
         cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
         root: Root<Post>,
         cursor: PostCursor?,
+        period: PostPeriod,
         sortType: PostSortType,
         predicates: MutableList<Predicate>,
     ) {
@@ -161,14 +334,14 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         val cursorPredicate =
             when (sortType) {
                 PostSortType.LATEST -> buildLatestCursorCondition(cb, root, cursor)
-                else -> buildCountCursorCondition(cb, root, cursor, sortType)
+                else -> buildCountCursorCondition(cb, query, root, cursor, period, sortType)
             }
         predicates.add(cursorPredicate)
     }
 
     private fun addViewerBanCondition(
         cb: CriteriaBuilder,
-        cq: CriteriaQuery<Post>,
+        query: CommonAbstractCriteria,
         root: Root<Post>,
         viewerId: UUID?,
         predicates: MutableList<Predicate>,
@@ -177,7 +350,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             return
         }
 
-        val banSubquery = cq.subquery(Long::class.java)
+        val banSubquery = query.subquery(Long::class.java)
         val banRoot = banSubquery.from(UserBan::class.java)
 
         banSubquery.select(cb.literal(1L))
@@ -220,27 +393,23 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
      */
     private fun buildCountCursorCondition(
         cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
         root: Root<Post>,
         cursor: PostCursor,
+        period: PostPeriod,
         sortType: PostSortType,
     ): Predicate {
-        val sortAttribute =
-            when (sortType) {
-                PostSortType.VIEW -> Post_.viewCount
-                PostSortType.LIKE -> Post_.likeCount
-                PostSortType.COMMENT -> Post_.commentCount
-                else -> throw ApiException(PostStatus.INVALID_SORT_TYPE)
-            }
+        val sortExpression = countSortExpression(cb, query, root, period, sortType)
 
-        val countLess = cb.lessThan(root.get(sortAttribute), cursor.sortValue)
+        val countLess = cb.lessThan(sortExpression, cursor.sortValue)
         val countEqualCreatedAtLess =
             cb.and(
-                cb.equal(root.get(sortAttribute), cursor.sortValue),
+                cb.equal(sortExpression, cursor.sortValue),
                 cb.lessThan(root.get(EntityBase_.createdAt), cursor.createdAt),
             )
         val countEqualCreatedAtEqualIdLess =
             cb.and(
-                cb.equal(root.get(sortAttribute), cursor.sortValue),
+                cb.equal(sortExpression, cursor.sortValue),
                 cb.equal(root.get(EntityBase_.createdAt), cursor.createdAt),
                 cb.lessThan(root.get(EntityBase_.id), cursor.id),
             )
@@ -256,8 +425,9 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
      */
     private fun applyOrdering(
         cb: CriteriaBuilder,
-        cq: CriteriaQuery<Post>,
+        cq: CriteriaQuery<*>,
         root: Root<Post>,
+        period: PostPeriod,
         sortType: PostSortType,
     ) {
         val orders =
@@ -269,23 +439,84 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
                     )
                 PostSortType.VIEW ->
                     listOf(
-                        cb.desc(root.get(Post_.viewCount)),
+                        cb.desc(countSortExpression(cb, cq, root, period, sortType)),
                         cb.desc(root.get(EntityBase_.createdAt)),
                         cb.desc(root.get(EntityBase_.id)),
                     )
                 PostSortType.LIKE ->
                     listOf(
-                        cb.desc(root.get(Post_.likeCount)),
+                        cb.desc(countSortExpression(cb, cq, root, period, sortType)),
                         cb.desc(root.get(EntityBase_.createdAt)),
                         cb.desc(root.get(EntityBase_.id)),
                     )
                 PostSortType.COMMENT ->
                     listOf(
-                        cb.desc(root.get(Post_.commentCount)),
+                        cb.desc(countSortExpression(cb, cq, root, period, sortType)),
                         cb.desc(root.get(EntityBase_.createdAt)),
                         cb.desc(root.get(EntityBase_.id)),
                     )
             }
         cq.orderBy(orders)
     }
+
+    private fun countSortExpression(
+        cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
+        root: Root<Post>,
+        period: PostPeriod,
+        sortType: PostSortType,
+    ): Expression<Long> {
+        return if (usesDailyStatsPeriodRanking(period, sortType)) {
+            dailyStatsSumExpression(cb, query, root, period.days!!, sortType)
+        } else {
+            postCountExpression(root, sortType)
+        }
+    }
+
+    private fun dailyStatsSumExpression(
+        cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
+        root: Root<Post>,
+        days: Int,
+        sortType: PostSortType,
+    ): Expression<Long> {
+        val sumSubquery = query.subquery(Long::class.java)
+        val statsRoot = sumSubquery.from(PostDailyStats::class.java)
+
+        sumSubquery.select(cb.coalesce(cb.sum(dailyStatsCountExpression(statsRoot, sortType)), 0L))
+        sumSubquery.where(
+            cb.equal(statsRoot.get(PostDailyStats_.post).get(EntityBase_.id), root.get(EntityBase_.id)),
+            cb.greaterThanOrEqualTo(statsRoot.get(PostDailyStats_.statDate), statsCutoffDate(days)),
+        )
+        return sumSubquery
+    }
+
+    private fun postCountExpression(
+        root: Root<Post>,
+        sortType: PostSortType,
+    ): Path<Long> =
+        when (sortType) {
+            PostSortType.VIEW -> root.get(Post_.viewCount)
+            PostSortType.LIKE -> root.get(Post_.likeCount)
+            PostSortType.COMMENT -> root.get(Post_.commentCount)
+            else -> throw ApiException(PostStatus.INVALID_SORT_TYPE)
+        }
+
+    private fun dailyStatsCountExpression(
+        statsRoot: Root<PostDailyStats>,
+        sortType: PostSortType,
+    ): Path<Long> =
+        when (sortType) {
+            PostSortType.VIEW -> statsRoot.get(PostDailyStats_.viewCount)
+            PostSortType.LIKE -> statsRoot.get(PostDailyStats_.likeCount)
+            PostSortType.COMMENT -> statsRoot.get(PostDailyStats_.commentCount)
+            else -> throw ApiException(PostStatus.INVALID_SORT_TYPE)
+        }
+
+    private fun usesDailyStatsPeriodRanking(
+        period: PostPeriod,
+        sortType: PostSortType,
+    ): Boolean = sortType != PostSortType.LATEST && period.days != null
+
+    private fun statsCutoffDate(days: Int): SqlDate = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC).minusDays(days.toLong()))
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -18,6 +18,7 @@ import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.entity.UserBan_
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
+import jakarta.persistence.Tuple
 import jakarta.persistence.criteria.CommonAbstractCriteria
 import jakarta.persistence.criteria.CriteriaBuilder
 import jakarta.persistence.criteria.CriteriaQuery
@@ -44,6 +45,11 @@ import java.util.Date as UtilDate
 class PostRepositoryCustomImpl : PostRepositoryCustom {
     @PersistenceContext
     private lateinit var entityManager: EntityManager
+
+    private data class RankedPostId(
+        val postId: UUID,
+        val sortValue: Long,
+    )
 
     /**
      * 기간 필터 + 정렬 조건을 적용하여 게시물 목록 조회
@@ -99,14 +105,14 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             viewerId = viewerId,
             predicates = predicates,
         )
-        addPeriodCondition(cb, cq, root, period, sortType, predicates)
-        addCursorCondition(cb, cq, root, cursor, period, sortType, predicates)
+        addPostCreatedAtPeriodCondition(cb, root, period, sortType, predicates)
+        addCursorCondition(cb, root, cursor, sortType, predicates)
 
         if (predicates.isNotEmpty()) {
             cq.where(*predicates.toTypedArray())
         }
 
-        applyOrdering(cb, cq, root, period, sortType)
+        applyOrdering(cb, cq, root, sortType)
 
         return entityManager.createQuery(cq)
             .setMaxResults(size)
@@ -126,9 +132,42 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         tagIds: List<UUID>?,
         viewerId: UUID?,
     ): List<Post> {
+        val rankedPostIds =
+            findRankedPostIdsWithDailyStats(
+                cursor = cursor,
+                size = size,
+                period = period,
+                sortType = sortType,
+                authorId = authorId,
+                statuses = statuses,
+                categoryId = categoryId,
+                visibleToUserId = visibleToUserId,
+                tagIds = tagIds,
+                viewerId = viewerId,
+            )
+
+        return findPostsByIdsInOrder(rankedPostIds.map { it.postId })
+    }
+
+    private fun findRankedPostIdsWithDailyStats(
+        cursor: PostCursor?,
+        size: Int,
+        period: PostPeriod,
+        sortType: PostSortType,
+        authorId: UUID?,
+        statuses: List<PostStatusEnum>?,
+        categoryId: UUID?,
+        visibleToUserId: UUID?,
+        tagIds: List<UUID>?,
+        viewerId: UUID?,
+    ): List<RankedPostId> {
         val cb = entityManager.criteriaBuilder
-        val cq = cb.createQuery(UUID::class.java)
+        val cq = cb.createTupleQuery()
         val root = cq.from(Post::class.java)
+        val statsRoot = cq.from(PostDailyStats::class.java)
+        val postIdPath = root.get<UUID>(EntityBase_.id)
+        val createdAtPath = root.get<UtilDate>(EntityBase_.createdAt)
+        val sortExpression = dailyStatsSumExpression(cb, statsRoot, sortType)
         val predicates = mutableListOf<Predicate>()
 
         addBaseConditions(
@@ -143,22 +182,25 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             viewerId = viewerId,
             predicates = predicates,
         )
-        addPeriodCondition(cb, cq, root, period, sortType, predicates)
-        addCursorCondition(cb, cq, root, cursor, period, sortType, predicates)
+        addDailyStatsJoinCondition(cb, root, statsRoot, period, predicates)
 
-        cq.select(root.get(EntityBase_.id))
-        if (predicates.isNotEmpty()) {
-            cq.where(*predicates.toTypedArray())
-        }
-        applyOrdering(cb, cq, root, period, sortType)
+        cq.multiselect(postIdPath, sortExpression)
+        cq.where(*predicates.toTypedArray())
+        cq.groupBy(postIdPath, createdAtPath)
+        cursor?.let { cq.having(buildCountCursorCondition(cb, root, it, sortExpression)) }
+        cq.orderBy(countSortOrders(cb, root, sortExpression))
 
-        val postIds =
-            entityManager.createQuery(cq)
-                .setMaxResults(size)
-                .resultList
-
-        return findPostsByIdsInOrder(postIds)
+        return entityManager.createQuery(cq)
+            .setMaxResults(size)
+            .resultList
+            .map { tuple -> tuple.toRankedPostId() }
     }
+
+    private fun Tuple.toRankedPostId(): RankedPostId =
+        RankedPostId(
+            postId = get(0) as UUID,
+            sortValue = (get(1) as Number).toLong(),
+        )
 
     private fun findPostsByIdsInOrder(postIds: List<UUID>): List<Post> {
         if (postIds.isEmpty()) {
@@ -257,62 +299,33 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         predicates.add(cb.exists(tagSubquery))
     }
 
-    /**
-     * 지정된 기간 조건을 적용합니다.
-     *
-     * LATEST 정렬은 기존처럼 게시물 작성일 기준으로 필터링하고,
-     * VIEW/LIKE/COMMENT 정렬은 게시물 작성일이 아니라 기간 내 일별 통계 존재 여부로 필터링합니다.
-     */
-    private fun addPeriodCondition(
+    private fun addPostCreatedAtPeriodCondition(
         cb: CriteriaBuilder,
-        query: CommonAbstractCriteria,
         root: Root<Post>,
         period: PostPeriod,
         sortType: PostSortType,
         predicates: MutableList<Predicate>,
     ) {
-        if (sortType == PostSortType.LATEST) {
-            addPostCreatedAtPeriodCondition(cb, root, period, predicates)
+        if (sortType != PostSortType.LATEST) {
             return
         }
-        addDailyStatsPeriodCondition(cb, query, root, period, predicates)
-    }
 
-    /**
-     * LATEST 정렬의 기간 필터는 게시물 작성일 기준을 유지합니다.
-     */
-    private fun addPostCreatedAtPeriodCondition(
-        cb: CriteriaBuilder,
-        root: Root<Post>,
-        period: PostPeriod,
-        predicates: MutableList<Predicate>,
-    ) {
         period.days?.let { days ->
             val cutoffDate = UtilDate.from(Instant.now().minus(days.toLong(), ChronoUnit.DAYS))
             predicates.add(cb.greaterThanOrEqualTo(root.get(EntityBase_.createdAt), cutoffDate))
         }
     }
 
-    /**
-     * count 기반 기간 랭킹은 게시물 작성일이 아니라 일별 통계 테이블의 최근 데이터 존재 여부로 필터링합니다.
-     */
-    private fun addDailyStatsPeriodCondition(
+    private fun addDailyStatsJoinCondition(
         cb: CriteriaBuilder,
-        query: CommonAbstractCriteria,
         root: Root<Post>,
+        statsRoot: Root<PostDailyStats>,
         period: PostPeriod,
         predicates: MutableList<Predicate>,
     ) {
         val days = period.days ?: return
-        val statsExistsSubquery = query.subquery(Long::class.java)
-        val statsRoot = statsExistsSubquery.from(PostDailyStats::class.java)
-
-        statsExistsSubquery.select(cb.literal(1L))
-        statsExistsSubquery.where(
-            cb.equal(statsRoot.get(PostDailyStats_.post).get(EntityBase_.id), root.get(EntityBase_.id)),
-            cb.greaterThanOrEqualTo(statsRoot.get(PostDailyStats_.statDate), statsCutoffDate(days)),
-        )
-        predicates.add(cb.exists(statsExistsSubquery))
+        predicates.add(cb.equal(statsRoot.get(PostDailyStats_.post).get(EntityBase_.id), root.get(EntityBase_.id)))
+        predicates.add(cb.greaterThanOrEqualTo(statsRoot.get(PostDailyStats_.statDate), statsCutoffDate(days)))
     }
 
     /**
@@ -322,10 +335,8 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
      */
     private fun addCursorCondition(
         cb: CriteriaBuilder,
-        query: CommonAbstractCriteria,
         root: Root<Post>,
         cursor: PostCursor?,
-        period: PostPeriod,
         sortType: PostSortType,
         predicates: MutableList<Predicate>,
     ) {
@@ -334,7 +345,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         val cursorPredicate =
             when (sortType) {
                 PostSortType.LATEST -> buildLatestCursorCondition(cb, root, cursor)
-                else -> buildCountCursorCondition(cb, query, root, cursor, period, sortType)
+                else -> buildCountCursorCondition(cb, root, cursor, postCountExpression(root, sortType))
             }
         predicates.add(cursorPredicate)
     }
@@ -393,14 +404,10 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
      */
     private fun buildCountCursorCondition(
         cb: CriteriaBuilder,
-        query: CommonAbstractCriteria,
         root: Root<Post>,
         cursor: PostCursor,
-        period: PostPeriod,
-        sortType: PostSortType,
+        sortExpression: Expression<Long>,
     ): Predicate {
-        val sortExpression = countSortExpression(cb, query, root, period, sortType)
-
         val countLess = cb.lessThan(sortExpression, cursor.sortValue)
         val countEqualCreatedAtLess =
             cb.and(
@@ -427,7 +434,6 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         cb: CriteriaBuilder,
         cq: CriteriaQuery<*>,
         root: Root<Post>,
-        period: PostPeriod,
         sortType: PostSortType,
     ) {
         val orders =
@@ -437,59 +443,26 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
                         cb.desc(root.get(EntityBase_.updatedAt)),
                         cb.desc(root.get(EntityBase_.id)),
                     )
-                PostSortType.VIEW ->
-                    listOf(
-                        cb.desc(countSortExpression(cb, cq, root, period, sortType)),
-                        cb.desc(root.get(EntityBase_.createdAt)),
-                        cb.desc(root.get(EntityBase_.id)),
-                    )
-                PostSortType.LIKE ->
-                    listOf(
-                        cb.desc(countSortExpression(cb, cq, root, period, sortType)),
-                        cb.desc(root.get(EntityBase_.createdAt)),
-                        cb.desc(root.get(EntityBase_.id)),
-                    )
-                PostSortType.COMMENT ->
-                    listOf(
-                        cb.desc(countSortExpression(cb, cq, root, period, sortType)),
-                        cb.desc(root.get(EntityBase_.createdAt)),
-                        cb.desc(root.get(EntityBase_.id)),
-                    )
+                else -> countSortOrders(cb, root, postCountExpression(root, sortType))
             }
         cq.orderBy(orders)
     }
 
-    private fun countSortExpression(
+    private fun countSortOrders(
         cb: CriteriaBuilder,
-        query: CommonAbstractCriteria,
         root: Root<Post>,
-        period: PostPeriod,
-        sortType: PostSortType,
-    ): Expression<Long> {
-        return if (usesDailyStatsPeriodRanking(period, sortType)) {
-            dailyStatsSumExpression(cb, query, root, period.days!!, sortType)
-        } else {
-            postCountExpression(root, sortType)
-        }
-    }
+        sortExpression: Expression<Long>,
+    ) = listOf(
+        cb.desc(sortExpression),
+        cb.desc(root.get(EntityBase_.createdAt)),
+        cb.desc(root.get(EntityBase_.id)),
+    )
 
     private fun dailyStatsSumExpression(
         cb: CriteriaBuilder,
-        query: CommonAbstractCriteria,
-        root: Root<Post>,
-        days: Int,
+        statsRoot: Root<PostDailyStats>,
         sortType: PostSortType,
-    ): Expression<Long> {
-        val sumSubquery = query.subquery(Long::class.java)
-        val statsRoot = sumSubquery.from(PostDailyStats::class.java)
-
-        sumSubquery.select(cb.coalesce(cb.sum(dailyStatsCountExpression(statsRoot, sortType)), 0L))
-        sumSubquery.where(
-            cb.equal(statsRoot.get(PostDailyStats_.post).get(EntityBase_.id), root.get(EntityBase_.id)),
-            cb.greaterThanOrEqualTo(statsRoot.get(PostDailyStats_.statDate), statsCutoffDate(days)),
-        )
-        return sumSubquery
-    }
+    ): Expression<Long> = cb.coalesce(cb.sum(dailyStatsCountExpression(statsRoot, sortType)), 0L)
 
     private fun postCountExpression(
         root: Root<Post>,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -2,6 +2,7 @@ package com.techtaurant.mainserver.post.infrastructure.out
 
 import com.techtaurant.mainserver.common.base.EntityBase_
 import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.post.application.PostWithSortValue
 import com.techtaurant.mainserver.post.dto.PostCursor
 import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
@@ -21,7 +22,6 @@ import jakarta.persistence.PersistenceContext
 import jakarta.persistence.Tuple
 import jakarta.persistence.criteria.CommonAbstractCriteria
 import jakarta.persistence.criteria.CriteriaBuilder
-import jakarta.persistence.criteria.CriteriaQuery
 import jakarta.persistence.criteria.Expression
 import jakarta.persistence.criteria.JoinType
 import jakarta.persistence.criteria.Path
@@ -67,9 +67,21 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         visibleToUserId: UUID?,
         tagIds: List<UUID>?,
         viewerId: UUID?,
-    ): List<Post> {
-        if (usesDailyStatsPeriodRanking(period, sortType)) {
-            return findPostsWithDailyStatsPeriodRanking(
+    ): List<PostWithSortValue> {
+        return if (sortType == PostSortType.LATEST) {
+            findLatestPostsWithConditions(
+                cursor = cursor,
+                size = size,
+                period = period,
+                authorId = authorId,
+                statuses = statuses,
+                categoryId = categoryId,
+                visibleToUserId = visibleToUserId,
+                tagIds = tagIds,
+                viewerId = viewerId,
+            )
+        } else {
+            findPostsWithStatsRanking(
                 cursor = cursor,
                 size = size,
                 period = period,
@@ -82,7 +94,19 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
                 viewerId = viewerId,
             )
         }
+    }
 
+    private fun findLatestPostsWithConditions(
+        cursor: PostCursor?,
+        size: Int,
+        period: PostPeriod,
+        authorId: UUID?,
+        statuses: List<PostStatusEnum>?,
+        categoryId: UUID?,
+        visibleToUserId: UUID?,
+        tagIds: List<UUID>?,
+        viewerId: UUID?,
+    ): List<PostWithSortValue> {
         val cb = entityManager.criteriaBuilder
         val cq = cb.createQuery(Post::class.java)
         val root = cq.from(Post::class.java)
@@ -105,22 +129,25 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             viewerId = viewerId,
             predicates = predicates,
         )
-        addPostCreatedAtPeriodCondition(cb, root, period, sortType, predicates)
-        addCursorCondition(cb, root, cursor, sortType, predicates)
+        addLatestPeriodCondition(cb, root, period, predicates)
+        cursor?.let { predicates.add(buildLatestCursorCondition(cb, root, it)) }
 
         if (predicates.isNotEmpty()) {
             cq.where(*predicates.toTypedArray())
         }
-
-        applyOrdering(cb, cq, root, sortType)
+        cq.orderBy(
+            cb.desc(root.get(EntityBase_.updatedAt)),
+            cb.desc(root.get(EntityBase_.id)),
+        )
 
         return entityManager.createQuery(cq)
             .setMaxResults(size)
             .resultList
             .distinctBy { it.id }
+            .map { post -> PostWithSortValue(post = post, sortValue = post.updatedAt.time) }
     }
 
-    private fun findPostsWithDailyStatsPeriodRanking(
+    private fun findPostsWithStatsRanking(
         cursor: PostCursor?,
         size: Int,
         period: PostPeriod,
@@ -131,9 +158,9 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         visibleToUserId: UUID?,
         tagIds: List<UUID>?,
         viewerId: UUID?,
-    ): List<Post> {
+    ): List<PostWithSortValue> {
         val rankedPostIds =
-            findRankedPostIdsWithDailyStats(
+            findRankedPostIdsWithStats(
                 cursor = cursor,
                 size = size,
                 period = period,
@@ -146,10 +173,10 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
                 viewerId = viewerId,
             )
 
-        return findPostsByIdsInOrder(rankedPostIds.map { it.postId })
+        return findPostsByRankedIdsInOrder(rankedPostIds)
     }
 
-    private fun findRankedPostIdsWithDailyStats(
+    private fun findRankedPostIdsWithStats(
         cursor: PostCursor?,
         size: Int,
         period: PostPeriod,
@@ -182,7 +209,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             viewerId = viewerId,
             predicates = predicates,
         )
-        addDailyStatsJoinCondition(cb, root, statsRoot, period, predicates)
+        addStatsJoinCondition(cb, root, statsRoot, period, predicates)
 
         cq.multiselect(postIdPath, sortExpression)
         cq.where(*predicates.toTypedArray())
@@ -202,10 +229,13 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             sortValue = (get(1) as Number).toLong(),
         )
 
-    private fun findPostsByIdsInOrder(postIds: List<UUID>): List<Post> {
-        if (postIds.isEmpty()) {
+    private fun findPostsByRankedIdsInOrder(rankedPostIds: List<RankedPostId>): List<PostWithSortValue> {
+        if (rankedPostIds.isEmpty()) {
             return emptyList()
         }
+
+        val postIds = rankedPostIds.map { it.postId }
+        val sortValueByPostId = rankedPostIds.associate { it.postId to it.sortValue }
 
         val cb = entityManager.criteriaBuilder
         val cq = cb.createQuery(Post::class.java)
@@ -222,6 +252,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             .resultList
             .distinctBy { it.id }
             .sortedBy { orderByPostId.getValue(it.id!!) }
+            .map { post -> PostWithSortValue(post = post, sortValue = sortValueByPostId.getValue(post.id!!)) }
     }
 
     override fun findVisiblePostDetailById(
@@ -299,55 +330,29 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         predicates.add(cb.exists(tagSubquery))
     }
 
-    private fun addPostCreatedAtPeriodCondition(
+    private fun addLatestPeriodCondition(
         cb: CriteriaBuilder,
         root: Root<Post>,
         period: PostPeriod,
-        sortType: PostSortType,
         predicates: MutableList<Predicate>,
     ) {
-        if (sortType != PostSortType.LATEST) {
-            return
-        }
-
         period.days?.let { days ->
             val cutoffDate = UtilDate.from(Instant.now().minus(days.toLong(), ChronoUnit.DAYS))
             predicates.add(cb.greaterThanOrEqualTo(root.get(EntityBase_.createdAt), cutoffDate))
         }
     }
 
-    private fun addDailyStatsJoinCondition(
+    private fun addStatsJoinCondition(
         cb: CriteriaBuilder,
         root: Root<Post>,
         statsRoot: Root<PostDailyStats>,
         period: PostPeriod,
         predicates: MutableList<Predicate>,
     ) {
-        val days = period.days ?: return
         predicates.add(cb.equal(statsRoot.get(PostDailyStats_.post).get(EntityBase_.id), root.get(EntityBase_.id)))
-        predicates.add(cb.greaterThanOrEqualTo(statsRoot.get(PostDailyStats_.statDate), statsCutoffDate(days)))
-    }
-
-    /**
-     * 정렬 타입에 따른 커서 조건 추가
-     *
-     * 최신순은 updatedAt + id 기준, 그 외(조회/추천/댓글순)는 해당 count + createdAt + id 기준
-     */
-    private fun addCursorCondition(
-        cb: CriteriaBuilder,
-        root: Root<Post>,
-        cursor: PostCursor?,
-        sortType: PostSortType,
-        predicates: MutableList<Predicate>,
-    ) {
-        cursor ?: return
-
-        val cursorPredicate =
-            when (sortType) {
-                PostSortType.LATEST -> buildLatestCursorCondition(cb, root, cursor)
-                else -> buildCountCursorCondition(cb, root, cursor, postCountExpression(root, sortType))
-            }
-        predicates.add(cursorPredicate)
+        period.days?.let { days ->
+            predicates.add(cb.greaterThanOrEqualTo(statsRoot.get(PostDailyStats_.statDate), statsCutoffDate(days)))
+        }
     }
 
     private fun addViewerBanCondition(
@@ -423,31 +428,6 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         return cb.or(countLess, countEqualCreatedAtLess, countEqualCreatedAtEqualIdLess)
     }
 
-    /**
-     * 정렬 타입에 따른 ORDER BY 절 적용
-     *
-     * 모든 정렬은 DESC이며 동점자 처리를 위해 createdAt, id를 보조 정렬 키로 추가합니다.
-     * 최신순(LATEST)은 updatedAt 기준입니다. createdAt을 기준으로 하면 한 번 생성된 게시물이
-     * 영구히 낮은 순위에 머물 수 있으므로, 수정된 게시물도 상단에 노출될 수 있도록 updatedAt을 사용합니다.
-     */
-    private fun applyOrdering(
-        cb: CriteriaBuilder,
-        cq: CriteriaQuery<*>,
-        root: Root<Post>,
-        sortType: PostSortType,
-    ) {
-        val orders =
-            when (sortType) {
-                PostSortType.LATEST ->
-                    listOf(
-                        cb.desc(root.get(EntityBase_.updatedAt)),
-                        cb.desc(root.get(EntityBase_.id)),
-                    )
-                else -> countSortOrders(cb, root, postCountExpression(root, sortType))
-            }
-        cq.orderBy(orders)
-    }
-
     private fun countSortOrders(
         cb: CriteriaBuilder,
         root: Root<Post>,
@@ -464,17 +444,6 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         sortType: PostSortType,
     ): Expression<Long> = cb.coalesce(cb.sum(dailyStatsCountExpression(statsRoot, sortType)), 0L)
 
-    private fun postCountExpression(
-        root: Root<Post>,
-        sortType: PostSortType,
-    ): Path<Long> =
-        when (sortType) {
-            PostSortType.VIEW -> root.get(Post_.viewCount)
-            PostSortType.LIKE -> root.get(Post_.likeCount)
-            PostSortType.COMMENT -> root.get(Post_.commentCount)
-            else -> throw ApiException(PostStatus.INVALID_SORT_TYPE)
-        }
-
     private fun dailyStatsCountExpression(
         statsRoot: Root<PostDailyStats>,
         sortType: PostSortType,
@@ -485,11 +454,6 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             PostSortType.COMMENT -> statsRoot.get(PostDailyStats_.commentCount)
             else -> throw ApiException(PostStatus.INVALID_SORT_TYPE)
         }
-
-    private fun usesDailyStatsPeriodRanking(
-        period: PostPeriod,
-        sortType: PostSortType,
-    ): Boolean = sortType != PostSortType.LATEST && period.days != null
 
     private fun statsCutoffDate(days: Int): SqlDate = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC).minusDays(days.toLong()))
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -4,12 +4,14 @@ import com.techtaurant.mainserver.attachment.application.AttachmentService
 import com.techtaurant.mainserver.attachment.entity.Attachment
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
 import com.techtaurant.mainserver.attachment.enums.AttachmentStatus
+import com.techtaurant.mainserver.post.dto.PostCursor
 import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostReadLog
 import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostLikeLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
@@ -32,6 +34,7 @@ import java.util.UUID
 
 class PostListReadServiceTest {
     private val postRepository: PostRepository = mockk()
+    private val postDailyStatsRepository: PostDailyStatsRepository = mockk()
     private val postReadLogRepository: PostReadLogRepository = mockk()
     private val postLikeLogRepository: PostLikeLogRepository = mockk()
     private val attachmentService: AttachmentService = mockk()
@@ -60,6 +63,7 @@ class PostListReadServiceTest {
     private fun createPostListReadService(postListQueryStrategies: List<PostListQueryStrategy> = createPostListQueryStrategies()) =
         PostListReadService(
             postRepository = postRepository,
+            postDailyStatsRepository = postDailyStatsRepository,
             attachmentService = attachmentService,
             postMetadataReadService = postMetadataReadService,
             postViewerStateReadService = postViewerStateReadService,
@@ -706,6 +710,48 @@ class PostListReadServiceTest {
             assertThat(result.hasNext).isTrue()
             assertThat(result.nextCursor).isNotNull()
             assertThat(result.content).hasSize(2)
+        }
+
+        @Test
+        @DisplayName("기간 랭킹 nextCursor는 전체 누적값이 아니라 기간 내 일별 집계 합계를 담는다")
+        fun getPosts_periodRankingNextCursor_usesDailyStatsSortValue() {
+            // given
+            val posts = (1..3).map { createPost(testUser) }
+            val lastContentPost = posts[1].apply { commentCount = 100 }
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 3,
+                    period = PostPeriod.MONTH,
+                    sortType = PostSortType.COMMENT,
+                    authorId = testUser.id!!,
+                    statuses = listOf(PostStatusEnum.PUBLISHED, PostStatusEnum.PRIVATE),
+                    categoryId = null,
+                    tagIds = null,
+                    viewerId = testUser.id!!,
+                )
+            } returns posts
+            every {
+                postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
+            } returns emptyList()
+            every {
+                postDailyStatsRepository.sumCommentCountSince(lastContentPost.id!!, any())
+            } returns 5
+
+            // when
+            val result =
+                postListReadService.getPosts(
+                    cursor = null,
+                    size = 2,
+                    period = PostPeriod.MONTH,
+                    sortType = PostSortType.COMMENT,
+                    currentUserId = testUser.id!!,
+                    authorId = testUser.id!!,
+                )
+
+            // then
+            val decodedCursor = PostCursor.decode(result.nextCursor!!)
+            assertThat(decodedCursor?.sortValue).isEqualTo(5)
         }
 
         @Test

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -11,7 +11,6 @@ import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostReadLog
 import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
-import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostLikeLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
@@ -34,7 +33,6 @@ import java.util.UUID
 
 class PostListReadServiceTest {
     private val postRepository: PostRepository = mockk()
-    private val postDailyStatsRepository: PostDailyStatsRepository = mockk()
     private val postReadLogRepository: PostReadLogRepository = mockk()
     private val postLikeLogRepository: PostLikeLogRepository = mockk()
     private val attachmentService: AttachmentService = mockk()
@@ -63,7 +61,6 @@ class PostListReadServiceTest {
     private fun createPostListReadService(postListQueryStrategies: List<PostListQueryStrategy> = createPostListQueryStrategies()) =
         PostListReadService(
             postRepository = postRepository,
-            postDailyStatsRepository = postDailyStatsRepository,
             attachmentService = attachmentService,
             postMetadataReadService = postMetadataReadService,
             postViewerStateReadService = postViewerStateReadService,
@@ -118,6 +115,9 @@ class PostListReadServiceTest {
             category = category,
             status = status,
         ).apply { id = UUID.randomUUID() }
+
+    private fun List<Post>.withSortValues(sortValueResolver: (Post) -> Long = { it.updatedAt.time }): List<PostWithSortValue> =
+        map { post -> PostWithSortValue(post = post, sortValue = sortValueResolver(post)) }
 
     private fun createAttachment(
         postId: UUID,
@@ -232,7 +232,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns emptyList()
@@ -269,7 +269,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = null,
                 )
-            } returns posts
+            } returns posts.withSortValues()
 
             // when
             postListReadService.getPosts(cursor = null, size = 20, currentUserId = null)
@@ -305,7 +305,7 @@ class PostListReadServiceTest {
                     tagIds = listOf(firstTagId, secondTagId),
                     viewerId = null,
                 )
-            } returns posts
+            } returns posts.withSortValues()
 
             // when
             postListReadService.getPosts(
@@ -356,7 +356,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = null,
                 )
-            } returns listOf(post)
+            } returns listOf(post).withSortValues()
             every {
                 attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(post.id!!), AttachmentReferenceType.POST)
             } returns mapOf(post.id!! to listOf(laterAttachment, firstAttachment))
@@ -398,7 +398,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = null,
                 )
-            } returns listOf(post)
+            } returns listOf(post).withSortValues()
             every {
                 attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(post.id!!), AttachmentReferenceType.POST)
             } returns mapOf(post.id!! to listOf(otherAttachment, thumbnailAttachment))
@@ -437,7 +437,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = null,
                 )
-            } returns listOf(post)
+            } returns listOf(post).withSortValues()
 
             // when
             val result = postListReadService.getPostContents(cursor = null, size = 20)
@@ -490,7 +490,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns emptyList()
@@ -536,7 +536,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns emptyList()
@@ -582,7 +582,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns emptyList()
@@ -628,7 +628,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = null,
                 )
-            } returns posts
+            } returns posts.withSortValues()
 
             // when
             val result =
@@ -692,7 +692,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns emptyList()
@@ -730,13 +730,10 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues { post -> if (post.id == lastContentPost.id) 5 else 10 }
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns emptyList()
-            every {
-                postDailyStatsRepository.sumCommentCountSince(lastContentPost.id!!, any())
-            } returns 5
 
             // when
             val result =
@@ -771,7 +768,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns emptyList()
@@ -812,7 +809,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns listOf(readLog)
@@ -850,7 +847,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = null,
                 )
-            } returns posts
+            } returns posts.withSortValues()
 
             // when
             val result =
@@ -890,7 +887,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = null,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(otherUser.id!!), AttachmentReferenceType.USER)
             } returns mapOf(otherUser.id!! to listOf(profileAttachment))

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostControllerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostControllerTest.kt
@@ -5,7 +5,9 @@ import com.techtaurant.mainserver.common.dto.ApiResponse
 import com.techtaurant.mainserver.common.dto.CursorPageResponse
 import com.techtaurant.mainserver.post.dto.PostListItemResponse
 import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.entity.PostDailyStats
 import com.techtaurant.mainserver.post.entity.Tag
+import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.post.infrastructure.out.TagRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
@@ -19,16 +21,22 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.Calendar
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import java.sql.Date as SqlDate
 
 @DisplayName("게시물 목록 조회 API")
 class PostControllerTest : IntegrationTest() {
     @Autowired
     private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var postDailyStatsRepository: PostDailyStatsRepository
 
     @Autowired
     private lateinit var userRepository: UserRepository
@@ -41,6 +49,7 @@ class PostControllerTest : IntegrationTest() {
 
     @BeforeEach
     fun setup() {
+        postDailyStatsRepository.deleteAllInBatch()
         postRepository.deleteAllInBatch()
         userRepository.deleteAllInBatch()
 
@@ -482,7 +491,7 @@ class PostControllerTest : IntegrationTest() {
         @Test
         @DisplayName("기간 필터와 정렬을 함께 적용하면 올바르게 로딩되어야 한다")
         fun whenApplyBothPeriodAndSort_thenCorrectPostsLoaded() {
-            // When: 최근 7일의 게시물을 조회수 기준으로 정렬해서 조회
+            // When: 최근 7일 내 일별 집계가 있는 게시물을 조회수 기준으로 정렬해서 조회
             val response =
                 RestAssured
                     .given()
@@ -496,9 +505,9 @@ class PostControllerTest : IntegrationTest() {
                     .extract()
                     .`as`(object : TypeRef<ApiResponse<CursorPageResponse<PostListItemResponse>>>() {})
 
-            // Then: 필터된 데이터가 정렬되어 로드되어야 함
+            // Then: 게시물 작성일이 아니라 최근 일별 집계 데이터를 기준으로 필터링/정렬되어야 함
             val content = response.data!!.content
-            assertEquals(3, content.size, "최근 7일 내 게시물은 2개여야 함")
+            assertEquals(3, content.size, "최근 7일 내 일별 집계가 있는 게시물은 3개여야 함")
             assertTrue(
                 content[0].viewCount >= content[1].viewCount,
                 "조회수 기준 내림차순 정렬되어야 함",
@@ -590,6 +599,20 @@ class PostControllerTest : IntegrationTest() {
         savedPosts[1].tags.add(tag2)
         savedPosts[2].tags.add(tag3)
 
-        return postRepository.saveAll(savedPosts)
+        val savedPostsWithTags = postRepository.saveAll(savedPosts)
+        val today = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC))
+        postDailyStatsRepository.saveAll(
+            savedPostsWithTags.map { post ->
+                PostDailyStats(
+                    post = post,
+                    statDate = today,
+                    viewCount = post.viewCount,
+                    likeCount = post.likeCount,
+                    commentCount = post.commentCount,
+                )
+            },
+        )
+
+        return savedPostsWithTags
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
@@ -2,7 +2,9 @@ package com.techtaurant.mainserver.post.infrastructure.`in`
 
 import com.techtaurant.mainserver.base.IntegrationTest
 import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.entity.PostDailyStats
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
@@ -13,6 +15,7 @@ import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import io.restassured.RestAssured.given
 import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.hasItem
 import org.hamcrest.Matchers.not
 import org.junit.jupiter.api.BeforeEach
@@ -20,7 +23,13 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import java.util.UUID
+import java.sql.Date as SqlDate
+import java.util.Date as UtilDate
 
 @DisplayName("PostReadOpenApiController 통합 테스트")
 class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
@@ -29,6 +38,9 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
 
     @Autowired
     private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var postDailyStatsRepository: PostDailyStatsRepository
 
     @Autowired
     private lateinit var jwtTokenProvider: JwtTokenProvider
@@ -43,6 +55,7 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
     @BeforeEach
     fun setUpTestData() {
         userBanRepository.deleteAllInBatch()
+        postDailyStatsRepository.deleteAllInBatch()
         postRepository.deleteAllInBatch()
         userRepository.deleteAllInBatch()
         testUser =
@@ -196,6 +209,124 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
     }
 
     @Test
+    @DisplayName("댓글순 30일 랭킹은 게시물 작성일이 아니라 기간 내 일별 댓글 집계 합계로 정렬하고 필터링한다")
+    fun getPosts_monthCommentRanking_usesRecentDailyStatsInsteadOfPostCreatedAt() {
+        // given
+        val oldPostWithMoreRecentComments =
+            createPublishedPost(
+                title = "오래됐지만 최근 댓글이 많은 게시물",
+                daysAgo = 500,
+                commentCount = 1,
+            )
+        createDailyStats(oldPostWithMoreRecentComments, daysAgo = 0, commentCount = 6)
+        createDailyStats(oldPostWithMoreRecentComments, daysAgo = 3, commentCount = 4)
+
+        val oldPostWithFewerRecentComments =
+            createPublishedPost(
+                title = "오래됐지만 최근 댓글이 있는 게시물",
+                daysAgo = 400,
+                commentCount = 999,
+            )
+        createDailyStats(oldPostWithFewerRecentComments, daysAgo = 2, commentCount = 5)
+
+        val recentPostWithoutStats =
+            createPublishedPost(
+                title = "최근 작성됐지만 집계가 없는 게시물",
+                daysAgo = 1,
+                commentCount = 2_000,
+            )
+        val oldPostWithStaleStats =
+            createPublishedPost(
+                title = "오래된 집계만 있는 게시물",
+                daysAgo = 300,
+                commentCount = 3_000,
+            )
+        createDailyStats(oldPostWithStaleStats, daysAgo = 31, commentCount = 100)
+
+        // when & then
+        given()
+            .queryParam("period", "MONTH")
+            .queryParam("sort", "COMMENT")
+            .queryParam("size", 10)
+            .`when`()
+            .get("/open-api/posts")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body(
+                "data.content.id",
+                contains(
+                    oldPostWithMoreRecentComments.id.toString(),
+                    oldPostWithFewerRecentComments.id.toString(),
+                ),
+            )
+            .body("data.content.id", not(hasItem(recentPostWithoutStats.id.toString())))
+            .body("data.content.id", not(hasItem(oldPostWithStaleStats.id.toString())))
+    }
+
+    @Test
+    @DisplayName("댓글순 30일 랭킹 커서는 전체 누적 댓글수가 아니라 기간 내 일별 댓글 집계 합계로 다음 페이지를 조회한다")
+    fun getPosts_monthCommentRankingCursor_usesRecentDailyStatsSortValue() {
+        // given
+        val firstPost =
+            createPublishedPost(
+                title = "첫 페이지 게시물",
+                daysAgo = 500,
+                commentCount = 1,
+            )
+        createDailyStats(firstPost, daysAgo = 0, commentCount = 10)
+
+        val secondPost =
+            createPublishedPost(
+                title = "두 번째 페이지 첫 게시물",
+                daysAgo = 400,
+                commentCount = 999,
+            )
+        createDailyStats(secondPost, daysAgo = 0, commentCount = 5)
+
+        val thirdPost =
+            createPublishedPost(
+                title = "두 번째 페이지 둘째 게시물",
+                daysAgo = 300,
+                commentCount = 998,
+            )
+        createDailyStats(thirdPost, daysAgo = 0, commentCount = 1)
+
+        // when
+        val firstPageResponse =
+            given()
+                .queryParam("period", "MONTH")
+                .queryParam("sort", "COMMENT")
+                .queryParam("size", 1)
+                .`when`()
+                .get("/open-api/posts")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+
+        val cursor = firstPageResponse.path<String>("data.nextCursor")
+
+        val secondPageResponse =
+            given()
+                .queryParam("period", "MONTH")
+                .queryParam("sort", "COMMENT")
+                .queryParam("size", 2)
+                .queryParam("cursor", cursor)
+                .`when`()
+                .get("/open-api/posts")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+
+        // then
+        assertThat(firstPageResponse.path<List<String>>("data.content.id")).containsExactly(firstPost.id.toString())
+        assertThat(cursor).isNotBlank()
+        assertThat(secondPageResponse.path<List<String>>("data.content.id")).containsExactly(
+            secondPost.id.toString(),
+            thirdPost.id.toString(),
+        )
+    }
+
+    @Test
     @DisplayName("로그인 사용자가 차단한 작성자의 게시물 상세 조회 시 404를 반환한다")
     fun getPostDetail_bannedAuthor_returnsNotFound() {
         // given
@@ -244,4 +375,49 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
         val updatedPost = postRepository.findById(post.id!!).orElseThrow()
         assertThat(updatedPost.viewCount).isEqualTo(1)
     }
+
+    private fun createPublishedPost(
+        title: String,
+        daysAgo: Long,
+        viewCount: Long = 0,
+        likeCount: Long = 0,
+        commentCount: Long = 0,
+    ): Post {
+        val createdAt = UtilDate.from(Instant.now().minus(daysAgo, ChronoUnit.DAYS))
+        val post =
+            postRepository.saveAndFlush(
+                Post(
+                    title = title,
+                    content = "본문",
+                    author = testUser,
+                    viewCount = viewCount,
+                    likeCount = likeCount,
+                    commentCount = commentCount,
+                    status = PostStatusEnum.PUBLISHED,
+                ),
+            )
+
+        post.createdAt = createdAt
+        post.updatedAt = createdAt
+        return postRepository.saveAndFlush(post)
+    }
+
+    private fun createDailyStats(
+        post: Post,
+        daysAgo: Long,
+        viewCount: Long = 0,
+        likeCount: Long = 0,
+        commentCount: Long = 0,
+    ): PostDailyStats =
+        postDailyStatsRepository.save(
+            PostDailyStats(
+                post = post,
+                statDate = statDateDaysAgo(daysAgo),
+                viewCount = viewCount,
+                likeCount = likeCount,
+                commentCount = commentCount,
+            ),
+        )
+
+    private fun statDateDaysAgo(daysAgo: Long): SqlDate = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC).minusDays(daysAgo))
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
@@ -264,6 +264,44 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
     }
 
     @Test
+    @DisplayName("조회순 전체 랭킹은 post 누적 조회수가 아니라 일별 집계 전체 합계로 정렬한다")
+    fun getPosts_allViewRanking_usesDailyStatsTotalSum() {
+        // given
+        val postWithMoreDailyStats =
+            createPublishedPost(
+                title = "누적 조회수는 낮지만 전체 집계 조회수가 높은 게시물",
+                daysAgo = 500,
+                viewCount = 1,
+            )
+        createDailyStats(postWithMoreDailyStats, daysAgo = 100, viewCount = 7)
+
+        val postWithFewerDailyStats =
+            createPublishedPost(
+                title = "누적 조회수는 높지만 전체 집계 조회수가 낮은 게시물",
+                daysAgo = 400,
+                viewCount = 100,
+            )
+        createDailyStats(postWithFewerDailyStats, daysAgo = 1, viewCount = 3)
+
+        // when & then
+        given()
+            .queryParam("period", "ALL")
+            .queryParam("sort", "VIEW")
+            .queryParam("size", 10)
+            .`when`()
+            .get("/open-api/posts")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body(
+                "data.content.id",
+                contains(
+                    postWithMoreDailyStats.id.toString(),
+                    postWithFewerDailyStats.id.toString(),
+                ),
+            )
+    }
+
+    @Test
     @DisplayName("댓글순 30일 랭킹 커서는 전체 누적 댓글수가 아니라 기간 내 일별 댓글 집계 합계로 다음 페이지를 조회한다")
     fun getPosts_monthCommentRankingCursor_usesRecentDailyStatsSortValue() {
         // given

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
@@ -368,6 +368,35 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
         }
 
         @Test
+        @DisplayName("조회순 전체 랭킹도 post 누적값이 아니라 일별 집계 전체 합계로 정렬한다")
+        fun findPostsWithConditions_viewAllStatsRanking_usesDailyStatsTotalSum() {
+            // given
+            val postWithMoreDailyStats = movePostCreatedAt(createPost(userA), daysAgo = 500)
+            postWithMoreDailyStats.viewCount = 1
+            createDailyStats(postWithMoreDailyStats, daysAgo = 100, viewCount = 7)
+
+            val postWithFewerDailyStats = movePostCreatedAt(createPost(userA), daysAgo = 400)
+            postWithFewerDailyStats.viewCount = 100
+            createDailyStats(postWithFewerDailyStats, daysAgo = 1, viewCount = 3)
+            postRepository.saveAllAndFlush(listOf(postWithMoreDailyStats, postWithFewerDailyStats))
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.VIEW,
+                )
+
+            // then
+            assertThat(result).extracting("id").containsExactly(
+                postWithMoreDailyStats.id,
+                postWithFewerDailyStats.id,
+            )
+        }
+
+        @Test
         @DisplayName("조회순 기간 랭킹은 기간 내 일별 조회 집계 합계로 정렬한다")
         fun findPostsWithConditions_viewPeriodRanking_usesRecentDailyStatsSum() {
             // given

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
@@ -1,8 +1,10 @@
 package com.techtaurant.mainserver.post.infrastructure.out
 
 import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.post.dto.PostCursor
 import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.entity.PostDailyStats
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
@@ -20,13 +22,22 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import java.util.UUID
+import java.sql.Date as SqlDate
+import java.util.Date as UtilDate
 
 @Transactional
 @ActiveProfiles("test")
 class PostRepositoryCustomImplTest : IntegrationTest() {
     @Autowired
     private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var postDailyStatsRepository: PostDailyStatsRepository
 
     @Autowired
     private lateinit var userRepository: UserRepository
@@ -43,6 +54,7 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
 
     @BeforeEach
     fun setUpTestData() {
+        postDailyStatsRepository.deleteAllInBatch()
         postRepository.deleteAll()
         userBanRepository.deleteAllInBatch()
 
@@ -93,6 +105,35 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
                 category = postCategory,
             ),
         )
+
+    private fun movePostCreatedAt(
+        post: Post,
+        daysAgo: Long,
+    ): Post {
+        val createdAt = UtilDate.from(Instant.now().minus(daysAgo, ChronoUnit.DAYS))
+        post.createdAt = createdAt
+        post.updatedAt = createdAt
+        return postRepository.saveAndFlush(post)
+    }
+
+    private fun createDailyStats(
+        post: Post,
+        daysAgo: Long,
+        viewCount: Long = 0,
+        likeCount: Long = 0,
+        commentCount: Long = 0,
+    ): PostDailyStats =
+        postDailyStatsRepository.save(
+            PostDailyStats(
+                post = post,
+                statDate = statDateDaysAgo(daysAgo),
+                viewCount = viewCount,
+                likeCount = likeCount,
+                commentCount = commentCount,
+            ),
+        )
+
+    private fun statDateDaysAgo(daysAgo: Long): SqlDate = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC).minusDays(daysAgo))
 
     @Nested
     @DisplayName("authorId 필터링")
@@ -286,6 +327,163 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
             // then
             assertThat(result).hasSize(1)
             assertThat(result[0].id).isEqualTo(target.id)
+        }
+    }
+
+    @Nested
+    @DisplayName("기간 통계 랭킹")
+    inner class PeriodStatsRanking {
+        @Test
+        @DisplayName("댓글순 기간 랭킹은 게시물 작성일이 아니라 기간 내 일별 댓글 집계 합계로 정렬하고 필터링한다")
+        fun findPostsWithConditions_commentPeriodRanking_usesRecentDailyStatsInsteadOfPostCreatedAt() {
+            // given
+            val oldPostWithTodayComments = movePostCreatedAt(createPost(userA), daysAgo = 500)
+            createDailyStats(oldPostWithTodayComments, daysAgo = 0, commentCount = 5)
+
+            val oldPostWithRecentComments = movePostCreatedAt(createPost(userA), daysAgo = 400)
+            createDailyStats(oldPostWithRecentComments, daysAgo = 3, commentCount = 2)
+
+            val recentPostWithoutStats = createPost(userA)
+            val oldPostWithStaleComments = movePostCreatedAt(createPost(userA), daysAgo = 300)
+            createDailyStats(oldPostWithStaleComments, daysAgo = 31, commentCount = 99)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.MONTH,
+                    sortType = PostSortType.COMMENT,
+                )
+
+            // then
+            assertThat(result).extracting("id").containsExactly(
+                oldPostWithTodayComments.id,
+                oldPostWithRecentComments.id,
+            )
+            assertThat(result).extracting("id").doesNotContain(
+                recentPostWithoutStats.id,
+                oldPostWithStaleComments.id,
+            )
+        }
+
+        @Test
+        @DisplayName("조회순 기간 랭킹은 기간 내 일별 조회 집계 합계로 정렬한다")
+        fun findPostsWithConditions_viewPeriodRanking_usesRecentDailyStatsSum() {
+            // given
+            val oldPostWithMoreViews = movePostCreatedAt(createPost(userA), daysAgo = 500)
+            oldPostWithMoreViews.viewCount = 1
+            createDailyStats(oldPostWithMoreViews, daysAgo = 0, viewCount = 7)
+
+            val oldPostWithFewerViews = movePostCreatedAt(createPost(userA), daysAgo = 400)
+            oldPostWithFewerViews.viewCount = 100
+            createDailyStats(oldPostWithFewerViews, daysAgo = 1, viewCount = 3)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.WEEK,
+                    sortType = PostSortType.VIEW,
+                )
+
+            // then
+            assertThat(result).extracting("id").containsExactly(
+                oldPostWithMoreViews.id,
+                oldPostWithFewerViews.id,
+            )
+        }
+
+        @Test
+        @DisplayName("추천순 기간 랭킹은 기간 내 일별 추천 집계 합계로 정렬한다")
+        fun findPostsWithConditions_likePeriodRanking_usesRecentDailyStatsSum() {
+            // given
+            val oldPostWithMoreLikes = movePostCreatedAt(createPost(userA), daysAgo = 500)
+            oldPostWithMoreLikes.likeCount = 1
+            createDailyStats(oldPostWithMoreLikes, daysAgo = 0, likeCount = 4)
+
+            val oldPostWithFewerLikes = movePostCreatedAt(createPost(userA), daysAgo = 400)
+            oldPostWithFewerLikes.likeCount = 100
+            createDailyStats(oldPostWithFewerLikes, daysAgo = 1, likeCount = 2)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.WEEK,
+                    sortType = PostSortType.LIKE,
+                )
+
+            // then
+            assertThat(result).extracting("id").containsExactly(
+                oldPostWithMoreLikes.id,
+                oldPostWithFewerLikes.id,
+            )
+        }
+
+        @Test
+        @DisplayName("기간 랭킹 커서는 전체 누적값이 아니라 기간 내 일별 집계 합계로 다음 페이지를 조회한다")
+        fun findPostsWithConditions_periodRankingCursor_usesRecentDailyStatsSortValue() {
+            // given
+            val firstPageLastPost = movePostCreatedAt(createPost(userA), daysAgo = 500)
+            firstPageLastPost.commentCount = 1_000
+            createDailyStats(firstPageLastPost, daysAgo = 0, commentCount = 10)
+
+            val secondPageFirstPost = movePostCreatedAt(createPost(userA), daysAgo = 400)
+            secondPageFirstPost.commentCount = 999
+            createDailyStats(secondPageFirstPost, daysAgo = 0, commentCount = 5)
+
+            val secondPageSecondPost = movePostCreatedAt(createPost(userA), daysAgo = 300)
+            secondPageSecondPost.commentCount = 998
+            createDailyStats(secondPageSecondPost, daysAgo = 0, commentCount = 1)
+            postRepository.saveAllAndFlush(listOf(firstPageLastPost, secondPageFirstPost, secondPageSecondPost))
+
+            val cursor =
+                PostCursor(
+                    sortValue = 10,
+                    createdAt = firstPageLastPost.createdAt,
+                    id = firstPageLastPost.id!!,
+                    sortType = PostSortType.COMMENT,
+                )
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = cursor,
+                    size = 10,
+                    period = PostPeriod.MONTH,
+                    sortType = PostSortType.COMMENT,
+                )
+
+            // then
+            assertThat(result).extracting("id").containsExactly(
+                secondPageFirstPost.id,
+                secondPageSecondPost.id,
+            )
+        }
+
+        @Test
+        @DisplayName("최신순 기간 필터는 기존처럼 게시물 작성일 기준으로 동작한다")
+        fun findPostsWithConditions_latestPeriod_keepsPostCreatedAtFilter() {
+            // given
+            val recentPost = createPost(userA)
+            val oldPost = movePostCreatedAt(createPost(userA), daysAgo = 500)
+            createDailyStats(oldPost, daysAgo = 0, commentCount = 5)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.MONTH,
+                    sortType = PostSortType.LATEST,
+                )
+
+            // then
+            assertThat(result).extracting("id").contains(recentPost.id)
+            assertThat(result).extracting("id").doesNotContain(oldPost.id)
         }
     }
 


### PR DESCRIPTION
## 어떤 작업인가요?
- 인기 게시물 목록 정렬을 게시물의 최근 30일 집계값 기준으로 산정하도록 변경합니다.
- 기간 인기순 조회 로직을 `post_daily_stats` join + 기간 조건 + 게시물별 `SUM(...)` 기준 정렬 구조로 정리합니다.

## 어떻게 해결했나요?
**30일 집계 기준 인기 순위 산정**
- 게시물 집계 테이블에서 최근 30일치 조회수, 좋아요수, 댓글수를 합산해 인기 순위에 사용하도록 조회 로직을 확장했습니다.
- 기간 인기순은 게시물 작성일이 아니라 집계 테이블의 기간 조건을 기준으로 필터링합니다.
- 동점 상황에서도 안정적으로 정렬/커서 페이지네이션이 동작하도록 `SUM(...) DESC, createdAt DESC, id DESC` 순서를 유지합니다.

**쿼리 구조 리팩터링**
- 기간 인기순 ID 조회 단계에서 `RankedPostId(postId, sortValue)` 형태로 집계 정렬값을 함께 계산합니다.
- 목록 응답 hydration은 정렬된 ID 목록을 다시 fetch join으로 로딩한 뒤 기존 순서를 유지하도록 분리했습니다.
- 커서 생성은 `sortValueOverride` 대신 명시적인 `sortValue`를 받도록 정리했습니다.

**순위 검증 테스트 추가**
- repository, service, controller, open API integration 계층에서 최근 30일 집계값만 반영되는지 검증했습니다.
- 30일 이전 집계값 제외와 커서 페이지네이션 순위 유지 케이스를 추가했습니다.

## 중요한 변경 사항은 무엇인가요?
### 인기 게시물 정렬 기준 변경

**최근 30일 집계값 합산 적용**
- **변경 이유**: 전체 누적값이 아니라 최근 30일 동안의 반응을 기준으로 게시물 순위를 산정해야 하기 때문입니다.
- **수정 파일**: `PostRepositoryCustomImpl.kt`, `PostDailyStatsRepository.kt`, `PostListReadService.kt`

**집계 쿼리 구조 개선**
- **변경 이유**: 기간 인기순 분기가 직관적으로 보이도록 join/group by/sum 정렬 로직을 repository 쿼리 단계로 모으기 위해서입니다.
- **수정 파일**: `PostRepositoryCustomImpl.kt`, `PostWithSortValue.kt`

**커서 정렬 값 명시화**
- **변경 이유**: 집계 기반 정렬 결과를 다음 페이지 조회에서도 동일하게 유지해야 하기 때문입니다.
- **수정 파일**: `PostCursor.kt`, `PostListReadService.kt`

### 테스트 보강

**집계 순위 테스트 추가**
- **변경 이유**: 최근 30일 집계값 기반 순위와 30일 이전 데이터 제외를 회귀 방지하기 위해서입니다.
- **수정 파일**: `PostReadOpenApiControllerIntegrationTest.kt`, `PostRepositoryCustomImplTest.kt`, `PostListReadServiceTest.kt`, `PostControllerTest.kt`

## 테스트
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew test --tests 'com.techtaurant.mainserver.post.infrastructure.in.PostReadOpenApiControllerIntegrationTest' --tests 'com.techtaurant.mainserver.post.infrastructure.out.PostRepositoryCustomImplTest' --tests 'com.techtaurant.mainserver.post.application.PostListReadServiceTest' -x jacocoTestCoverageVerification`
- [x] GitHub Actions `test` check passed

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙입니다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
