### PR TITLE
feat: 30일 집계 랭킹과 UTC 시간 컬럼 전환

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,3 +4,11 @@
 - 성공 응답은 Controller/Docs 메서드의 실제 반환 타입(`ApiResponse<SomeResponse>`)에서 SpringDoc이 자동 추론하도록 둔다.
 - Swagger 테스트의 media type 경로를 맞추기 위해 Controller mapping에 불필요한 `produces`를 추가하지 않는다.
 - 서버 내부 시간은 항상 UTC 기준으로 동작시킨다. 별도 `Clock` Bean 또는 `TimeConfig`를 만들지 말고, JVM/JPA/Jackson 기본 시간대를 UTC로 고정한 상태에서 `Instant`, `ZoneOffset.UTC`를 명시적으로 사용한다.
+
+## Temporal Rules
+
+- 절대 시각(생성/수정/만료/로그 시각 등)은 PostgreSQL `TIMESTAMPTZ`, Kotlin/Java `Instant`로 관리한다.
+- 날짜 단위 집계/버킷(일별 통계 키 등)은 PostgreSQL `DATE`, Kotlin/Java `LocalDate`로 관리하고 기준 날짜는 `ZoneOffset.UTC`에서 계산한다.
+- `LocalDateTime`, `java.util.Date`, `java.sql.Timestamp`는 도메인/엔티티/DTO의 시간 타입으로 새로 사용하지 않는다. 외부 라이브러리 경계에서 필요할 때만 변환한다.
+- 기존 `TIMESTAMP` 컬럼을 UTC 컬럼으로 전환할 때는 expand-contract 방식으로 `*_utc TIMESTAMPTZ` 컬럼을 추가하고, backfill과 old/new 컬럼 동기화 trigger를 둔 뒤 애플리케이션 read/write 경로를 UTC 컬럼으로 옮긴다.
+- 운영 중 인덱스 추가는 가능한 한 `CREATE INDEX CONCURRENTLY`를 사용하고, Flyway PostgreSQL migration에서는 해당 migration이 트랜잭션 안에서 실행되지 않도록 설정을 확인한다.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,7 +159,7 @@ tasks.named<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
 
     violationRules {
         rule {
-            element = "CLASS"
+            element = "BUNDLE"
 
             limit {
                 counter = "METHOD"

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentDeleteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/application/CommentDeleteService.kt
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 /**
@@ -50,7 +50,7 @@ class CommentDeleteService(
         }
 
         comment.content = hashContent(comment.content)
-        comment.deletedAt = Date()
+        comment.deletedAt = Instant.now()
 
         commentRepository.save(comment)
         comment.parent?.id?.let(commentRepository::decrementReplyCount)

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentContentListResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentContentListResponse.kt
@@ -2,7 +2,7 @@ package com.techtaurant.mainserver.comment.dto
 
 import com.techtaurant.mainserver.comment.entity.Comment
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 @Schema(description = "댓글 공개 콘텐츠 목록 응답")
@@ -20,9 +20,9 @@ data class CommentContentListResponse(
     @field:Schema(description = "댓글 깊이 (0: 댓글, 1: 대댓글)")
     val depth: Int,
     @field:Schema(description = "생성 시각")
-    val createdAt: Date,
+    val createdAt: Instant,
     @field:Schema(description = "수정 시각")
-    val updatedAt: Date,
+    val updatedAt: Instant,
 ) {
     companion object {
         fun from(comment: Comment): CommentContentListResponse =

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentCursor.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentCursor.kt
@@ -2,8 +2,8 @@ package com.techtaurant.mainserver.comment.dto
 
 import com.techtaurant.mainserver.comment.entity.Comment
 import com.techtaurant.mainserver.comment.enums.CommentSortType
+import java.time.Instant
 import java.util.Base64
-import java.util.Date
 import java.util.UUID
 
 /**
@@ -20,7 +20,7 @@ import java.util.UUID
  */
 data class CommentCursor(
     val sortValue: Long,
-    val createdAt: Date,
+    val createdAt: Instant,
     val id: UUID,
     val sortType: CommentSortType,
 ) {
@@ -28,7 +28,7 @@ data class CommentCursor(
      * 커서를 Base64 인코딩된 문자열로 변환
      */
     fun encode(): String {
-        val raw = "${sortType.name}:$sortValue:${createdAt.time}:$id"
+        val raw = "${sortType.name}|$sortValue|$createdAt|$id"
         return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.toByteArray())
     }
 
@@ -42,18 +42,34 @@ data class CommentCursor(
         fun decode(cursor: String): CommentCursor? {
             return try {
                 val decoded = String(Base64.getUrlDecoder().decode(cursor))
-                val parts = decoded.split(":")
-                if (parts.size != 4) return null
-
-                val sortType = CommentSortType.fromString(parts[0])
-                val sortValue = parts[1].toLongOrNull() ?: return null
-                val timestamp = parts[2].toLongOrNull() ?: return null
-                val uuid = UUID.fromString(parts[3])
-
-                CommentCursor(sortValue, Date(timestamp), uuid, sortType)
+                decodePipeDelimited(decoded) ?: decodeLegacyColonDelimited(decoded)
             } catch (e: Exception) {
                 null
             }
+        }
+
+        private fun decodePipeDelimited(decoded: String): CommentCursor? {
+            val parts = decoded.split("|")
+            if (parts.size != 4) return null
+
+            val sortType = CommentSortType.fromString(parts[0])
+            val sortValue = parts[1].toLongOrNull() ?: return null
+            val timestamp = Instant.parse(parts[2])
+            val uuid = UUID.fromString(parts[3])
+
+            return CommentCursor(sortValue, timestamp, uuid, sortType)
+        }
+
+        private fun decodeLegacyColonDelimited(decoded: String): CommentCursor? {
+            val parts = decoded.split(":")
+            if (parts.size != 4) return null
+
+            val sortType = CommentSortType.fromString(parts[0])
+            val sortValue = parts[1].toLongOrNull() ?: return null
+            val timestamp = parts[2].toLongOrNull() ?: return null
+            val uuid = UUID.fromString(parts[3])
+
+            return CommentCursor(sortValue, Instant.ofEpochMilli(timestamp), uuid, sortType)
         }
 
         /**

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentListResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentListResponse.kt
@@ -3,7 +3,8 @@ package com.techtaurant.mainserver.comment.dto
 import com.techtaurant.mainserver.comment.entity.Comment
 import com.techtaurant.mainserver.common.enums.LikeStatus
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.*
+import java.time.Instant
+import java.util.UUID
 
 /**
  * 댓글 목록 응답 DTO
@@ -37,9 +38,9 @@ data class CommentListResponse(
     @field:Schema(description = "현재 사용자가 차단한 작성자의 댓글인지 여부")
     val isBanned: Boolean,
     @field:Schema(description = "생성 시각")
-    val createdAt: Date,
+    val createdAt: Instant,
     @field:Schema(description = "수정 시각")
-    val updatedAt: Date,
+    val updatedAt: Instant,
 ) {
     companion object {
         fun from(

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/dto/CommentResponse.kt
@@ -2,7 +2,7 @@ package com.techtaurant.mainserver.comment.dto
 
 import com.techtaurant.mainserver.comment.entity.Comment
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 /**
@@ -27,9 +27,9 @@ data class CommentResponse(
     @field:Schema(description = "삭제 여부")
     val isDeleted: Boolean,
     @field:Schema(description = "생성 시각")
-    val createdAt: Date,
+    val createdAt: Instant,
     @field:Schema(description = "수정 시각")
-    val updatedAt: Date,
+    val updatedAt: Instant,
 ) {
     companion object {
         fun from(comment: Comment): CommentResponse {

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/entity/Comment.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/entity/Comment.kt
@@ -4,7 +4,7 @@ import com.techtaurant.mainserver.common.base.EntityBase
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.user.entity.User
 import jakarta.persistence.*
-import java.util.Date
+import java.time.Instant
 
 /**
  * 댓글 엔티티
@@ -43,6 +43,6 @@ class Comment(
     var replyCount: Long = 0,
     @OneToMany(mappedBy = "parent", cascade = [CascadeType.ALL], orphanRemoval = true)
     var children: MutableList<Comment> = mutableListOf(),
-    @Column(name = "deleted_at")
-    var deletedAt: Date? = null,
+    @Column(name = "deleted_at_utc")
+    var deletedAt: Instant? = null,
 ) : EntityBase()

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/entity/CommentLikeLog.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/entity/CommentLikeLog.kt
@@ -18,8 +18,8 @@ import jakarta.persistence.*
     name = "comment_like_log",
     uniqueConstraints = [UniqueConstraint(columnNames = ["comment_id", "user_id"])],
     indexes = [
-        Index(name = "idx_comment_like_log_comment_created", columnList = "comment_id,created_at"),
-        Index(name = "idx_comment_like_log_created", columnList = "created_at"),
+        Index(name = "idx_comment_like_log_comment_created_utc", columnList = "comment_id,created_at_utc"),
+        Index(name = "idx_comment_like_log_created_utc", columnList = "created_at_utc"),
     ],
 )
 class CommentLikeLog(

--- a/src/main/kotlin/com/techtaurant/mainserver/common/base/EntityBase.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/common/base/EntityBase.kt
@@ -7,7 +7,7 @@ import jakarta.persistence.MappedSuperclass
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 @MappedSuperclass
@@ -18,9 +18,9 @@ open class EntityBase(
     @Column(columnDefinition = "UUID")
     var id: UUID? = null,
     @CreatedDate
-    @Column(name = "created_at")
-    var createdAt: Date = Date(),
+    @Column(name = "created_at_utc")
+    var createdAt: Instant = Instant.now(),
     @LastModifiedDate
-    @Column(name = "updated_at")
-    var updatedAt: Date = Date(),
+    @Column(name = "updated_at_utc")
+    var updatedAt: Instant = Instant.now(),
 )

--- a/src/main/kotlin/com/techtaurant/mainserver/common/util/DateUtils.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/common/util/DateUtils.kt
@@ -1,34 +1,22 @@
 package com.techtaurant.mainserver.common.util
 
-import java.util.Calendar
-import java.util.Date
-import java.util.TimeZone
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
 
 object DateUtils {
-    private val utcTimeZone: TimeZone = TimeZone.getTimeZone("UTC")
+    /**
+     * UTC 기준 현재 날짜를 반환합니다.
+     *
+     * @return UTC 기준 현재 날짜
+     */
+    fun today(): LocalDate = toUtcDate(Instant.now())
 
     /**
-     * UTC 기준 현재 날짜를 자정으로 정규화한 Date로 반환합니다.
+     * UTC 기준으로 Instant를 해당 날짜로 변환합니다.
      *
-     * @return UTC 기준 현재 날짜의 00:00:00.000 시각
+     * @param instant 변환할 절대 시각
+     * @return UTC 기준 날짜
      */
-    fun today(): java.sql.Date = toUtcDate(Date())
-
-    /**
-     * UTC 기준으로 Date를 해당 날짜의 자정 시각으로 정규화합니다.
-     *
-     * @param date 변환할 날짜/시간
-     * @return UTC 기준 날짜의 00:00:00.000 시각
-     */
-    fun toUtcDate(date: Date): java.sql.Date {
-        val calendar = newUtcCalendar()
-        calendar.time = date
-        calendar.set(Calendar.HOUR_OF_DAY, 0)
-        calendar.set(Calendar.MINUTE, 0)
-        calendar.set(Calendar.SECOND, 0)
-        calendar.set(Calendar.MILLISECOND, 0)
-        return java.sql.Date(calendar.timeInMillis)
-    }
-
-    private fun newUtcCalendar(): Calendar = Calendar.getInstance(utcTimeZone)
+    fun toUtcDate(instant: Instant): LocalDate = instant.atZone(ZoneOffset.UTC).toLocalDate()
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkDailyStatsService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkDailyStatsService.kt
@@ -3,7 +3,7 @@ package com.techtaurant.mainserver.link.application
 import com.github.f4b6a3.uuid.UuidCreator
 import com.techtaurant.mainserver.link.infrastructure.out.LinkDailyStatsRepository
 import org.springframework.stereotype.Service
-import java.sql.Date
+import java.time.LocalDate
 import java.util.UUID
 
 @Service
@@ -12,43 +12,43 @@ class LinkDailyStatsService(
 ) {
     fun incrementViewCount(
         linkId: UUID,
-        statDate: Date,
+        statDate: LocalDate,
     ) {
         applyDailyStatsChange(linkId, statDate, linkDailyStatsRepository::incrementViewCount)
     }
 
     fun incrementLikeCount(
         linkId: UUID,
-        statDate: Date,
+        statDate: LocalDate,
     ) {
         applyDailyStatsChange(linkId, statDate, linkDailyStatsRepository::incrementLikeCount)
     }
 
     fun decrementLikeCount(
         linkId: UUID,
-        statDate: Date,
+        statDate: LocalDate,
     ) {
         applyDailyStatsChange(linkId, statDate, linkDailyStatsRepository::decrementLikeCount)
     }
 
     fun incrementSaveCount(
         linkId: UUID,
-        statDate: Date,
+        statDate: LocalDate,
     ) {
         applyDailyStatsChange(linkId, statDate, linkDailyStatsRepository::incrementSaveCount)
     }
 
     fun decrementSaveCount(
         linkId: UUID,
-        statDate: Date,
+        statDate: LocalDate,
     ) {
         linkDailyStatsRepository.decrementSaveCount(linkId, statDate)
     }
 
     private fun applyDailyStatsChange(
         linkId: UUID,
-        statDate: Date,
-        changeFn: (UUID, Date) -> Int,
+        statDate: LocalDate,
+        changeFn: (UUID, LocalDate) -> Int,
     ) {
         if (changeFn(linkId, statDate) == 0) {
             linkDailyStatsRepository.insertIfAbsent(

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkLikeLogService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkLikeLogService.kt
@@ -12,6 +12,7 @@ import com.techtaurant.mainserver.user.enums.UserStatus
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 import java.util.UUID
 
 @Service
@@ -53,7 +54,7 @@ class LinkLikeLogService(
         existingLog: LinkLikeLog,
         linkId: UUID,
         likeStatus: LikeStatus,
-        eventStatDate: java.sql.Date,
+        eventStatDate: LocalDate,
     ) {
         val previousIsLiked = existingLog.isLiked
 
@@ -86,7 +87,7 @@ class LinkLikeLogService(
         userId: UUID,
         likeStatus: LikeStatus,
         isLiked: Boolean,
-        eventStatDate: java.sql.Date,
+        eventStatDate: LocalDate,
     ) {
         val inserted =
             linkLikeLogRepository.insertIfAbsent(
@@ -109,7 +110,7 @@ class LinkLikeLogService(
     private fun updateLikeCount(
         linkId: UUID,
         increment: Boolean,
-        statDate: java.sql.Date,
+        statDate: LocalDate,
     ) {
         if (increment) {
             linkRepository.incrementLikeCount(linkId)

--- a/src/main/kotlin/com/techtaurant/mainserver/link/dto/LinkContentDetailResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/dto/LinkContentDetailResponse.kt
@@ -4,7 +4,6 @@ import com.techtaurant.mainserver.link.entity.Link
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
-import java.util.Date
 import java.util.UUID
 
 @Schema(description = "링크 정적 콘텐츠 상세 응답")
@@ -24,9 +23,9 @@ data class LinkContentDetailResponse(
     @field:ArraySchema(schema = Schema(description = "링크 태그명", example = "engineering"))
     val tags: List<String>,
     @field:Schema(description = "생성일")
-    val createdAt: Date,
+    val createdAt: Instant,
     @field:Schema(description = "최종 수정일")
-    val updatedAt: Date,
+    val updatedAt: Instant,
 ) {
     companion object {
         fun from(

--- a/src/main/kotlin/com/techtaurant/mainserver/link/dto/LinkContentListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/dto/LinkContentListItemResponse.kt
@@ -4,7 +4,6 @@ import com.techtaurant.mainserver.link.entity.Link
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.Instant
-import java.util.Date
 import java.util.UUID
 
 @Schema(description = "링크 정적 콘텐츠 목록 아이템")
@@ -24,9 +23,9 @@ data class LinkContentListItemResponse(
     @field:ArraySchema(schema = Schema(description = "링크 태그명", example = "engineering"))
     val tags: List<String>,
     @field:Schema(description = "생성일")
-    val createdAt: Date,
+    val createdAt: Instant,
     @field:Schema(description = "최종 수정일")
-    val updatedAt: Date,
+    val updatedAt: Instant,
 ) {
     companion object {
         fun from(

--- a/src/main/kotlin/com/techtaurant/mainserver/link/dto/LinkCursor.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/dto/LinkCursor.kt
@@ -1,14 +1,14 @@
 package com.techtaurant.mainserver.link.dto
 
 import com.techtaurant.mainserver.link.entity.Link
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 data class LinkCursor(
-    val createdAt: Date,
+    val createdAt: Instant,
     val id: UUID,
 ) {
-    fun encode(): String = "${createdAt.time}$CURSOR_DELIMITER$id"
+    fun encode(): String = "$createdAt$CURSOR_DELIMITER$id"
 
     companion object {
         private const val CURSOR_DELIMITER = "_"
@@ -17,8 +17,10 @@ data class LinkCursor(
             runCatching {
                 val parts = cursor.split(CURSOR_DELIMITER, limit = 2)
                 require(parts.size == 2)
-                LinkCursor(Date(parts[0].toLong()), UUID.fromString(parts[1]))
+                LinkCursor(parseInstant(parts[0]), UUID.fromString(parts[1]))
             }.getOrNull()
+
+        private fun parseInstant(value: String): Instant = value.toLongOrNull()?.let(Instant::ofEpochMilli) ?: Instant.parse(value)
 
         fun from(link: Link): LinkCursor = LinkCursor(link.createdAt, link.id!!)
     }

--- a/src/main/kotlin/com/techtaurant/mainserver/link/entity/Link.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/entity/Link.kt
@@ -26,7 +26,7 @@ class Link(
     var url: String,
     @Column(nullable = false, columnDefinition = "TEXT")
     var summary: String,
-    @Column(name = "published_at")
+    @Column(name = "published_at_utc")
     var publishedAt: Instant? = null,
     @ManyToMany(fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST, CascadeType.MERGE])
     @JoinTable(

--- a/src/main/kotlin/com/techtaurant/mainserver/link/entity/LinkCrawlBatch.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/entity/LinkCrawlBatch.kt
@@ -47,6 +47,6 @@ class LinkCrawlBatch(
     var startPage: Int = 1,
     @Column(nullable = false)
     var active: Boolean = true,
-    @Column(name = "last_triggered_at")
+    @Column(name = "last_triggered_at_utc")
     var lastTriggeredAt: Instant? = null,
 ) : EntityBase()

--- a/src/main/kotlin/com/techtaurant/mainserver/link/entity/LinkDailyStats.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/entity/LinkDailyStats.kt
@@ -8,7 +8,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
-import java.sql.Date
+import java.time.LocalDate
 
 @Entity
 @Table(
@@ -20,7 +20,7 @@ class LinkDailyStats(
     @JoinColumn(name = "link_id", nullable = false)
     var link: Link,
     @Column(name = "stat_date", nullable = false)
-    var statDate: Date,
+    var statDate: LocalDate,
     @Column(name = "view_count", nullable = false)
     var viewCount: Long = 0,
     @Column(name = "like_count", nullable = false)

--- a/src/main/kotlin/com/techtaurant/mainserver/link/entity/LinkLikeLog.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/entity/LinkLikeLog.kt
@@ -16,8 +16,8 @@ import jakarta.persistence.UniqueConstraint
     name = "link_like_log",
     uniqueConstraints = [UniqueConstraint(name = "uk_link_like_log_link_id_user_id", columnNames = ["link_id", "user_id"])],
     indexes = [
-        Index(name = "idx_link_like_log_link_created", columnList = "link_id,created_at"),
-        Index(name = "idx_link_like_log_created", columnList = "created_at"),
+        Index(name = "idx_link_like_log_link_created_utc", columnList = "link_id,created_at_utc"),
+        Index(name = "idx_link_like_log_created_utc", columnList = "created_at_utc"),
     ],
 )
 class LinkLikeLog(

--- a/src/main/kotlin/com/techtaurant/mainserver/link/entity/LinkViewLog.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/entity/LinkViewLog.kt
@@ -14,8 +14,8 @@ import jakarta.persistence.Table
 @Table(
     name = "link_view_log",
     indexes = [
-        Index(name = "idx_link_view_log_link_created", columnList = "link_id,created_at"),
-        Index(name = "idx_link_view_log_created", columnList = "created_at"),
+        Index(name = "idx_link_view_log_link_created_utc", columnList = "link_id,created_at_utc"),
+        Index(name = "idx_link_view_log_created_utc", columnList = "created_at_utc"),
     ],
 )
 class LinkViewLog(

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/LinkDailyStatsRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/LinkDailyStatsRepository.kt
@@ -5,14 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
-import java.sql.Date
+import java.time.LocalDate
 import java.util.UUID
 
 interface LinkDailyStatsRepository : JpaRepository<LinkDailyStats, UUID> {
     @Modifying(clearAutomatically = false, flushAutomatically = true)
     @Query(
         """
-        INSERT INTO link_daily_stats (id, link_id, stat_date, view_count, like_count, save_count, created_at, updated_at)
+        INSERT INTO link_daily_stats (id, link_id, stat_date, view_count, like_count, save_count, created_at_utc, updated_at_utc)
         VALUES (:id, :linkId, :statDate, 0, 0, 0, NOW(), NOW())
         ON CONFLICT (link_id, stat_date) DO NOTHING
         """,
@@ -21,76 +21,76 @@ interface LinkDailyStatsRepository : JpaRepository<LinkDailyStats, UUID> {
     fun insertIfAbsent(
         @Param("id") id: UUID,
         @Param("linkId") linkId: UUID,
-        @Param("statDate") statDate: Date,
+        @Param("statDate") statDate: LocalDate,
     ): Int
 
     @Modifying(clearAutomatically = false, flushAutomatically = true)
     @Query(
         """
         UPDATE link_daily_stats
-        SET view_count = view_count + 1, updated_at = NOW()
+        SET view_count = view_count + 1, updated_at_utc = NOW()
         WHERE link_id = :linkId AND stat_date = :statDate
         """,
         nativeQuery = true,
     )
     fun incrementViewCount(
         @Param("linkId") linkId: UUID,
-        @Param("statDate") statDate: Date,
+        @Param("statDate") statDate: LocalDate,
     ): Int
 
     @Modifying(clearAutomatically = false, flushAutomatically = true)
     @Query(
         """
         UPDATE link_daily_stats
-        SET like_count = like_count + 1, updated_at = NOW()
+        SET like_count = like_count + 1, updated_at_utc = NOW()
         WHERE link_id = :linkId AND stat_date = :statDate
         """,
         nativeQuery = true,
     )
     fun incrementLikeCount(
         @Param("linkId") linkId: UUID,
-        @Param("statDate") statDate: Date,
+        @Param("statDate") statDate: LocalDate,
     ): Int
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
         """
         UPDATE link_daily_stats
-        SET like_count = like_count - 1, updated_at = NOW()
+        SET like_count = like_count - 1, updated_at_utc = NOW()
         WHERE link_id = :linkId AND stat_date = :statDate
         """,
         nativeQuery = true,
     )
     fun decrementLikeCount(
         @Param("linkId") linkId: UUID,
-        @Param("statDate") statDate: Date,
+        @Param("statDate") statDate: LocalDate,
     ): Int
 
     @Modifying(clearAutomatically = false, flushAutomatically = true)
     @Query(
         """
         UPDATE link_daily_stats
-        SET save_count = save_count + 1, updated_at = NOW()
+        SET save_count = save_count + 1, updated_at_utc = NOW()
         WHERE link_id = :linkId AND stat_date = :statDate
         """,
         nativeQuery = true,
     )
     fun incrementSaveCount(
         @Param("linkId") linkId: UUID,
-        @Param("statDate") statDate: Date,
+        @Param("statDate") statDate: LocalDate,
     ): Int
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(
         """
         UPDATE link_daily_stats
-        SET save_count = save_count - 1, updated_at = NOW()
+        SET save_count = save_count - 1, updated_at_utc = NOW()
         WHERE link_id = :linkId AND stat_date = :statDate
         """,
         nativeQuery = true,
     )
     fun decrementSaveCount(
         @Param("linkId") linkId: UUID,
-        @Param("statDate") statDate: Date,
+        @Param("statDate") statDate: LocalDate,
     ): Int
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/LinkLikeLogRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/LinkLikeLogRepository.kt
@@ -13,7 +13,7 @@ interface LinkLikeLogRepository : JpaRepository<LinkLikeLog, UUID> {
     @Modifying(clearAutomatically = false, flushAutomatically = true)
     @Query(
         """
-        INSERT INTO link_like_log (id, link_id, user_id, is_liked, created_at, updated_at)
+        INSERT INTO link_like_log (id, link_id, user_id, is_liked, created_at_utc, updated_at_utc)
         VALUES (:id, :linkId, :userId, :isLiked, NOW(), NOW())
         ON CONFLICT ON CONSTRAINT uk_link_like_log_link_id_user_id DO NOTHING
         """,

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/LinkRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/LinkRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 interface LinkRepository : JpaRepository<Link, UUID> {
@@ -129,7 +129,7 @@ interface LinkRepository : JpaRepository<Link, UUID> {
     fun findNextPageIds(
         @Param("sourceCompanyUserId") sourceCompanyUserId: UUID?,
         @Param("tag") tag: String?,
-        @Param("cursorCreatedAt") cursorCreatedAt: Date,
+        @Param("cursorCreatedAt") cursorCreatedAt: Instant,
         @Param("cursorId") cursorId: UUID,
         pageable: Pageable,
     ): List<UUID>

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/UserLinkRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/UserLinkRepository.kt
@@ -14,7 +14,7 @@ interface UserLinkRepository : JpaRepository<UserLink, UUID> {
     @Modifying(clearAutomatically = false, flushAutomatically = true)
     @Query(
         """
-        INSERT INTO user_links (id, user_id, link_id, created_at, updated_at)
+        INSERT INTO user_links (id, user_id, link_id, created_at_utc, updated_at_utc)
         VALUES (:id, :userId, :linkId, NOW(), NOW())
         ON CONFLICT ON CONSTRAINT uk_user_links_user_id_link_id DO NOTHING
         """,

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationReadService.kt
@@ -11,7 +11,7 @@ import com.techtaurant.mainserver.notification.infrastructure.out.NotificationRe
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 @Service
@@ -101,7 +101,7 @@ class NotificationReadService(
 
         val unreadRecipientsByNotificationId = unreadRecipients.associateBy { it.notification.id!! }
         val updatedRecipients = distinctNotificationIds.mapNotNull(unreadRecipientsByNotificationId::get)
-        val readAt = Date()
+        val readAt = Instant.now()
         updatedRecipients.forEach { recipient ->
             recipient.markAsRead(readAt)
         }

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/dto/NotificationCursor.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/dto/NotificationCursor.kt
@@ -1,16 +1,16 @@
 package com.techtaurant.mainserver.notification.dto
 
 import com.techtaurant.mainserver.notification.entity.NotificationRecipient
+import java.time.Instant
 import java.util.Base64
-import java.util.Date
 import java.util.UUID
 
 data class NotificationCursor(
-    val createdAt: Date,
+    val createdAt: Instant,
     val id: UUID,
 ) {
     fun encode(): String {
-        val raw = "${createdAt.time}:$id"
+        val raw = "$createdAt|$id"
         return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.toByteArray())
     }
 
@@ -18,17 +18,30 @@ data class NotificationCursor(
         fun decode(cursor: String): NotificationCursor? {
             return try {
                 val decoded = String(Base64.getUrlDecoder().decode(cursor))
-                val parts = decoded.split(":")
-                if (parts.size != 2) {
-                    return null
-                }
-
-                val timestamp = parts[0].toLongOrNull() ?: return null
-                val id = UUID.fromString(parts[1])
-                NotificationCursor(createdAt = Date(timestamp), id = id)
+                decodePipeDelimited(decoded) ?: decodeLegacyColonDelimited(decoded)
             } catch (exception: Exception) {
                 null
             }
+        }
+
+        private fun decodePipeDelimited(decoded: String): NotificationCursor? {
+            val parts = decoded.split("|")
+            if (parts.size != 2) return null
+
+            val createdAt = Instant.parse(parts[0])
+            val id = UUID.fromString(parts[1])
+
+            return NotificationCursor(createdAt = createdAt, id = id)
+        }
+
+        private fun decodeLegacyColonDelimited(decoded: String): NotificationCursor? {
+            val parts = decoded.split(":")
+            if (parts.size != 2) return null
+
+            val timestamp = parts[0].toLongOrNull() ?: return null
+            val id = UUID.fromString(parts[1])
+
+            return NotificationCursor(createdAt = Instant.ofEpochMilli(timestamp), id = id)
         }
 
         fun from(recipient: NotificationRecipient): NotificationCursor = NotificationCursor(recipient.createdAt, recipient.id!!)

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/dto/NotificationListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/dto/NotificationListItemResponse.kt
@@ -5,7 +5,7 @@ import com.techtaurant.mainserver.notification.entity.NotificationRecipient
 import com.techtaurant.mainserver.notification.enums.NotificationTargetType
 import com.techtaurant.mainserver.notification.enums.NotificationType
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 @Schema(description = "알림 목록 아이템")
@@ -21,9 +21,9 @@ data class NotificationListItemResponse(
     @field:Schema(description = "읽음 여부")
     val isRead: Boolean,
     @field:Schema(description = "읽음 시각", nullable = true)
-    val readAt: Date?,
+    val readAt: Instant?,
     @field:Schema(description = "알림 생성 시각")
-    val createdAt: Date,
+    val createdAt: Instant,
     @field:Schema(description = "알림 메시지 인자 목록")
     val arguments: List<NotificationArgumentResponse>,
 ) {

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/entity/NotificationRecipient.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/entity/NotificationRecipient.kt
@@ -10,7 +10,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
-import java.util.Date
+import java.time.Instant
 
 @Entity
 @Table(
@@ -23,8 +23,8 @@ import java.util.Date
     ],
     indexes = [
         Index(name = "idx_notification_recipients_notification_id", columnList = "notification_id"),
-        Index(name = "idx_notification_recipients_user_id_created_at", columnList = "user_id, created_at"),
-        Index(name = "idx_notification_recipients_user_id_read_at", columnList = "user_id, read_at"),
+        Index(name = "idx_notification_recipients_user_id_created_at_utc", columnList = "user_id, created_at_utc"),
+        Index(name = "idx_notification_recipients_user_id_read_at_utc", columnList = "user_id, read_at_utc"),
     ],
 )
 class NotificationRecipient(
@@ -34,10 +34,10 @@ class NotificationRecipient(
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     var recipientUser: User,
-    @Column(name = "read_at")
-    var readAt: Date? = null,
+    @Column(name = "read_at_utc")
+    var readAt: Instant? = null,
 ) : EntityBase() {
-    fun markAsRead(readAt: Date) {
+    fun markAsRead(readAt: Instant) {
         if (this.readAt == null) {
             this.readAt = readAt
         }

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/infrastructure/out/NotificationRecipientRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/infrastructure/out/NotificationRecipientRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 interface NotificationRecipientRepository : JpaRepository<NotificationRecipient, UUID> {
@@ -30,7 +30,7 @@ interface NotificationRecipientRepository : JpaRepository<NotificationRecipient,
     )
     fun findPageByUserIdAndCursor(
         @Param("userId") userId: UUID,
-        @Param("cursorCreatedAt") cursorCreatedAt: Date,
+        @Param("cursorCreatedAt") cursorCreatedAt: Instant,
         @Param("cursorId") cursorId: UUID,
         pageable: Pageable,
     ): List<NotificationRecipient>

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/AllVisiblePostsQueryStrategy.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/AllVisiblePostsQueryStrategy.kt
@@ -1,6 +1,5 @@
 package com.techtaurant.mainserver.post.application
 
-import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import org.springframework.stereotype.Component
 
@@ -10,7 +9,7 @@ internal class AllVisiblePostsQueryStrategy(
 ) : PostListQueryStrategy {
     override val queryType: PostListQueryType = PostListQueryType.ALL_VISIBLE
 
-    override fun findPosts(criteria: PostListQueryCriteria): List<Post> =
+    override fun findPosts(criteria: PostListQueryCriteria): List<PostWithSortValue> =
         postRepository.findPostsWithConditions(
             cursor = criteria.cursor,
             size = criteria.querySize,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/AuthorPublicPostsQueryStrategy.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/AuthorPublicPostsQueryStrategy.kt
@@ -1,6 +1,5 @@
 package com.techtaurant.mainserver.post.application
 
-import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import org.springframework.stereotype.Component
@@ -11,7 +10,7 @@ internal class AuthorPublicPostsQueryStrategy(
 ) : PostListQueryStrategy {
     override val queryType: PostListQueryType = PostListQueryType.AUTHOR_PUBLIC
 
-    override fun findPosts(criteria: PostListQueryCriteria): List<Post> =
+    override fun findPosts(criteria: PostListQueryCriteria): List<PostWithSortValue> =
         postRepository.findPostsWithConditions(
             cursor = criteria.cursor,
             size = criteria.querySize,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/OwnVisiblePostsQueryStrategy.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/OwnVisiblePostsQueryStrategy.kt
@@ -1,6 +1,5 @@
 package com.techtaurant.mainserver.post.application
 
-import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import org.springframework.stereotype.Component
@@ -11,7 +10,7 @@ internal class OwnVisiblePostsQueryStrategy(
 ) : PostListQueryStrategy {
     override val queryType: PostListQueryType = PostListQueryType.OWN_VISIBLE
 
-    override fun findPosts(criteria: PostListQueryCriteria): List<Post> =
+    override fun findPosts(criteria: PostListQueryCriteria): List<PostWithSortValue> =
         postRepository.findPostsWithConditions(
             cursor = criteria.cursor,
             size = criteria.querySize,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDailyStatsService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostDailyStatsService.kt
@@ -6,7 +6,7 @@ import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import org.slf4j.LoggerFactory
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.stereotype.Service
-import java.sql.Date
+import java.time.LocalDate
 import java.util.UUID
 
 /**
@@ -28,7 +28,7 @@ class PostDailyStatsService(
      */
     fun incrementViewCount(
         postId: UUID,
-        statDate: Date,
+        statDate: LocalDate,
     ) {
         applyDailyStatsChange(postId, statDate, postDailyStatsRepository::incrementViewCount)
     }
@@ -40,7 +40,7 @@ class PostDailyStatsService(
      */
     fun incrementLikeCount(
         postId: UUID,
-        statDate: Date,
+        statDate: LocalDate,
     ) {
         applyDailyStatsChange(postId, statDate, postDailyStatsRepository::incrementLikeCount)
     }
@@ -53,7 +53,7 @@ class PostDailyStatsService(
      */
     fun decrementLikeCount(
         postId: UUID,
-        statDate: Date,
+        statDate: LocalDate,
     ) {
         applyDailyStatsChange(postId, statDate, postDailyStatsRepository::decrementLikeCount)
     }
@@ -65,7 +65,7 @@ class PostDailyStatsService(
      */
     fun incrementCommentCount(
         postId: UUID,
-        statDate: Date,
+        statDate: LocalDate,
     ) {
         applyDailyStatsChange(postId, statDate, postDailyStatsRepository::incrementCommentCount)
     }
@@ -79,15 +79,15 @@ class PostDailyStatsService(
      */
     fun decrementCommentCount(
         postId: UUID,
-        statDate: Date,
+        statDate: LocalDate,
     ) {
         applyDailyStatsChange(postId, statDate, postDailyStatsRepository::decrementCommentCount)
     }
 
     private fun applyDailyStatsChange(
         postId: UUID,
-        statDate: Date,
-        changeFn: (UUID, Date) -> Int,
+        statDate: LocalDate,
+        changeFn: (UUID, LocalDate) -> Int,
     ) {
         if (changeFn(postId, statDate) == 0) {
             retryDailyStatsChangeAfterCreate(postId, statDate, changeFn)
@@ -100,8 +100,8 @@ class PostDailyStatsService(
      */
     private fun retryDailyStatsChangeAfterCreate(
         postId: UUID,
-        statDate: Date,
-        changeFn: (UUID, Date) -> Int,
+        statDate: LocalDate,
+        changeFn: (UUID, LocalDate) -> Int,
     ) {
         try {
             createDailyStats(postId, statDate)
@@ -116,7 +116,7 @@ class PostDailyStatsService(
      */
     private fun createDailyStats(
         postId: UUID,
-        statDate: Date,
+        statDate: LocalDate,
     ) {
         val post = postRepository.getReferenceById(postId)
         val dailyStats = PostDailyStats(post = post, statDate = statDate)

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostLikeLogService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostLikeLogService.kt
@@ -11,6 +11,7 @@ import com.techtaurant.mainserver.user.enums.UserStatus
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 import java.util.UUID
 
 /**
@@ -106,7 +107,7 @@ class PostLikeLogService(
     private fun updateLikeCount(
         postId: UUID,
         increment: Boolean,
-        statDate: java.sql.Date,
+        statDate: LocalDate,
     ) {
         if (increment) {
             postRepository.incrementLikeCount(postId)
@@ -117,5 +118,5 @@ class PostLikeLogService(
         }
     }
 
-    private fun toStatDate(log: PostLikeLog): java.sql.Date = DateUtils.toUtcDate(log.createdAt)
+    private fun toStatDate(log: PostLikeLog): LocalDate = DateUtils.toUtcDate(log.createdAt)
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListQueryStrategy.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListQueryStrategy.kt
@@ -1,9 +1,7 @@
 package com.techtaurant.mainserver.post.application
 
-import com.techtaurant.mainserver.post.entity.Post
-
 interface PostListQueryStrategy {
     val queryType: PostListQueryType
 
-    fun findPosts(criteria: PostListQueryCriteria): List<Post>
+    fun findPosts(criteria: PostListQueryCriteria): List<PostWithSortValue>
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -184,7 +184,7 @@ class PostListReadService(
 
         val nextCursor =
             if (hasNext && content.isNotEmpty()) {
-                createPostCursor(content.last(), period, sortType).encode()
+                createPostCursor(createPostWithSortValue(content.last(), period, sortType), sortType).encode()
             } else {
                 null
             }
@@ -198,34 +198,52 @@ class PostListReadService(
     }
 
     private fun createPostCursor(
-        post: Post,
-        period: PostPeriod,
+        sortedPost: PostWithSortValue,
         sortType: PostSortType,
     ): PostCursor {
         return PostCursor.from(
-            post = post,
+            post = sortedPost.post,
             sortType = sortType,
-            sortValueOverride = resolvePeriodSortValue(post, period, sortType),
+            sortValue = sortedPost.sortValue,
         )
     }
 
-    private fun resolvePeriodSortValue(
+    private fun createPostWithSortValue(
         post: Post,
         period: PostPeriod,
         sortType: PostSortType,
-    ): Long? {
-        val days = period.days ?: return null
-        if (sortType == PostSortType.LATEST) {
-            return null
+    ): PostWithSortValue = PostWithSortValue(post = post, sortValue = resolveCursorSortValue(post, period, sortType))
+
+    private fun resolveCursorSortValue(
+        post: Post,
+        period: PostPeriod,
+        sortType: PostSortType,
+    ): Long {
+        val days = period.days
+        if (days != null && sortType != PostSortType.LATEST) {
+            return resolveDailyStatsSortValue(post, days, sortType)
         }
 
-        val postId = post.id ?: return null
+        return when (sortType) {
+            PostSortType.LATEST -> 0L
+            PostSortType.VIEW -> post.viewCount
+            PostSortType.LIKE -> post.likeCount
+            PostSortType.COMMENT -> post.commentCount
+        }
+    }
+
+    private fun resolveDailyStatsSortValue(
+        post: Post,
+        days: Int,
+        sortType: PostSortType,
+    ): Long {
+        val postId = post.id ?: return 0L
         val cutoffDate = dailyStatsCutoffDate(days)
         return when (sortType) {
             PostSortType.VIEW -> postDailyStatsRepository.sumViewCountSince(postId, cutoffDate)
             PostSortType.LIKE -> postDailyStatsRepository.sumLikeCountSince(postId, cutoffDate)
             PostSortType.COMMENT -> postDailyStatsRepository.sumCommentCountSince(postId, cutoffDate)
-            PostSortType.LATEST -> null
+            PostSortType.LATEST -> 0L
         }
     }
 

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -225,7 +225,7 @@ class PostListReadService(
         }
 
         return when (sortType) {
-            PostSortType.LATEST -> 0L
+            PostSortType.LATEST -> post.updatedAt.time
             PostSortType.VIEW -> post.viewCount
             PostSortType.LIKE -> post.likeCount
             PostSortType.COMMENT -> post.commentCount

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -14,13 +14,17 @@ import com.techtaurant.mainserver.post.dto.PostViewerStateResponse
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
+import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.user.application.UserProfileImageResolver
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.Calendar
 import java.util.Date
 import java.util.UUID
+import java.sql.Date as SqlDate
 
 /**
  * 게시물 목록 조회 서비스
@@ -29,6 +33,7 @@ import java.util.UUID
 @Transactional(readOnly = true)
 class PostListReadService(
     private val postRepository: PostRepository,
+    private val postDailyStatsRepository: PostDailyStatsRepository,
     private val attachmentService: AttachmentService,
     private val postMetadataReadService: PostMetadataReadService,
     private val postViewerStateReadService: PostViewerStateReadService,
@@ -179,7 +184,7 @@ class PostListReadService(
 
         val nextCursor =
             if (hasNext && content.isNotEmpty()) {
-                PostCursor.from(content.last(), sortType).encode()
+                createPostCursor(content.last(), period, sortType).encode()
             } else {
                 null
             }
@@ -191,6 +196,40 @@ class PostListReadService(
             size = content.size,
         )
     }
+
+    private fun createPostCursor(
+        post: Post,
+        period: PostPeriod,
+        sortType: PostSortType,
+    ): PostCursor {
+        return PostCursor.from(
+            post = post,
+            sortType = sortType,
+            sortValueOverride = resolvePeriodSortValue(post, period, sortType),
+        )
+    }
+
+    private fun resolvePeriodSortValue(
+        post: Post,
+        period: PostPeriod,
+        sortType: PostSortType,
+    ): Long? {
+        val days = period.days ?: return null
+        if (sortType == PostSortType.LATEST) {
+            return null
+        }
+
+        val postId = post.id ?: return null
+        val cutoffDate = dailyStatsCutoffDate(days)
+        return when (sortType) {
+            PostSortType.VIEW -> postDailyStatsRepository.sumViewCountSince(postId, cutoffDate)
+            PostSortType.LIKE -> postDailyStatsRepository.sumLikeCountSince(postId, cutoffDate)
+            PostSortType.COMMENT -> postDailyStatsRepository.sumCommentCountSince(postId, cutoffDate)
+            PostSortType.LATEST -> null
+        }
+    }
+
+    private fun dailyStatsCutoffDate(days: Int): SqlDate = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC).minusDays(days.toLong()))
 
     private fun emptyPostPage(): CursorPageResponse<Post> =
         CursorPageResponse(

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -18,8 +18,8 @@ import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.user.application.UserProfileImageResolver
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.Calendar
-import java.util.Date
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 /**
@@ -279,18 +279,19 @@ class PostListReadService(
         )
     }
 
-    private fun parseDraftCursor(cursor: String): Pair<java.util.Date, UUID> {
+    private fun parseDraftCursor(cursor: String): Pair<Instant, UUID> {
         val parts = cursor.split("_")
-        val updatedAtMillis = parts[0].toLong()
         val id = UUID.fromString(parts[1])
-        return Pair(java.util.Date(updatedAtMillis), id)
+        return Pair(parseCursorInstant(parts[0]), id)
     }
 
+    private fun parseCursorInstant(value: String): Instant = value.toLongOrNull()?.let(Instant::ofEpochMilli) ?: Instant.parse(value)
+
     private fun encodeDraftCursor(
-        updatedAt: java.util.Date,
+        updatedAt: Instant,
         id: UUID,
     ): String {
-        return "${updatedAt.time}_$id"
+        return "${updatedAt}_$id"
     }
 
     /**
@@ -300,11 +301,7 @@ class PostListReadService(
      * @param userId 사용자 ID
      */
     private fun deleteExpiredDrafts(userId: UUID) {
-        val calendar =
-            Calendar.getInstance().apply {
-                add(Calendar.DAY_OF_MONTH, -STALE_DRAFT_DAYS)
-            }
-        val expirationDate = calendar.time
+        val expirationDate = Instant.now().minus(STALE_DRAFT_DAYS.toLong(), ChronoUnit.DAYS)
 
         val staleDrafts = postRepository.findStaleDraftsByAuthor(userId, expirationDate)
         staleDrafts.forEach { post ->

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostListReadService.kt
@@ -14,17 +14,13 @@ import com.techtaurant.mainserver.post.dto.PostViewerStateResponse
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
-import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.user.application.UserProfileImageResolver
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDate
-import java.time.ZoneOffset
 import java.util.Calendar
 import java.util.Date
 import java.util.UUID
-import java.sql.Date as SqlDate
 
 /**
  * 게시물 목록 조회 서비스
@@ -33,7 +29,6 @@ import java.sql.Date as SqlDate
 @Transactional(readOnly = true)
 class PostListReadService(
     private val postRepository: PostRepository,
-    private val postDailyStatsRepository: PostDailyStatsRepository,
     private val attachmentService: AttachmentService,
     private val postMetadataReadService: PostMetadataReadService,
     private val postViewerStateReadService: PostViewerStateReadService,
@@ -178,13 +173,14 @@ class PostListReadService(
                 categoryId = categoryId,
                 tagIds = normalizedTagIds,
             )
-        val posts = selectPostListQueryStrategy(postListQueryCriteria).findPosts(postListQueryCriteria)
-        val hasNext = posts.size > size
-        val content = posts.take(size)
+        val sortedPosts = selectPostListQueryStrategy(postListQueryCriteria).findPosts(postListQueryCriteria)
+        val hasNext = sortedPosts.size > size
+        val contentWithSortValues = sortedPosts.take(size)
+        val content = contentWithSortValues.map { it.post }
 
         val nextCursor =
-            if (hasNext && content.isNotEmpty()) {
-                createPostCursor(createPostWithSortValue(content.last(), period, sortType), sortType).encode()
+            if (hasNext && contentWithSortValues.isNotEmpty()) {
+                createPostCursor(contentWithSortValues.last(), sortType).encode()
             } else {
                 null
             }
@@ -207,47 +203,6 @@ class PostListReadService(
             sortValue = sortedPost.sortValue,
         )
     }
-
-    private fun createPostWithSortValue(
-        post: Post,
-        period: PostPeriod,
-        sortType: PostSortType,
-    ): PostWithSortValue = PostWithSortValue(post = post, sortValue = resolveCursorSortValue(post, period, sortType))
-
-    private fun resolveCursorSortValue(
-        post: Post,
-        period: PostPeriod,
-        sortType: PostSortType,
-    ): Long {
-        val days = period.days
-        if (days != null && sortType != PostSortType.LATEST) {
-            return resolveDailyStatsSortValue(post, days, sortType)
-        }
-
-        return when (sortType) {
-            PostSortType.LATEST -> post.updatedAt.time
-            PostSortType.VIEW -> post.viewCount
-            PostSortType.LIKE -> post.likeCount
-            PostSortType.COMMENT -> post.commentCount
-        }
-    }
-
-    private fun resolveDailyStatsSortValue(
-        post: Post,
-        days: Int,
-        sortType: PostSortType,
-    ): Long {
-        val postId = post.id ?: return 0L
-        val cutoffDate = dailyStatsCutoffDate(days)
-        return when (sortType) {
-            PostSortType.VIEW -> postDailyStatsRepository.sumViewCountSince(postId, cutoffDate)
-            PostSortType.LIKE -> postDailyStatsRepository.sumLikeCountSince(postId, cutoffDate)
-            PostSortType.COMMENT -> postDailyStatsRepository.sumCommentCountSince(postId, cutoffDate)
-            PostSortType.LATEST -> 0L
-        }
-    }
-
-    private fun dailyStatsCutoffDate(days: Int): SqlDate = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC).minusDays(days.toLong()))
 
     private fun emptyPostPage(): CursorPageResponse<Post> =
         CursorPageResponse(

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWithSortValue.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWithSortValue.kt
@@ -2,7 +2,10 @@ package com.techtaurant.mainserver.post.application
 
 import com.techtaurant.mainserver.post.entity.Post
 
-internal data class PostWithSortValue(
+data class PostWithSortValue(
     val post: Post,
     val sortValue: Long,
-)
+) {
+    val id
+        get() = post.id
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWithSortValue.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWithSortValue.kt
@@ -1,0 +1,8 @@
+package com.techtaurant.mainserver.post.application
+
+import com.techtaurant.mainserver.post.entity.Post
+
+internal data class PostWithSortValue(
+    val post: Post,
+    val sortValue: Long,
+)

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -22,7 +22,6 @@ import com.techtaurant.mainserver.user.infrastructure.out.UserFollowRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.Date
 import java.util.UUID
 
 @Service
@@ -93,7 +92,7 @@ class PostWriteService(
             ).apply { replaceTags(tags) }
 
         val savedPost = postRepository.save(post)
-        request.createdAt?.let { savedPost.createdAt = Date.from(it) }
+        request.createdAt?.let { savedPost.createdAt = it }
 
         if (status != PostStatusEnum.DRAFT) {
             val attachmentIds =

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/DraftListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/DraftListItemResponse.kt
@@ -2,7 +2,7 @@ package com.techtaurant.mainserver.post.dto
 
 import com.techtaurant.mainserver.post.entity.Post
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 /**
@@ -26,9 +26,9 @@ data class DraftListItemResponse(
     @field:Schema(description = "게시물 본문 미리보기 (최대 100자)", example = "Empty")
     val contentPreview: String,
     @field:Schema(description = "생성일시")
-    val createdAt: Date,
+    val createdAt: Instant,
     @field:Schema(description = "최종 수정일시")
-    val updatedAt: Date,
+    val updatedAt: Instant,
 ) {
     companion object {
         fun from(post: Post): DraftListItemResponse {

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostContentDetailResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostContentDetailResponse.kt
@@ -2,7 +2,7 @@ package com.techtaurant.mainserver.post.dto
 
 import com.techtaurant.mainserver.post.entity.Post
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 @Schema(description = "게시물 정적 콘텐츠 상세 응답")
@@ -20,9 +20,9 @@ data class PostContentDetailResponse(
     @field:Schema(description = "태그 목록")
     val tags: List<PostListTagResponse>,
     @field:Schema(description = "작성일")
-    val createdAt: Date,
+    val createdAt: Instant,
     @field:Schema(description = "수정일")
-    val updatedAt: Date,
+    val updatedAt: Instant,
 ) {
     companion object {
         fun from(post: Post): PostContentDetailResponse =

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostContentListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostContentListItemResponse.kt
@@ -2,7 +2,7 @@ package com.techtaurant.mainserver.post.dto
 
 import com.techtaurant.mainserver.post.entity.Post
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 @Schema(description = "게시물 정적 콘텐츠 목록 아이템")
@@ -20,9 +20,9 @@ data class PostContentListItemResponse(
     @field:Schema(description = "태그 목록")
     val tags: List<PostListTagResponse>,
     @field:Schema(description = "작성일")
-    val createdAt: Date,
+    val createdAt: Instant,
     @field:Schema(description = "최종 수정일")
-    val updatedAt: Date,
+    val updatedAt: Instant,
 ) {
     companion object {
         private const val CONTENT_MAX_LENGTH = 2000

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
@@ -64,13 +64,14 @@ data class PostCursor(
         fun from(
             post: com.techtaurant.mainserver.post.entity.Post,
             sortType: PostSortType,
+            sortValueOverride: Long? = null,
         ): PostCursor {
             val sortValue =
                 when (sortType) {
                     PostSortType.LATEST -> 0L
-                    PostSortType.VIEW -> post.viewCount
-                    PostSortType.LIKE -> post.likeCount
-                    PostSortType.COMMENT -> post.commentCount
+                    PostSortType.VIEW -> sortValueOverride ?: post.viewCount
+                    PostSortType.LIKE -> sortValueOverride ?: post.likeCount
+                    PostSortType.COMMENT -> sortValueOverride ?: post.commentCount
                 }
             // LATEST 정렬은 updatedAt 기준이므로 커서에 updatedAt을 저장합니다.
             val cursorDate = if (sortType == PostSortType.LATEST) post.updatedAt else post.createdAt

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
@@ -13,7 +13,7 @@ import java.util.UUID
  * - LATEST: updatedAt(최신 수정 시간), id
  * - VIEW/LIKE/COMMENT: sortValue(해당 count), createdAt, id
  *
- * @property sortValue 정렬 기준 값 (조회수, 좋아요수, 댓글수)
+ * @property sortValue 정렬 기준 값 (LATEST는 updatedAt epoch milliseconds, 그 외는 조회수/좋아요수/댓글수)
  * @property createdAt LATEST 정렬 시 updatedAt, 그 외 정렬 시 createdAt을 담는 보조 정렬 시간 필드
  * @property id 게시물 ID
  * @property sortType 정렬 타입
@@ -68,7 +68,7 @@ data class PostCursor(
         ): PostCursor {
             val sortValue =
                 when (sortType) {
-                    PostSortType.LATEST -> 0L
+                    PostSortType.LATEST -> post.updatedAt.time
                     PostSortType.VIEW -> post.viewCount
                     PostSortType.LIKE -> post.likeCount
                     PostSortType.COMMENT -> post.commentCount

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
@@ -1,5 +1,6 @@
 package com.techtaurant.mainserver.post.dto
 
+import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostSortType
 import java.util.Base64
 import java.util.Date
@@ -56,24 +57,37 @@ data class PostCursor(
         }
 
         /**
-         * Post 엔티티에서 커서 생성
+         * Post 엔티티의 누적 정렬값으로 커서를 생성합니다.
          *
          * @param post 게시물 엔티티
          * @param sortType 정렬 타입
          */
         fun from(
-            post: com.techtaurant.mainserver.post.entity.Post,
+            post: Post,
             sortType: PostSortType,
-            sortValueOverride: Long? = null,
         ): PostCursor {
             val sortValue =
                 when (sortType) {
                     PostSortType.LATEST -> 0L
-                    PostSortType.VIEW -> sortValueOverride ?: post.viewCount
-                    PostSortType.LIKE -> sortValueOverride ?: post.likeCount
-                    PostSortType.COMMENT -> sortValueOverride ?: post.commentCount
+                    PostSortType.VIEW -> post.viewCount
+                    PostSortType.LIKE -> post.likeCount
+                    PostSortType.COMMENT -> post.commentCount
                 }
-            // LATEST 정렬은 updatedAt 기준이므로 커서에 updatedAt을 저장합니다.
+            return from(post, sortType, sortValue)
+        }
+
+        /**
+         * 쿼리에서 실제 정렬에 사용한 값으로 커서를 생성합니다.
+         *
+         * @param post 게시물 엔티티
+         * @param sortType 정렬 타입
+         * @param sortValue 정렬에 사용된 값
+         */
+        fun from(
+            post: Post,
+            sortType: PostSortType,
+            sortValue: Long,
+        ): PostCursor {
             val cursorDate = if (sortType == PostSortType.LATEST) post.updatedAt else post.createdAt
             return PostCursor(sortValue, cursorDate, post.id!!, sortType)
         }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostCursor.kt
@@ -2,8 +2,8 @@ package com.techtaurant.mainserver.post.dto
 
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostSortType
+import java.time.Instant
 import java.util.Base64
-import java.util.Date
 import java.util.UUID
 
 /**
@@ -20,7 +20,7 @@ import java.util.UUID
  */
 data class PostCursor(
     val sortValue: Long,
-    val createdAt: Date,
+    val createdAt: Instant,
     val id: UUID,
     val sortType: PostSortType,
 ) {
@@ -28,7 +28,7 @@ data class PostCursor(
      * 커서를 Base64 인코딩된 문자열로 변환
      */
     fun encode(): String {
-        val raw = "${sortType.name}:$sortValue:${createdAt.time}:$id"
+        val raw = "${sortType.name}|$sortValue|$createdAt|$id"
         return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.toByteArray())
     }
 
@@ -42,18 +42,34 @@ data class PostCursor(
         fun decode(cursor: String): PostCursor? {
             return try {
                 val decoded = String(Base64.getUrlDecoder().decode(cursor))
-                val parts = decoded.split(":")
-                if (parts.size != 4) return null
-
-                val sortType = PostSortType.fromString(parts[0])
-                val sortValue = parts[1].toLongOrNull() ?: return null
-                val timestamp = parts[2].toLongOrNull() ?: return null
-                val uuid = UUID.fromString(parts[3])
-
-                PostCursor(sortValue, Date(timestamp), uuid, sortType)
+                decodePipeDelimited(decoded) ?: decodeLegacyColonDelimited(decoded)
             } catch (e: Exception) {
                 null
             }
+        }
+
+        private fun decodePipeDelimited(decoded: String): PostCursor? {
+            val parts = decoded.split("|")
+            if (parts.size != 4) return null
+
+            val sortType = PostSortType.fromString(parts[0])
+            val sortValue = parts[1].toLongOrNull() ?: return null
+            val timestamp = Instant.parse(parts[2])
+            val uuid = UUID.fromString(parts[3])
+
+            return PostCursor(sortValue, timestamp, uuid, sortType)
+        }
+
+        private fun decodeLegacyColonDelimited(decoded: String): PostCursor? {
+            val parts = decoded.split(":")
+            if (parts.size != 4) return null
+
+            val sortType = PostSortType.fromString(parts[0])
+            val sortValue = parts[1].toLongOrNull() ?: return null
+            val timestamp = parts[2].toLongOrNull() ?: return null
+            val uuid = UUID.fromString(parts[3])
+
+            return PostCursor(sortValue, Instant.ofEpochMilli(timestamp), uuid, sortType)
         }
 
         /**
@@ -68,7 +84,7 @@ data class PostCursor(
         ): PostCursor {
             val sortValue =
                 when (sortType) {
-                    PostSortType.LATEST -> post.updatedAt.time
+                    PostSortType.LATEST -> post.updatedAt.toEpochMilli()
                     PostSortType.VIEW -> post.viewCount
                     PostSortType.LIKE -> post.likeCount
                     PostSortType.COMMENT -> post.commentCount

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostDetailResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostDetailResponse.kt
@@ -5,7 +5,7 @@ import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.user.entity.User
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 /**
@@ -56,9 +56,9 @@ data class PostDetailResponse(
     @field:Schema(description = "attachmentId와 presigned URL 매핑 목록")
     val attachmentPresignedUrls: List<PostDetailAttachmentPresignedUrlResponse>,
     @field:Schema(description = "작성일")
-    val createdAt: Date,
+    val createdAt: Instant,
     @field:Schema(description = "수정일")
-    val updatedAt: Date,
+    val updatedAt: Instant,
 ) {
     companion object {
         /**

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostListItemResponse.kt
@@ -3,7 +3,7 @@ package com.techtaurant.mainserver.post.dto
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 @Schema(description = "게시물 목록 아이템")
@@ -37,9 +37,9 @@ data class PostListItemResponse(
     @field:Schema(description = "게시물 상태 (DRAFT: 임시저장, PUBLISHED: 발행, PRIVATE: 비공개)")
     val status: PostStatusEnum,
     @field:Schema(description = "작성일")
-    val createdAt: Date,
+    val createdAt: Instant,
     @field:Schema(description = "최종 수정일")
-    val updatedAt: Date,
+    val updatedAt: Instant,
 ) {
     companion object {
         /**

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/PostResponse.kt
@@ -4,7 +4,7 @@ import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.enums.PostStatus
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 /**
@@ -27,9 +27,9 @@ data class PostResponse(
     @field:Schema(description = "태그 목록", example = "[\"spring\", \"backend\"]")
     val tags: List<String>,
     @field:Schema(description = "생성일시")
-    val createdAt: Date,
+    val createdAt: Instant,
     @field:Schema(description = "수정일시")
-    val updatedAt: Date,
+    val updatedAt: Instant,
 ) {
     companion object {
         fun from(post: Post): PostResponse {

--- a/src/main/kotlin/com/techtaurant/mainserver/post/entity/PostDailyStats.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/entity/PostDailyStats.kt
@@ -2,7 +2,7 @@ package com.techtaurant.mainserver.post.entity
 
 import com.techtaurant.mainserver.common.base.EntityBase
 import jakarta.persistence.*
-import java.sql.Date
+import java.time.LocalDate
 
 /**
  * 일별 게시물 통계 엔티티
@@ -23,7 +23,7 @@ class PostDailyStats(
     @JoinColumn(name = "post_id", nullable = false)
     var post: Post,
     @Column(name = "stat_date", nullable = false)
-    var statDate: Date,
+    var statDate: LocalDate,
     @Column(name = "view_count", nullable = false)
     var viewCount: Long = 0,
     @Column(name = "like_count", nullable = false)

--- a/src/main/kotlin/com/techtaurant/mainserver/post/entity/PostLikeLog.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/entity/PostLikeLog.kt
@@ -18,8 +18,8 @@ import jakarta.persistence.*
     name = "post_like_log",
     uniqueConstraints = [UniqueConstraint(columnNames = ["post_id", "user_id"])],
     indexes = [
-        Index(name = "idx_post_like_log_post_created", columnList = "post_id,created_at"),
-        Index(name = "idx_post_like_log_created", columnList = "created_at"),
+        Index(name = "idx_post_like_log_post_created_utc", columnList = "post_id,created_at_utc"),
+        Index(name = "idx_post_like_log_created_utc", columnList = "created_at_utc"),
     ],
 )
 class PostLikeLog(

--- a/src/main/kotlin/com/techtaurant/mainserver/post/entity/PostViewLog.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/entity/PostViewLog.kt
@@ -17,8 +17,8 @@ import jakarta.persistence.*
 @Table(
     name = "post_view_log",
     indexes = [
-        Index(name = "idx_post_view_log_post_created", columnList = "post_id,created_at"),
-        Index(name = "idx_post_view_log_created", columnList = "created_at"),
+        Index(name = "idx_post_view_log_post_created_utc", columnList = "post_id,created_at_utc"),
+        Index(name = "idx_post_view_log_created_utc", columnList = "created_at_utc"),
     ],
 )
 class PostViewLog(

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostDailyStatsRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostDailyStatsRepository.kt
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
-import java.sql.Date
+import java.time.LocalDate
 import java.util.UUID
 
 interface PostDailyStatsRepository : JpaRepository<PostDailyStats, UUID> {
@@ -20,14 +20,14 @@ interface PostDailyStatsRepository : JpaRepository<PostDailyStats, UUID> {
     @Query(
         """
         UPDATE post_daily_stats
-        SET view_count = view_count + 1, updated_at = NOW()
+        SET view_count = view_count + 1, updated_at_utc = NOW()
         WHERE post_id = :postId AND stat_date = :statDate
         """,
         nativeQuery = true,
     )
     fun incrementViewCount(
         @Param("postId") postId: UUID,
-        @Param("statDate") statDate: Date,
+        @Param("statDate") statDate: LocalDate,
     ): Int
 
     /**
@@ -41,14 +41,14 @@ interface PostDailyStatsRepository : JpaRepository<PostDailyStats, UUID> {
     @Query(
         """
         UPDATE post_daily_stats
-        SET like_count = like_count + 1, updated_at = NOW()
+        SET like_count = like_count + 1, updated_at_utc = NOW()
         WHERE post_id = :postId AND stat_date = :statDate
         """,
         nativeQuery = true,
     )
     fun incrementLikeCount(
         @Param("postId") postId: UUID,
-        @Param("statDate") statDate: Date,
+        @Param("statDate") statDate: LocalDate,
     ): Int
 
     /**
@@ -63,14 +63,14 @@ interface PostDailyStatsRepository : JpaRepository<PostDailyStats, UUID> {
     @Query(
         """
         UPDATE post_daily_stats
-        SET like_count = like_count - 1, updated_at = NOW()
+        SET like_count = like_count - 1, updated_at_utc = NOW()
         WHERE post_id = :postId AND stat_date = :statDate
         """,
         nativeQuery = true,
     )
     fun decrementLikeCount(
         @Param("postId") postId: UUID,
-        @Param("statDate") statDate: Date,
+        @Param("statDate") statDate: LocalDate,
     ): Int
 
     /**
@@ -84,14 +84,14 @@ interface PostDailyStatsRepository : JpaRepository<PostDailyStats, UUID> {
     @Query(
         """
         UPDATE post_daily_stats
-        SET comment_count = comment_count + 1, updated_at = NOW()
+        SET comment_count = comment_count + 1, updated_at_utc = NOW()
         WHERE post_id = :postId AND stat_date = :statDate
         """,
         nativeQuery = true,
     )
     fun incrementCommentCount(
         @Param("postId") postId: UUID,
-        @Param("statDate") statDate: Date,
+        @Param("statDate") statDate: LocalDate,
     ): Int
 
     /**
@@ -106,13 +106,13 @@ interface PostDailyStatsRepository : JpaRepository<PostDailyStats, UUID> {
     @Query(
         """
         UPDATE post_daily_stats
-        SET comment_count = comment_count - 1, updated_at = NOW()
+        SET comment_count = comment_count - 1, updated_at_utc = NOW()
         WHERE post_id = :postId AND stat_date = :statDate
         """,
         nativeQuery = true,
     )
     fun decrementCommentCount(
         @Param("postId") postId: UUID,
-        @Param("statDate") statDate: Date,
+        @Param("statDate") statDate: LocalDate,
     ): Int
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostDailyStatsRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostDailyStatsRepository.kt
@@ -9,42 +9,6 @@ import java.sql.Date
 import java.util.UUID
 
 interface PostDailyStatsRepository : JpaRepository<PostDailyStats, UUID> {
-    @Query(
-        """
-        SELECT COALESCE(SUM(stats.viewCount), 0)
-        FROM PostDailyStats stats
-        WHERE stats.post.id = :postId AND stats.statDate >= :cutoffDate
-        """,
-    )
-    fun sumViewCountSince(
-        @Param("postId") postId: UUID,
-        @Param("cutoffDate") cutoffDate: Date,
-    ): Long
-
-    @Query(
-        """
-        SELECT COALESCE(SUM(stats.likeCount), 0)
-        FROM PostDailyStats stats
-        WHERE stats.post.id = :postId AND stats.statDate >= :cutoffDate
-        """,
-    )
-    fun sumLikeCountSince(
-        @Param("postId") postId: UUID,
-        @Param("cutoffDate") cutoffDate: Date,
-    ): Long
-
-    @Query(
-        """
-        SELECT COALESCE(SUM(stats.commentCount), 0)
-        FROM PostDailyStats stats
-        WHERE stats.post.id = :postId AND stats.statDate >= :cutoffDate
-        """,
-    )
-    fun sumCommentCountSince(
-        @Param("postId") postId: UUID,
-        @Param("cutoffDate") cutoffDate: Date,
-    ): Long
-
     /**
      * 특정 게시물의 일별 조회수를 원자적으로 1 증가시킵니다.
      *

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostDailyStatsRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostDailyStatsRepository.kt
@@ -9,6 +9,42 @@ import java.sql.Date
 import java.util.UUID
 
 interface PostDailyStatsRepository : JpaRepository<PostDailyStats, UUID> {
+    @Query(
+        """
+        SELECT COALESCE(SUM(stats.viewCount), 0)
+        FROM PostDailyStats stats
+        WHERE stats.post.id = :postId AND stats.statDate >= :cutoffDate
+        """,
+    )
+    fun sumViewCountSince(
+        @Param("postId") postId: UUID,
+        @Param("cutoffDate") cutoffDate: Date,
+    ): Long
+
+    @Query(
+        """
+        SELECT COALESCE(SUM(stats.likeCount), 0)
+        FROM PostDailyStats stats
+        WHERE stats.post.id = :postId AND stats.statDate >= :cutoffDate
+        """,
+    )
+    fun sumLikeCountSince(
+        @Param("postId") postId: UUID,
+        @Param("cutoffDate") cutoffDate: Date,
+    ): Long
+
+    @Query(
+        """
+        SELECT COALESCE(SUM(stats.commentCount), 0)
+        FROM PostDailyStats stats
+        WHERE stats.post.id = :postId AND stats.statDate >= :cutoffDate
+        """,
+    )
+    fun sumCommentCountSince(
+        @Param("postId") postId: UUID,
+        @Param("cutoffDate") cutoffDate: Date,
+    ): Long
+
     /**
      * 특정 게시물의 일별 조회수를 원자적으로 1 증가시킵니다.
      *

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepository.kt
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 interface PostRepository : JpaRepository<Post, UUID>, PostRepositoryCustom {
@@ -53,7 +53,7 @@ interface PostRepository : JpaRepository<Post, UUID>, PostRepositoryCustom {
     )
     fun findDraftsByAuthorWithCursor(
         @Param("authorId") authorId: UUID,
-        @Param("cursorUpdatedAt") cursorUpdatedAt: Date,
+        @Param("cursorUpdatedAt") cursorUpdatedAt: Instant,
         @Param("cursorId") cursorId: UUID,
         @Param("limit") limit: Int,
     ): List<Post>
@@ -219,6 +219,6 @@ interface PostRepository : JpaRepository<Post, UUID>, PostRepositoryCustom {
     )
     fun findStaleDraftsByAuthor(
         @Param("authorId") authorId: UUID,
-        @Param("before") before: Date,
+        @Param("before") before: Instant,
     ): List<Post>
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustom.kt
@@ -1,5 +1,6 @@
 package com.techtaurant.mainserver.post.infrastructure.out
 
+import com.techtaurant.mainserver.post.application.PostWithSortValue
 import com.techtaurant.mainserver.post.dto.PostCursor
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
@@ -23,7 +24,7 @@ interface PostRepositoryCustom {
      * @param categoryId 카테고리 ID 필터 (null이면 미적용)
      * @param visibleToUserId PUBLISHED + 해당 사용자의 PRIVATE 게시물 조회 (null이면 미적용, statuses보다 우선)
      * @param tagIds 태그 UUID 필터 (여러 개 전달 시 OR 조건)
-     * @return 게시물 목록
+     * @return 실제 정렬값을 포함한 게시물 목록
      */
     fun findPostsWithConditions(
         cursor: PostCursor?,
@@ -36,7 +37,7 @@ interface PostRepositoryCustom {
         visibleToUserId: UUID? = null,
         tagIds: List<UUID>? = null,
         viewerId: UUID? = null,
-    ): List<Post>
+    ): List<PostWithSortValue>
 
     fun findVisiblePostDetailById(
         postId: UUID,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -5,6 +5,8 @@ import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.post.dto.PostCursor
 import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.entity.PostDailyStats
+import com.techtaurant.mainserver.post.entity.PostDailyStats_
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.post.entity.Post_
@@ -16,14 +18,22 @@ import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.entity.UserBan_
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
+import jakarta.persistence.criteria.CommonAbstractCriteria
 import jakarta.persistence.criteria.CriteriaBuilder
 import jakarta.persistence.criteria.CriteriaQuery
+import jakarta.persistence.criteria.Expression
 import jakarta.persistence.criteria.JoinType
+import jakarta.persistence.criteria.Path
 import jakarta.persistence.criteria.Predicate
 import jakarta.persistence.criteria.Root
 import org.springframework.stereotype.Repository
-import java.util.Calendar
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import java.util.UUID
+import java.sql.Date as SqlDate
+import java.util.Date as UtilDate
 
 /**
  * 게시물 동적 쿼리 구현체
@@ -52,6 +62,21 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         tagIds: List<UUID>?,
         viewerId: UUID?,
     ): List<Post> {
+        if (usesDailyStatsPeriodRanking(period, sortType)) {
+            return findPostsWithDailyStatsPeriodRanking(
+                cursor = cursor,
+                size = size,
+                period = period,
+                sortType = sortType,
+                authorId = authorId,
+                statuses = statuses,
+                categoryId = categoryId,
+                visibleToUserId = visibleToUserId,
+                tagIds = tagIds,
+                viewerId = viewerId,
+            )
+        }
+
         val cb = entityManager.criteriaBuilder
         val cq = cb.createQuery(Post::class.java)
         val root = cq.from(Post::class.java)
@@ -62,42 +87,99 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         root.fetch<Post, Tag>(Post_.TAGS, JoinType.LEFT)
 
         val predicates = mutableListOf<Predicate>()
-
-        if (visibleToUserId != null) {
-            val publishedPredicate = cb.equal(root.get(Post_.status), PostStatusEnum.PUBLISHED)
-            val ownPrivatePostPredicate =
-                cb.and(
-                    cb.equal(root.get(Post_.author).get(EntityBase_.id), visibleToUserId),
-                    cb.equal(root.get(Post_.status), PostStatusEnum.PRIVATE),
-                )
-            predicates.add(cb.or(publishedPredicate, ownPrivatePostPredicate))
-        } else if (statuses != null) {
-            predicates.add(root.get(Post_.status).`in`(statuses))
-        } else {
-            predicates.add(cb.equal(root.get(Post_.status), PostStatusEnum.PUBLISHED))
-        }
-
-        authorId?.let { predicates.add(cb.equal(root.get(Post_.author).get(EntityBase_.id), it)) }
-        categoryId?.let { predicates.add(cb.equal(root.get(Post_.category).get(EntityBase_.id), it)) }
-        tagIds?.let { ids ->
-            val tagJoin = root.join<Post, Tag>(Post_.TAGS, JoinType.LEFT)
-            predicates.add(tagJoin.get<UUID>("id").`in`(ids))
-        }
-        addViewerBanCondition(cb, cq, root, viewerId, predicates)
-
-        addPeriodCondition(cb, root, period, predicates)
-        addCursorCondition(cb, root, cursor, sortType, predicates)
+        addBaseConditions(
+            cb = cb,
+            query = cq,
+            root = root,
+            authorId = authorId,
+            statuses = statuses,
+            categoryId = categoryId,
+            visibleToUserId = visibleToUserId,
+            tagIds = tagIds,
+            viewerId = viewerId,
+            predicates = predicates,
+        )
+        addPeriodCondition(cb, cq, root, period, sortType, predicates)
+        addCursorCondition(cb, cq, root, cursor, period, sortType, predicates)
 
         if (predicates.isNotEmpty()) {
             cq.where(*predicates.toTypedArray())
         }
 
-        applyOrdering(cb, cq, root, sortType)
+        applyOrdering(cb, cq, root, period, sortType)
 
         return entityManager.createQuery(cq)
             .setMaxResults(size)
             .resultList
             .distinctBy { it.id }
+    }
+
+    private fun findPostsWithDailyStatsPeriodRanking(
+        cursor: PostCursor?,
+        size: Int,
+        period: PostPeriod,
+        sortType: PostSortType,
+        authorId: UUID?,
+        statuses: List<PostStatusEnum>?,
+        categoryId: UUID?,
+        visibleToUserId: UUID?,
+        tagIds: List<UUID>?,
+        viewerId: UUID?,
+    ): List<Post> {
+        val cb = entityManager.criteriaBuilder
+        val cq = cb.createQuery(UUID::class.java)
+        val root = cq.from(Post::class.java)
+        val predicates = mutableListOf<Predicate>()
+
+        addBaseConditions(
+            cb = cb,
+            query = cq,
+            root = root,
+            authorId = authorId,
+            statuses = statuses,
+            categoryId = categoryId,
+            visibleToUserId = visibleToUserId,
+            tagIds = tagIds,
+            viewerId = viewerId,
+            predicates = predicates,
+        )
+        addPeriodCondition(cb, cq, root, period, sortType, predicates)
+        addCursorCondition(cb, cq, root, cursor, period, sortType, predicates)
+
+        cq.select(root.get(EntityBase_.id))
+        if (predicates.isNotEmpty()) {
+            cq.where(*predicates.toTypedArray())
+        }
+        applyOrdering(cb, cq, root, period, sortType)
+
+        val postIds =
+            entityManager.createQuery(cq)
+                .setMaxResults(size)
+                .resultList
+
+        return findPostsByIdsInOrder(postIds)
+    }
+
+    private fun findPostsByIdsInOrder(postIds: List<UUID>): List<Post> {
+        if (postIds.isEmpty()) {
+            return emptyList()
+        }
+
+        val cb = entityManager.criteriaBuilder
+        val cq = cb.createQuery(Post::class.java)
+        val root = cq.from(Post::class.java)
+        cq.distinct(true)
+
+        root.fetch<Post, User>(Post_.AUTHOR)
+        root.fetch<Post, Category>(Post_.CATEGORY, JoinType.LEFT)
+        root.fetch<Post, Tag>(Post_.TAGS, JoinType.LEFT)
+        cq.where(root.get<UUID>(EntityBase_.id).`in`(postIds))
+
+        val orderByPostId = postIds.withIndex().associate { (index, postId) -> postId to index }
+        return entityManager.createQuery(cq)
+            .resultList
+            .distinctBy { it.id }
+            .sortedBy { orderByPostId.getValue(it.id!!) }
     }
 
     override fun findVisiblePostDetailById(
@@ -124,24 +206,113 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         return entityManager.createQuery(cq).resultList.firstOrNull()
     }
 
+    private fun addBaseConditions(
+        cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
+        root: Root<Post>,
+        authorId: UUID?,
+        statuses: List<PostStatusEnum>?,
+        categoryId: UUID?,
+        visibleToUserId: UUID?,
+        tagIds: List<UUID>?,
+        viewerId: UUID?,
+        predicates: MutableList<Predicate>,
+    ) {
+        if (visibleToUserId != null) {
+            val publishedPredicate = cb.equal(root.get(Post_.status), PostStatusEnum.PUBLISHED)
+            val ownPrivatePostPredicate =
+                cb.and(
+                    cb.equal(root.get(Post_.author).get(EntityBase_.id), visibleToUserId),
+                    cb.equal(root.get(Post_.status), PostStatusEnum.PRIVATE),
+                )
+            predicates.add(cb.or(publishedPredicate, ownPrivatePostPredicate))
+        } else if (statuses != null) {
+            predicates.add(root.get(Post_.status).`in`(statuses))
+        } else {
+            predicates.add(cb.equal(root.get(Post_.status), PostStatusEnum.PUBLISHED))
+        }
+
+        authorId?.let { predicates.add(cb.equal(root.get(Post_.author).get(EntityBase_.id), it)) }
+        categoryId?.let { predicates.add(cb.equal(root.get(Post_.category).get(EntityBase_.id), it)) }
+        tagIds?.let { addTagIdsCondition(cb, query, root, it, predicates) }
+        addViewerBanCondition(cb, query, root, viewerId, predicates)
+    }
+
+    private fun addTagIdsCondition(
+        cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
+        root: Root<Post>,
+        tagIds: List<UUID>,
+        predicates: MutableList<Predicate>,
+    ) {
+        val tagSubquery = query.subquery(Long::class.java)
+        val tagPostRoot = tagSubquery.from(Post::class.java)
+        val tagJoin = tagPostRoot.join<Post, Tag>(Post_.TAGS, JoinType.INNER)
+
+        tagSubquery.select(cb.literal(1L))
+        tagSubquery.where(
+            cb.equal(tagPostRoot.get(EntityBase_.id), root.get(EntityBase_.id)),
+            tagJoin.get<UUID>("id").`in`(tagIds),
+        )
+        predicates.add(cb.exists(tagSubquery))
+    }
+
     /**
-     * 지정된 기간 이내의 게시물만 조회하도록 필터 추가
+     * 지정된 기간 조건을 적용합니다.
      *
-     * period가 ALL이면 필터 미적용, WEEK/MONTH/YEAR면 해당 일수만큼 이전부터 조회
+     * LATEST 정렬은 기존처럼 게시물 작성일 기준으로 필터링하고,
+     * VIEW/LIKE/COMMENT 정렬은 게시물 작성일이 아니라 기간 내 일별 통계 존재 여부로 필터링합니다.
      */
     private fun addPeriodCondition(
+        cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
+        root: Root<Post>,
+        period: PostPeriod,
+        sortType: PostSortType,
+        predicates: MutableList<Predicate>,
+    ) {
+        if (sortType == PostSortType.LATEST) {
+            addPostCreatedAtPeriodCondition(cb, root, period, predicates)
+            return
+        }
+        addDailyStatsPeriodCondition(cb, query, root, period, predicates)
+    }
+
+    /**
+     * LATEST 정렬의 기간 필터는 게시물 작성일 기준을 유지합니다.
+     */
+    private fun addPostCreatedAtPeriodCondition(
         cb: CriteriaBuilder,
         root: Root<Post>,
         period: PostPeriod,
         predicates: MutableList<Predicate>,
     ) {
         period.days?.let { days ->
-            val cutoffDate =
-                Calendar.getInstance().apply {
-                    add(Calendar.DAY_OF_YEAR, -days)
-                }.time
+            val cutoffDate = UtilDate.from(Instant.now().minus(days.toLong(), ChronoUnit.DAYS))
             predicates.add(cb.greaterThanOrEqualTo(root.get(EntityBase_.createdAt), cutoffDate))
         }
+    }
+
+    /**
+     * count 기반 기간 랭킹은 게시물 작성일이 아니라 일별 통계 테이블의 최근 데이터 존재 여부로 필터링합니다.
+     */
+    private fun addDailyStatsPeriodCondition(
+        cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
+        root: Root<Post>,
+        period: PostPeriod,
+        predicates: MutableList<Predicate>,
+    ) {
+        val days = period.days ?: return
+        val statsExistsSubquery = query.subquery(Long::class.java)
+        val statsRoot = statsExistsSubquery.from(PostDailyStats::class.java)
+
+        statsExistsSubquery.select(cb.literal(1L))
+        statsExistsSubquery.where(
+            cb.equal(statsRoot.get(PostDailyStats_.post).get(EntityBase_.id), root.get(EntityBase_.id)),
+            cb.greaterThanOrEqualTo(statsRoot.get(PostDailyStats_.statDate), statsCutoffDate(days)),
+        )
+        predicates.add(cb.exists(statsExistsSubquery))
     }
 
     /**
@@ -151,8 +322,10 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
      */
     private fun addCursorCondition(
         cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
         root: Root<Post>,
         cursor: PostCursor?,
+        period: PostPeriod,
         sortType: PostSortType,
         predicates: MutableList<Predicate>,
     ) {
@@ -161,14 +334,14 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         val cursorPredicate =
             when (sortType) {
                 PostSortType.LATEST -> buildLatestCursorCondition(cb, root, cursor)
-                else -> buildCountCursorCondition(cb, root, cursor, sortType)
+                else -> buildCountCursorCondition(cb, query, root, cursor, period, sortType)
             }
         predicates.add(cursorPredicate)
     }
 
     private fun addViewerBanCondition(
         cb: CriteriaBuilder,
-        cq: CriteriaQuery<Post>,
+        query: CommonAbstractCriteria,
         root: Root<Post>,
         viewerId: UUID?,
         predicates: MutableList<Predicate>,
@@ -177,7 +350,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             return
         }
 
-        val banSubquery = cq.subquery(Long::class.java)
+        val banSubquery = query.subquery(Long::class.java)
         val banRoot = banSubquery.from(UserBan::class.java)
 
         banSubquery.select(cb.literal(1L))
@@ -220,27 +393,23 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
      */
     private fun buildCountCursorCondition(
         cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
         root: Root<Post>,
         cursor: PostCursor,
+        period: PostPeriod,
         sortType: PostSortType,
     ): Predicate {
-        val sortAttribute =
-            when (sortType) {
-                PostSortType.VIEW -> Post_.viewCount
-                PostSortType.LIKE -> Post_.likeCount
-                PostSortType.COMMENT -> Post_.commentCount
-                else -> throw ApiException(PostStatus.INVALID_SORT_TYPE)
-            }
+        val sortExpression = countSortExpression(cb, query, root, period, sortType)
 
-        val countLess = cb.lessThan(root.get(sortAttribute), cursor.sortValue)
+        val countLess = cb.lessThan(sortExpression, cursor.sortValue)
         val countEqualCreatedAtLess =
             cb.and(
-                cb.equal(root.get(sortAttribute), cursor.sortValue),
+                cb.equal(sortExpression, cursor.sortValue),
                 cb.lessThan(root.get(EntityBase_.createdAt), cursor.createdAt),
             )
         val countEqualCreatedAtEqualIdLess =
             cb.and(
-                cb.equal(root.get(sortAttribute), cursor.sortValue),
+                cb.equal(sortExpression, cursor.sortValue),
                 cb.equal(root.get(EntityBase_.createdAt), cursor.createdAt),
                 cb.lessThan(root.get(EntityBase_.id), cursor.id),
             )
@@ -256,8 +425,9 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
      */
     private fun applyOrdering(
         cb: CriteriaBuilder,
-        cq: CriteriaQuery<Post>,
+        cq: CriteriaQuery<*>,
         root: Root<Post>,
+        period: PostPeriod,
         sortType: PostSortType,
     ) {
         val orders =
@@ -269,23 +439,84 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
                     )
                 PostSortType.VIEW ->
                     listOf(
-                        cb.desc(root.get(Post_.viewCount)),
+                        cb.desc(countSortExpression(cb, cq, root, period, sortType)),
                         cb.desc(root.get(EntityBase_.createdAt)),
                         cb.desc(root.get(EntityBase_.id)),
                     )
                 PostSortType.LIKE ->
                     listOf(
-                        cb.desc(root.get(Post_.likeCount)),
+                        cb.desc(countSortExpression(cb, cq, root, period, sortType)),
                         cb.desc(root.get(EntityBase_.createdAt)),
                         cb.desc(root.get(EntityBase_.id)),
                     )
                 PostSortType.COMMENT ->
                     listOf(
-                        cb.desc(root.get(Post_.commentCount)),
+                        cb.desc(countSortExpression(cb, cq, root, period, sortType)),
                         cb.desc(root.get(EntityBase_.createdAt)),
                         cb.desc(root.get(EntityBase_.id)),
                     )
             }
         cq.orderBy(orders)
     }
+
+    private fun countSortExpression(
+        cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
+        root: Root<Post>,
+        period: PostPeriod,
+        sortType: PostSortType,
+    ): Expression<Long> {
+        return if (usesDailyStatsPeriodRanking(period, sortType)) {
+            dailyStatsSumExpression(cb, query, root, period.days!!, sortType)
+        } else {
+            postCountExpression(root, sortType)
+        }
+    }
+
+    private fun dailyStatsSumExpression(
+        cb: CriteriaBuilder,
+        query: CommonAbstractCriteria,
+        root: Root<Post>,
+        days: Int,
+        sortType: PostSortType,
+    ): Expression<Long> {
+        val sumSubquery = query.subquery(Long::class.java)
+        val statsRoot = sumSubquery.from(PostDailyStats::class.java)
+
+        sumSubquery.select(cb.coalesce(cb.sum(dailyStatsCountExpression(statsRoot, sortType)), 0L))
+        sumSubquery.where(
+            cb.equal(statsRoot.get(PostDailyStats_.post).get(EntityBase_.id), root.get(EntityBase_.id)),
+            cb.greaterThanOrEqualTo(statsRoot.get(PostDailyStats_.statDate), statsCutoffDate(days)),
+        )
+        return sumSubquery
+    }
+
+    private fun postCountExpression(
+        root: Root<Post>,
+        sortType: PostSortType,
+    ): Path<Long> =
+        when (sortType) {
+            PostSortType.VIEW -> root.get(Post_.viewCount)
+            PostSortType.LIKE -> root.get(Post_.likeCount)
+            PostSortType.COMMENT -> root.get(Post_.commentCount)
+            else -> throw ApiException(PostStatus.INVALID_SORT_TYPE)
+        }
+
+    private fun dailyStatsCountExpression(
+        statsRoot: Root<PostDailyStats>,
+        sortType: PostSortType,
+    ): Path<Long> =
+        when (sortType) {
+            PostSortType.VIEW -> statsRoot.get(PostDailyStats_.viewCount)
+            PostSortType.LIKE -> statsRoot.get(PostDailyStats_.likeCount)
+            PostSortType.COMMENT -> statsRoot.get(PostDailyStats_.commentCount)
+            else -> throw ApiException(PostStatus.INVALID_SORT_TYPE)
+        }
+
+    private fun usesDailyStatsPeriodRanking(
+        period: PostPeriod,
+        sortType: PostSortType,
+    ): Boolean = sortType != PostSortType.LATEST && period.days != null
+
+    private fun statsCutoffDate(days: Int): SqlDate = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC).minusDays(days.toLong()))
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -18,6 +18,7 @@ import com.techtaurant.mainserver.user.entity.UserBan
 import com.techtaurant.mainserver.user.entity.UserBan_
 import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
+import jakarta.persistence.Tuple
 import jakarta.persistence.criteria.CommonAbstractCriteria
 import jakarta.persistence.criteria.CriteriaBuilder
 import jakarta.persistence.criteria.CriteriaQuery
@@ -44,6 +45,11 @@ import java.util.Date as UtilDate
 class PostRepositoryCustomImpl : PostRepositoryCustom {
     @PersistenceContext
     private lateinit var entityManager: EntityManager
+
+    private data class RankedPostId(
+        val postId: UUID,
+        val sortValue: Long,
+    )
 
     /**
      * 기간 필터 + 정렬 조건을 적용하여 게시물 목록 조회
@@ -99,14 +105,14 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             viewerId = viewerId,
             predicates = predicates,
         )
-        addPeriodCondition(cb, cq, root, period, sortType, predicates)
-        addCursorCondition(cb, cq, root, cursor, period, sortType, predicates)
+        addPostCreatedAtPeriodCondition(cb, root, period, sortType, predicates)
+        addCursorCondition(cb, root, cursor, sortType, predicates)
 
         if (predicates.isNotEmpty()) {
             cq.where(*predicates.toTypedArray())
         }
 
-        applyOrdering(cb, cq, root, period, sortType)
+        applyOrdering(cb, cq, root, sortType)
 
         return entityManager.createQuery(cq)
             .setMaxResults(size)
@@ -126,9 +132,42 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         tagIds: List<UUID>?,
         viewerId: UUID?,
     ): List<Post> {
+        val rankedPostIds =
+            findRankedPostIdsWithDailyStats(
+                cursor = cursor,
+                size = size,
+                period = period,
+                sortType = sortType,
+                authorId = authorId,
+                statuses = statuses,
+                categoryId = categoryId,
+                visibleToUserId = visibleToUserId,
+                tagIds = tagIds,
+                viewerId = viewerId,
+            )
+
+        return findPostsByIdsInOrder(rankedPostIds.map { it.postId })
+    }
+
+    private fun findRankedPostIdsWithDailyStats(
+        cursor: PostCursor?,
+        size: Int,
+        period: PostPeriod,
+        sortType: PostSortType,
+        authorId: UUID?,
+        statuses: List<PostStatusEnum>?,
+        categoryId: UUID?,
+        visibleToUserId: UUID?,
+        tagIds: List<UUID>?,
+        viewerId: UUID?,
+    ): List<RankedPostId> {
         val cb = entityManager.criteriaBuilder
-        val cq = cb.createQuery(UUID::class.java)
+        val cq = cb.createTupleQuery()
         val root = cq.from(Post::class.java)
+        val statsRoot = cq.from(PostDailyStats::class.java)
+        val postIdPath = root.get<UUID>(EntityBase_.id)
+        val createdAtPath = root.get<UtilDate>(EntityBase_.createdAt)
+        val sortExpression = dailyStatsSumExpression(cb, statsRoot, sortType)
         val predicates = mutableListOf<Predicate>()
 
         addBaseConditions(
@@ -143,22 +182,25 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             viewerId = viewerId,
             predicates = predicates,
         )
-        addPeriodCondition(cb, cq, root, period, sortType, predicates)
-        addCursorCondition(cb, cq, root, cursor, period, sortType, predicates)
+        addDailyStatsJoinCondition(cb, root, statsRoot, period, predicates)
 
-        cq.select(root.get(EntityBase_.id))
-        if (predicates.isNotEmpty()) {
-            cq.where(*predicates.toTypedArray())
-        }
-        applyOrdering(cb, cq, root, period, sortType)
+        cq.multiselect(postIdPath, sortExpression)
+        cq.where(*predicates.toTypedArray())
+        cq.groupBy(postIdPath, createdAtPath)
+        cursor?.let { cq.having(buildCountCursorCondition(cb, root, it, sortExpression)) }
+        cq.orderBy(countSortOrders(cb, root, sortExpression))
 
-        val postIds =
-            entityManager.createQuery(cq)
-                .setMaxResults(size)
-                .resultList
-
-        return findPostsByIdsInOrder(postIds)
+        return entityManager.createQuery(cq)
+            .setMaxResults(size)
+            .resultList
+            .map { tuple -> tuple.toRankedPostId() }
     }
+
+    private fun Tuple.toRankedPostId(): RankedPostId =
+        RankedPostId(
+            postId = get(0) as UUID,
+            sortValue = (get(1) as Number).toLong(),
+        )
 
     private fun findPostsByIdsInOrder(postIds: List<UUID>): List<Post> {
         if (postIds.isEmpty()) {
@@ -257,62 +299,33 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         predicates.add(cb.exists(tagSubquery))
     }
 
-    /**
-     * 지정된 기간 조건을 적용합니다.
-     *
-     * LATEST 정렬은 기존처럼 게시물 작성일 기준으로 필터링하고,
-     * VIEW/LIKE/COMMENT 정렬은 게시물 작성일이 아니라 기간 내 일별 통계 존재 여부로 필터링합니다.
-     */
-    private fun addPeriodCondition(
+    private fun addPostCreatedAtPeriodCondition(
         cb: CriteriaBuilder,
-        query: CommonAbstractCriteria,
         root: Root<Post>,
         period: PostPeriod,
         sortType: PostSortType,
         predicates: MutableList<Predicate>,
     ) {
-        if (sortType == PostSortType.LATEST) {
-            addPostCreatedAtPeriodCondition(cb, root, period, predicates)
+        if (sortType != PostSortType.LATEST) {
             return
         }
-        addDailyStatsPeriodCondition(cb, query, root, period, predicates)
-    }
 
-    /**
-     * LATEST 정렬의 기간 필터는 게시물 작성일 기준을 유지합니다.
-     */
-    private fun addPostCreatedAtPeriodCondition(
-        cb: CriteriaBuilder,
-        root: Root<Post>,
-        period: PostPeriod,
-        predicates: MutableList<Predicate>,
-    ) {
         period.days?.let { days ->
             val cutoffDate = UtilDate.from(Instant.now().minus(days.toLong(), ChronoUnit.DAYS))
             predicates.add(cb.greaterThanOrEqualTo(root.get(EntityBase_.createdAt), cutoffDate))
         }
     }
 
-    /**
-     * count 기반 기간 랭킹은 게시물 작성일이 아니라 일별 통계 테이블의 최근 데이터 존재 여부로 필터링합니다.
-     */
-    private fun addDailyStatsPeriodCondition(
+    private fun addDailyStatsJoinCondition(
         cb: CriteriaBuilder,
-        query: CommonAbstractCriteria,
         root: Root<Post>,
+        statsRoot: Root<PostDailyStats>,
         period: PostPeriod,
         predicates: MutableList<Predicate>,
     ) {
         val days = period.days ?: return
-        val statsExistsSubquery = query.subquery(Long::class.java)
-        val statsRoot = statsExistsSubquery.from(PostDailyStats::class.java)
-
-        statsExistsSubquery.select(cb.literal(1L))
-        statsExistsSubquery.where(
-            cb.equal(statsRoot.get(PostDailyStats_.post).get(EntityBase_.id), root.get(EntityBase_.id)),
-            cb.greaterThanOrEqualTo(statsRoot.get(PostDailyStats_.statDate), statsCutoffDate(days)),
-        )
-        predicates.add(cb.exists(statsExistsSubquery))
+        predicates.add(cb.equal(statsRoot.get(PostDailyStats_.post).get(EntityBase_.id), root.get(EntityBase_.id)))
+        predicates.add(cb.greaterThanOrEqualTo(statsRoot.get(PostDailyStats_.statDate), statsCutoffDate(days)))
     }
 
     /**
@@ -322,10 +335,8 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
      */
     private fun addCursorCondition(
         cb: CriteriaBuilder,
-        query: CommonAbstractCriteria,
         root: Root<Post>,
         cursor: PostCursor?,
-        period: PostPeriod,
         sortType: PostSortType,
         predicates: MutableList<Predicate>,
     ) {
@@ -334,7 +345,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         val cursorPredicate =
             when (sortType) {
                 PostSortType.LATEST -> buildLatestCursorCondition(cb, root, cursor)
-                else -> buildCountCursorCondition(cb, query, root, cursor, period, sortType)
+                else -> buildCountCursorCondition(cb, root, cursor, postCountExpression(root, sortType))
             }
         predicates.add(cursorPredicate)
     }
@@ -393,14 +404,10 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
      */
     private fun buildCountCursorCondition(
         cb: CriteriaBuilder,
-        query: CommonAbstractCriteria,
         root: Root<Post>,
         cursor: PostCursor,
-        period: PostPeriod,
-        sortType: PostSortType,
+        sortExpression: Expression<Long>,
     ): Predicate {
-        val sortExpression = countSortExpression(cb, query, root, period, sortType)
-
         val countLess = cb.lessThan(sortExpression, cursor.sortValue)
         val countEqualCreatedAtLess =
             cb.and(
@@ -427,7 +434,6 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         cb: CriteriaBuilder,
         cq: CriteriaQuery<*>,
         root: Root<Post>,
-        period: PostPeriod,
         sortType: PostSortType,
     ) {
         val orders =
@@ -437,59 +443,26 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
                         cb.desc(root.get(EntityBase_.updatedAt)),
                         cb.desc(root.get(EntityBase_.id)),
                     )
-                PostSortType.VIEW ->
-                    listOf(
-                        cb.desc(countSortExpression(cb, cq, root, period, sortType)),
-                        cb.desc(root.get(EntityBase_.createdAt)),
-                        cb.desc(root.get(EntityBase_.id)),
-                    )
-                PostSortType.LIKE ->
-                    listOf(
-                        cb.desc(countSortExpression(cb, cq, root, period, sortType)),
-                        cb.desc(root.get(EntityBase_.createdAt)),
-                        cb.desc(root.get(EntityBase_.id)),
-                    )
-                PostSortType.COMMENT ->
-                    listOf(
-                        cb.desc(countSortExpression(cb, cq, root, period, sortType)),
-                        cb.desc(root.get(EntityBase_.createdAt)),
-                        cb.desc(root.get(EntityBase_.id)),
-                    )
+                else -> countSortOrders(cb, root, postCountExpression(root, sortType))
             }
         cq.orderBy(orders)
     }
 
-    private fun countSortExpression(
+    private fun countSortOrders(
         cb: CriteriaBuilder,
-        query: CommonAbstractCriteria,
         root: Root<Post>,
-        period: PostPeriod,
-        sortType: PostSortType,
-    ): Expression<Long> {
-        return if (usesDailyStatsPeriodRanking(period, sortType)) {
-            dailyStatsSumExpression(cb, query, root, period.days!!, sortType)
-        } else {
-            postCountExpression(root, sortType)
-        }
-    }
+        sortExpression: Expression<Long>,
+    ) = listOf(
+        cb.desc(sortExpression),
+        cb.desc(root.get(EntityBase_.createdAt)),
+        cb.desc(root.get(EntityBase_.id)),
+    )
 
     private fun dailyStatsSumExpression(
         cb: CriteriaBuilder,
-        query: CommonAbstractCriteria,
-        root: Root<Post>,
-        days: Int,
+        statsRoot: Root<PostDailyStats>,
         sortType: PostSortType,
-    ): Expression<Long> {
-        val sumSubquery = query.subquery(Long::class.java)
-        val statsRoot = sumSubquery.from(PostDailyStats::class.java)
-
-        sumSubquery.select(cb.coalesce(cb.sum(dailyStatsCountExpression(statsRoot, sortType)), 0L))
-        sumSubquery.where(
-            cb.equal(statsRoot.get(PostDailyStats_.post).get(EntityBase_.id), root.get(EntityBase_.id)),
-            cb.greaterThanOrEqualTo(statsRoot.get(PostDailyStats_.statDate), statsCutoffDate(days)),
-        )
-        return sumSubquery
-    }
+    ): Expression<Long> = cb.coalesce(cb.sum(dailyStatsCountExpression(statsRoot, sortType)), 0L)
 
     private fun postCountExpression(
         root: Root<Post>,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -33,8 +33,6 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-import java.sql.Date as SqlDate
-import java.util.Date as UtilDate
 
 /**
  * 게시물 동적 쿼리 구현체
@@ -144,7 +142,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             .setMaxResults(size)
             .resultList
             .distinctBy { it.id }
-            .map { post -> PostWithSortValue(post = post, sortValue = post.updatedAt.time) }
+            .map { post -> PostWithSortValue(post = post, sortValue = post.updatedAt.toEpochMilli()) }
     }
 
     private fun findPostsWithStatsRanking(
@@ -193,7 +191,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         val root = cq.from(Post::class.java)
         val statsRoot = cq.from(PostDailyStats::class.java)
         val postIdPath = root.get<UUID>(EntityBase_.id)
-        val createdAtPath = root.get<UtilDate>(EntityBase_.createdAt)
+        val createdAtPath = root.get<Instant>(EntityBase_.createdAt)
         val sortExpression = dailyStatsSumExpression(cb, statsRoot, sortType)
         val predicates = mutableListOf<Predicate>()
 
@@ -337,7 +335,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         predicates: MutableList<Predicate>,
     ) {
         period.days?.let { days ->
-            val cutoffDate = UtilDate.from(Instant.now().minus(days.toLong(), ChronoUnit.DAYS))
+            val cutoffDate = Instant.now().minus(days.toLong(), ChronoUnit.DAYS)
             predicates.add(cb.greaterThanOrEqualTo(root.get(EntityBase_.createdAt), cutoffDate))
         }
     }
@@ -455,5 +453,5 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             else -> throw ApiException(PostStatus.INVALID_SORT_TYPE)
         }
 
-    private fun statsCutoffDate(days: Int): SqlDate = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC).minusDays(days.toLong()))
+    private fun statsCutoffDate(days: Int): LocalDate = LocalDate.now(ZoneOffset.UTC).minusDays(days.toLong())
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImpl.kt
@@ -2,6 +2,7 @@ package com.techtaurant.mainserver.post.infrastructure.out
 
 import com.techtaurant.mainserver.common.base.EntityBase_
 import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.post.application.PostWithSortValue
 import com.techtaurant.mainserver.post.dto.PostCursor
 import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
@@ -21,7 +22,6 @@ import jakarta.persistence.PersistenceContext
 import jakarta.persistence.Tuple
 import jakarta.persistence.criteria.CommonAbstractCriteria
 import jakarta.persistence.criteria.CriteriaBuilder
-import jakarta.persistence.criteria.CriteriaQuery
 import jakarta.persistence.criteria.Expression
 import jakarta.persistence.criteria.JoinType
 import jakarta.persistence.criteria.Path
@@ -67,9 +67,21 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         visibleToUserId: UUID?,
         tagIds: List<UUID>?,
         viewerId: UUID?,
-    ): List<Post> {
-        if (usesDailyStatsPeriodRanking(period, sortType)) {
-            return findPostsWithDailyStatsPeriodRanking(
+    ): List<PostWithSortValue> {
+        return if (sortType == PostSortType.LATEST) {
+            findLatestPostsWithConditions(
+                cursor = cursor,
+                size = size,
+                period = period,
+                authorId = authorId,
+                statuses = statuses,
+                categoryId = categoryId,
+                visibleToUserId = visibleToUserId,
+                tagIds = tagIds,
+                viewerId = viewerId,
+            )
+        } else {
+            findPostsWithStatsRanking(
                 cursor = cursor,
                 size = size,
                 period = period,
@@ -82,7 +94,19 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
                 viewerId = viewerId,
             )
         }
+    }
 
+    private fun findLatestPostsWithConditions(
+        cursor: PostCursor?,
+        size: Int,
+        period: PostPeriod,
+        authorId: UUID?,
+        statuses: List<PostStatusEnum>?,
+        categoryId: UUID?,
+        visibleToUserId: UUID?,
+        tagIds: List<UUID>?,
+        viewerId: UUID?,
+    ): List<PostWithSortValue> {
         val cb = entityManager.criteriaBuilder
         val cq = cb.createQuery(Post::class.java)
         val root = cq.from(Post::class.java)
@@ -105,22 +129,25 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             viewerId = viewerId,
             predicates = predicates,
         )
-        addPostCreatedAtPeriodCondition(cb, root, period, sortType, predicates)
-        addCursorCondition(cb, root, cursor, sortType, predicates)
+        addLatestPeriodCondition(cb, root, period, predicates)
+        cursor?.let { predicates.add(buildLatestCursorCondition(cb, root, it)) }
 
         if (predicates.isNotEmpty()) {
             cq.where(*predicates.toTypedArray())
         }
-
-        applyOrdering(cb, cq, root, sortType)
+        cq.orderBy(
+            cb.desc(root.get(EntityBase_.updatedAt)),
+            cb.desc(root.get(EntityBase_.id)),
+        )
 
         return entityManager.createQuery(cq)
             .setMaxResults(size)
             .resultList
             .distinctBy { it.id }
+            .map { post -> PostWithSortValue(post = post, sortValue = post.updatedAt.time) }
     }
 
-    private fun findPostsWithDailyStatsPeriodRanking(
+    private fun findPostsWithStatsRanking(
         cursor: PostCursor?,
         size: Int,
         period: PostPeriod,
@@ -131,9 +158,9 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         visibleToUserId: UUID?,
         tagIds: List<UUID>?,
         viewerId: UUID?,
-    ): List<Post> {
+    ): List<PostWithSortValue> {
         val rankedPostIds =
-            findRankedPostIdsWithDailyStats(
+            findRankedPostIdsWithStats(
                 cursor = cursor,
                 size = size,
                 period = period,
@@ -146,10 +173,10 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
                 viewerId = viewerId,
             )
 
-        return findPostsByIdsInOrder(rankedPostIds.map { it.postId })
+        return findPostsByRankedIdsInOrder(rankedPostIds)
     }
 
-    private fun findRankedPostIdsWithDailyStats(
+    private fun findRankedPostIdsWithStats(
         cursor: PostCursor?,
         size: Int,
         period: PostPeriod,
@@ -182,7 +209,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             viewerId = viewerId,
             predicates = predicates,
         )
-        addDailyStatsJoinCondition(cb, root, statsRoot, period, predicates)
+        addStatsJoinCondition(cb, root, statsRoot, period, predicates)
 
         cq.multiselect(postIdPath, sortExpression)
         cq.where(*predicates.toTypedArray())
@@ -202,10 +229,13 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             sortValue = (get(1) as Number).toLong(),
         )
 
-    private fun findPostsByIdsInOrder(postIds: List<UUID>): List<Post> {
-        if (postIds.isEmpty()) {
+    private fun findPostsByRankedIdsInOrder(rankedPostIds: List<RankedPostId>): List<PostWithSortValue> {
+        if (rankedPostIds.isEmpty()) {
             return emptyList()
         }
+
+        val postIds = rankedPostIds.map { it.postId }
+        val sortValueByPostId = rankedPostIds.associate { it.postId to it.sortValue }
 
         val cb = entityManager.criteriaBuilder
         val cq = cb.createQuery(Post::class.java)
@@ -222,6 +252,7 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             .resultList
             .distinctBy { it.id }
             .sortedBy { orderByPostId.getValue(it.id!!) }
+            .map { post -> PostWithSortValue(post = post, sortValue = sortValueByPostId.getValue(post.id!!)) }
     }
 
     override fun findVisiblePostDetailById(
@@ -299,55 +330,29 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         predicates.add(cb.exists(tagSubquery))
     }
 
-    private fun addPostCreatedAtPeriodCondition(
+    private fun addLatestPeriodCondition(
         cb: CriteriaBuilder,
         root: Root<Post>,
         period: PostPeriod,
-        sortType: PostSortType,
         predicates: MutableList<Predicate>,
     ) {
-        if (sortType != PostSortType.LATEST) {
-            return
-        }
-
         period.days?.let { days ->
             val cutoffDate = UtilDate.from(Instant.now().minus(days.toLong(), ChronoUnit.DAYS))
             predicates.add(cb.greaterThanOrEqualTo(root.get(EntityBase_.createdAt), cutoffDate))
         }
     }
 
-    private fun addDailyStatsJoinCondition(
+    private fun addStatsJoinCondition(
         cb: CriteriaBuilder,
         root: Root<Post>,
         statsRoot: Root<PostDailyStats>,
         period: PostPeriod,
         predicates: MutableList<Predicate>,
     ) {
-        val days = period.days ?: return
         predicates.add(cb.equal(statsRoot.get(PostDailyStats_.post).get(EntityBase_.id), root.get(EntityBase_.id)))
-        predicates.add(cb.greaterThanOrEqualTo(statsRoot.get(PostDailyStats_.statDate), statsCutoffDate(days)))
-    }
-
-    /**
-     * 정렬 타입에 따른 커서 조건 추가
-     *
-     * 최신순은 updatedAt + id 기준, 그 외(조회/추천/댓글순)는 해당 count + createdAt + id 기준
-     */
-    private fun addCursorCondition(
-        cb: CriteriaBuilder,
-        root: Root<Post>,
-        cursor: PostCursor?,
-        sortType: PostSortType,
-        predicates: MutableList<Predicate>,
-    ) {
-        cursor ?: return
-
-        val cursorPredicate =
-            when (sortType) {
-                PostSortType.LATEST -> buildLatestCursorCondition(cb, root, cursor)
-                else -> buildCountCursorCondition(cb, root, cursor, postCountExpression(root, sortType))
-            }
-        predicates.add(cursorPredicate)
+        period.days?.let { days ->
+            predicates.add(cb.greaterThanOrEqualTo(statsRoot.get(PostDailyStats_.statDate), statsCutoffDate(days)))
+        }
     }
 
     private fun addViewerBanCondition(
@@ -423,31 +428,6 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         return cb.or(countLess, countEqualCreatedAtLess, countEqualCreatedAtEqualIdLess)
     }
 
-    /**
-     * 정렬 타입에 따른 ORDER BY 절 적용
-     *
-     * 모든 정렬은 DESC이며 동점자 처리를 위해 createdAt, id를 보조 정렬 키로 추가합니다.
-     * 최신순(LATEST)은 updatedAt 기준입니다. createdAt을 기준으로 하면 한 번 생성된 게시물이
-     * 영구히 낮은 순위에 머물 수 있으므로, 수정된 게시물도 상단에 노출될 수 있도록 updatedAt을 사용합니다.
-     */
-    private fun applyOrdering(
-        cb: CriteriaBuilder,
-        cq: CriteriaQuery<*>,
-        root: Root<Post>,
-        sortType: PostSortType,
-    ) {
-        val orders =
-            when (sortType) {
-                PostSortType.LATEST ->
-                    listOf(
-                        cb.desc(root.get(EntityBase_.updatedAt)),
-                        cb.desc(root.get(EntityBase_.id)),
-                    )
-                else -> countSortOrders(cb, root, postCountExpression(root, sortType))
-            }
-        cq.orderBy(orders)
-    }
-
     private fun countSortOrders(
         cb: CriteriaBuilder,
         root: Root<Post>,
@@ -464,17 +444,6 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
         sortType: PostSortType,
     ): Expression<Long> = cb.coalesce(cb.sum(dailyStatsCountExpression(statsRoot, sortType)), 0L)
 
-    private fun postCountExpression(
-        root: Root<Post>,
-        sortType: PostSortType,
-    ): Path<Long> =
-        when (sortType) {
-            PostSortType.VIEW -> root.get(Post_.viewCount)
-            PostSortType.LIKE -> root.get(Post_.likeCount)
-            PostSortType.COMMENT -> root.get(Post_.commentCount)
-            else -> throw ApiException(PostStatus.INVALID_SORT_TYPE)
-        }
-
     private fun dailyStatsCountExpression(
         statsRoot: Root<PostDailyStats>,
         sortType: PostSortType,
@@ -485,11 +454,6 @@ class PostRepositoryCustomImpl : PostRepositoryCustom {
             PostSortType.COMMENT -> statsRoot.get(PostDailyStats_.commentCount)
             else -> throw ApiException(PostStatus.INVALID_SORT_TYPE)
         }
-
-    private fun usesDailyStatsPeriodRanking(
-        period: PostPeriod,
-        sortType: PostSortType,
-    ): Boolean = sortType != PostSortType.LATEST && period.days != null
 
     private fun statsCutoffDate(days: Int): SqlDate = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC).minusDays(days.toLong()))
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/TagRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/TagRepository.kt
@@ -13,12 +13,12 @@ interface TagRepository : JpaRepository<Tag, UUID> {
 
     @Query(
         value = """
-            SELECT t.id, t.name, t.created_at as createdAt, t.updated_at as updatedAt,
+            SELECT t.id, t.name, t.created_at_utc as createdAt, t.updated_at_utc as updatedAt,
                    COALESCE(COUNT(pt.post_id), 0) as postCount
             FROM tags t
             JOIN post_tags pt ON t.id = pt.tag_id
             WHERE (:name IS NULL OR t.name ILIKE '%' || :name || '%')
-            GROUP BY t.id, t.name, t.created_at, t.updated_at
+            GROUP BY t.id, t.name, t.created_at_utc, t.updated_at_utc
             ORDER BY postCount DESC, t.id ASC
             LIMIT :limit
         """,
@@ -41,12 +41,12 @@ interface TagRepository : JpaRepository<Tag, UUID> {
      */
     @Query(
         value = """
-            SELECT t.id, t.name, t.created_at as createdAt, t.updated_at as updatedAt,
+            SELECT t.id, t.name, t.created_at_utc as createdAt, t.updated_at_utc as updatedAt,
                    COALESCE(COUNT(pt.post_id), 0) as postCount
             FROM tags t
             JOIN post_tags pt ON t.id = pt.tag_id
             WHERE (:name IS NULL OR t.name ILIKE '%' || :name || '%')
-            GROUP BY t.id, t.name, t.created_at, t.updated_at
+            GROUP BY t.id, t.name, t.created_at_utc, t.updated_at_utc
             HAVING COALESCE(COUNT(pt.post_id), 0) < :lastPostCount
                 OR (COALESCE(COUNT(pt.post_id), 0) = :lastPostCount AND t.id > :lastTagId)
             ORDER BY postCount DESC, t.id ASC

--- a/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/TagWithPostCountProjection.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/infrastructure/out/TagWithPostCountProjection.kt
@@ -1,6 +1,6 @@
 package com.techtaurant.mainserver.post.infrastructure.out
 
-import java.time.LocalDateTime
+import java.time.Instant
 import java.util.UUID
 
 interface TagWithPostCountProjection {
@@ -8,9 +8,9 @@ interface TagWithPostCountProjection {
 
     fun getName(): String
 
-    fun getCreatedAt(): LocalDateTime
+    fun getCreatedAt(): Instant
 
-    fun getUpdatedAt(): LocalDateTime
+    fun getUpdatedAt(): Instant
 
     fun getPostCount(): Long
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/security/jwt/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/jwt/JwtTokenProvider.kt
@@ -9,6 +9,7 @@ import io.jsonwebtoken.UnsupportedJwtException
 import io.jsonwebtoken.security.Keys
 import org.springframework.stereotype.Component
 import java.security.MessageDigest
+import java.time.Instant
 import java.util.Date
 import java.util.HexFormat
 import java.util.UUID
@@ -26,15 +27,15 @@ class JwtTokenProvider(
         userId: UUID,
         role: UserRole,
     ): String {
-        val now = Date()
-        val expiryDate = Date(now.time + jwtProperties.accessTokenExpireMs)
+        val now = Instant.now()
+        val expiryAt = now.plusMillis(jwtProperties.accessTokenExpireMs)
 
         return Jwts.builder()
             .subject(userId.toString())
             .claim(JwtConstants.ROLE_CLAIM, role.key)
             .claim(JwtConstants.PERMANENT_CLAIM, JwtConstants.EXPIRING_ACCESS_TOKEN_IS_PERMANENT)
-            .issuedAt(now)
-            .expiration(expiryDate)
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(expiryAt))
             .signWith(secretKey)
             .compact()
     }
@@ -43,14 +44,14 @@ class JwtTokenProvider(
         userId: UUID,
         role: UserRole,
     ): String {
-        val now = Date()
+        val now = Instant.now()
 
         return Jwts.builder()
             .id(UUID.randomUUID().toString())
             .subject(userId.toString())
             .claim(JwtConstants.ROLE_CLAIM, role.key)
             .claim(JwtConstants.PERMANENT_CLAIM, JwtConstants.PERMANENT_ACCESS_TOKEN_IS_PERMANENT)
-            .issuedAt(now)
+            .issuedAt(Date.from(now))
             .signWith(secretKey)
             .compact()
     }
@@ -63,13 +64,13 @@ class JwtTokenProvider(
         userId: UUID,
         expiration: Long,
     ): String {
-        val now = Date()
-        val expiryDate = Date(now.time + expiration)
+        val now = Instant.now()
+        val expiryAt = now.plusMillis(expiration)
 
         return Jwts.builder()
             .subject(userId.toString())
-            .issuedAt(now)
-            .expiration(expiryDate)
+            .issuedAt(Date.from(now))
+            .expiration(Date.from(expiryAt))
             .signWith(secretKey)
             .compact()
     }

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserBanListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserBanListItemResponse.kt
@@ -2,7 +2,7 @@ package com.techtaurant.mainserver.user.dto
 
 import com.techtaurant.mainserver.user.entity.UserBan
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 @Schema(description = "차단한 사용자 목록 아이템 응답")
@@ -14,7 +14,7 @@ data class UserBanListItemResponse(
     @field:Schema(description = "차단 대상 사용자 프로필 이미지 URL", nullable = true)
     val profileImageUrl: String?,
     @field:Schema(description = "차단 시각")
-    val bannedAt: Date,
+    val bannedAt: Instant,
 ) {
     companion object {
         fun from(

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserBanResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserBanResponse.kt
@@ -2,7 +2,7 @@ package com.techtaurant.mainserver.user.dto
 
 import com.techtaurant.mainserver.user.entity.UserBan
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 @Schema(description = "사용자 차단 응답")
@@ -12,7 +12,7 @@ data class UserBanResponse(
     @field:Schema(description = "차단 대상 사용자 이름")
     val name: String,
     @field:Schema(description = "차단 시각")
-    val bannedAt: Date,
+    val bannedAt: Instant,
 ) {
     companion object {
         fun from(userBan: UserBan): UserBanResponse =

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowListItemResponse.kt
@@ -2,7 +2,7 @@ package com.techtaurant.mainserver.user.dto
 
 import com.techtaurant.mainserver.user.entity.UserFollow
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 @Schema(description = "사용자 팔로워/팔로잉 목록 아이템 응답")
@@ -14,7 +14,7 @@ data class UserFollowListItemResponse(
     @field:Schema(description = "사용자 프로필 이미지 URL")
     val profileImageUrl: String,
     @field:Schema(description = "팔로우 생성 시각")
-    val followedAt: Date,
+    val followedAt: Instant,
 ) {
     companion object {
         fun fromFollowing(

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserFollowResponse.kt
@@ -2,7 +2,7 @@ package com.techtaurant.mainserver.user.dto
 
 import com.techtaurant.mainserver.user.entity.UserFollow
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 @Schema(description = "사용자 팔로우 응답")
@@ -12,7 +12,7 @@ data class UserFollowResponse(
     @field:Schema(description = "팔로우한 사용자 이름")
     val name: String,
     @field:Schema(description = "팔로우 시각")
-    val followedAt: Date,
+    val followedAt: Instant,
 ) {
     companion object {
         fun from(userFollow: UserFollow): UserFollowResponse =

--- a/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserTokenResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/user/dto/UserTokenResponse.kt
@@ -4,7 +4,7 @@ import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.common.status.DefaultStatus
 import com.techtaurant.mainserver.user.entity.UserToken
 import io.swagger.v3.oas.annotations.media.Schema
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 @Schema(description = "사용자 토큰 발급 응답")
@@ -20,7 +20,7 @@ data class UserTokenResponse(
     @field:Schema(description = "영구 토큰 여부", example = "true")
     val permanent: Boolean,
     @field:Schema(description = "토큰 생성 시각")
-    val createdAt: Date,
+    val createdAt: Instant,
 ) {
     companion object {
         fun from(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,6 +34,8 @@ spring:
         enabled: true
         baseline-on-migrate: true
         locations: classpath:db/migration
+        postgresql:
+            transactional-lock: false
 
     security:
         oauth2:

--- a/src/main/resources/db/migration/V35__add_utc_timestamptz_columns.sql
+++ b/src/main/resources/db/migration/V35__add_utc_timestamptz_columns.sql
@@ -1,0 +1,307 @@
+-- flyway:executeInTransaction=false
+-- Expand migration for UTC-safe absolute instants.
+-- Old TIMESTAMP columns are kept for rolling deploy compatibility; new application code uses *_utc TIMESTAMPTZ columns.
+
+-- Add nullable columns without defaults to avoid table rewrites.
+ALTER TABLE attachments ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE attachments ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE categories ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE categories ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE comment_like_log ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE comment_like_log ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE comments ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE comments ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE link_crawl_batches ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE link_crawl_batches ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE link_daily_stats ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE link_daily_stats ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE link_like_log ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE link_like_log ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE link_read_log ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE link_read_log ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE link_view_log ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE link_view_log ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE links ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE links ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE notification_arguments ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE notification_arguments ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE notification_recipients ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE notification_recipients ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE notifications ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE notifications ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE post_daily_stats ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE post_daily_stats ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE post_like_log ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE post_like_log ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE post_read_log ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE post_read_log ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE post_view_log ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE post_view_log ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE posts ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE posts ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE tags ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE tags ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE user_bans ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE user_bans ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE user_follows ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE user_follows ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE user_links ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE user_links ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE user_tokens ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE user_tokens ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS created_at_utc TIMESTAMPTZ;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS updated_at_utc TIMESTAMPTZ;
+ALTER TABLE comments ADD COLUMN IF NOT EXISTS deleted_at_utc TIMESTAMPTZ;
+ALTER TABLE link_crawl_batches ADD COLUMN IF NOT EXISTS last_triggered_at_utc TIMESTAMPTZ;
+ALTER TABLE links ADD COLUMN IF NOT EXISTS published_at_utc TIMESTAMPTZ;
+ALTER TABLE notification_recipients ADD COLUMN IF NOT EXISTS read_at_utc TIMESTAMPTZ;
+ALTER TABLE posts ADD COLUMN IF NOT EXISTS stats_updated_at_utc TIMESTAMPTZ;
+
+-- Generic bidirectional sync trigger for old TIMESTAMP columns and new TIMESTAMPTZ *_utc columns.
+CREATE OR REPLACE FUNCTION sync_utc_temporal_columns()
+RETURNS trigger AS $$
+DECLARE
+    arg_index integer := 0;
+    old_column_name text;
+    utc_column_name text;
+    old_column_value timestamp;
+    utc_column_value timestamptz;
+    patch jsonb := '{}'::jsonb;
+    new_row jsonb;
+    old_row jsonb;
+BEGIN
+    new_row := to_jsonb(NEW);
+    IF TG_OP = 'UPDATE' THEN
+        old_row := to_jsonb(OLD);
+    END IF;
+
+    WHILE arg_index < TG_NARGS LOOP
+        old_column_name := TG_ARGV[arg_index];
+        utc_column_name := TG_ARGV[arg_index + 1];
+        old_column_value := (new_row ->> old_column_name)::timestamp;
+        utc_column_value := (new_row ->> utc_column_name)::timestamptz;
+
+        IF TG_OP = 'INSERT' THEN
+            IF utc_column_value IS NOT NULL THEN
+                patch := patch || jsonb_build_object(old_column_name, utc_column_value AT TIME ZONE 'UTC');
+            ELSIF old_column_value IS NOT NULL THEN
+                patch := patch || jsonb_build_object(utc_column_name, old_column_value AT TIME ZONE 'UTC');
+            END IF;
+        ELSE
+            IF (new_row -> utc_column_name) IS DISTINCT FROM (old_row -> utc_column_name) THEN
+                patch := patch || jsonb_build_object(old_column_name, utc_column_value AT TIME ZONE 'UTC');
+            ELSIF (new_row -> old_column_name) IS DISTINCT FROM (old_row -> old_column_name) THEN
+                patch := patch || jsonb_build_object(utc_column_name, old_column_value AT TIME ZONE 'UTC');
+            END IF;
+        END IF;
+
+        arg_index := arg_index + 2;
+    END LOOP;
+
+    IF patch <> '{}'::jsonb THEN
+        NEW := jsonb_populate_record(NEW, patch);
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create sync triggers before backfill so old app instances writing during migration also populate *_utc columns.
+DROP TRIGGER IF EXISTS trigger_sync_attachments_utc_temporal_columns ON attachments;
+CREATE TRIGGER trigger_sync_attachments_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON attachments
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_categories_utc_temporal_columns ON categories;
+CREATE TRIGGER trigger_sync_categories_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON categories
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_comment_like_log_utc_temporal_columns ON comment_like_log;
+CREATE TRIGGER trigger_sync_comment_like_log_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON comment_like_log
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_comments_utc_temporal_columns ON comments;
+CREATE TRIGGER trigger_sync_comments_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON comments
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc', 'deleted_at', 'deleted_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_link_crawl_batches_utc_temporal_columns ON link_crawl_batches;
+CREATE TRIGGER trigger_sync_link_crawl_batches_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON link_crawl_batches
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc', 'last_triggered_at', 'last_triggered_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_link_daily_stats_utc_temporal_columns ON link_daily_stats;
+CREATE TRIGGER trigger_sync_link_daily_stats_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON link_daily_stats
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_link_like_log_utc_temporal_columns ON link_like_log;
+CREATE TRIGGER trigger_sync_link_like_log_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON link_like_log
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_link_read_log_utc_temporal_columns ON link_read_log;
+CREATE TRIGGER trigger_sync_link_read_log_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON link_read_log
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_link_view_log_utc_temporal_columns ON link_view_log;
+CREATE TRIGGER trigger_sync_link_view_log_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON link_view_log
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_links_utc_temporal_columns ON links;
+CREATE TRIGGER trigger_sync_links_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON links
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc', 'published_at', 'published_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_notification_arguments_utc_temporal_columns ON notification_arguments;
+CREATE TRIGGER trigger_sync_notification_arguments_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON notification_arguments
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_notification_recipients_utc_temporal_columns ON notification_recipients;
+CREATE TRIGGER trigger_sync_notification_recipients_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON notification_recipients
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc', 'read_at', 'read_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_notifications_utc_temporal_columns ON notifications;
+CREATE TRIGGER trigger_sync_notifications_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON notifications
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_post_daily_stats_utc_temporal_columns ON post_daily_stats;
+CREATE TRIGGER trigger_sync_post_daily_stats_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON post_daily_stats
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_post_like_log_utc_temporal_columns ON post_like_log;
+CREATE TRIGGER trigger_sync_post_like_log_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON post_like_log
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_post_read_log_utc_temporal_columns ON post_read_log;
+CREATE TRIGGER trigger_sync_post_read_log_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON post_read_log
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_post_view_log_utc_temporal_columns ON post_view_log;
+CREATE TRIGGER trigger_sync_post_view_log_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON post_view_log
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_posts_utc_temporal_columns ON posts;
+CREATE TRIGGER trigger_sync_posts_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON posts
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc', 'stats_updated_at', 'stats_updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_tags_utc_temporal_columns ON tags;
+CREATE TRIGGER trigger_sync_tags_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON tags
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_user_bans_utc_temporal_columns ON user_bans;
+CREATE TRIGGER trigger_sync_user_bans_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON user_bans
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_user_follows_utc_temporal_columns ON user_follows;
+CREATE TRIGGER trigger_sync_user_follows_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON user_follows
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_user_links_utc_temporal_columns ON user_links;
+CREATE TRIGGER trigger_sync_user_links_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON user_links
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_user_tokens_utc_temporal_columns ON user_tokens;
+CREATE TRIGGER trigger_sync_user_tokens_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON user_tokens
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+DROP TRIGGER IF EXISTS trigger_sync_users_utc_temporal_columns ON users;
+CREATE TRIGGER trigger_sync_users_utc_temporal_columns
+BEFORE INSERT OR UPDATE ON users
+FOR EACH ROW
+EXECUTE FUNCTION sync_utc_temporal_columns('created_at', 'created_at_utc', 'updated_at', 'updated_at_utc');
+
+-- Backfill old timestamp values as UTC instants. Existing naive TIMESTAMP values are interpreted as UTC.
+UPDATE attachments SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE attachments SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE categories SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE categories SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE comment_like_log SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE comment_like_log SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE comments SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE comments SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE link_crawl_batches SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE link_crawl_batches SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE link_daily_stats SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE link_daily_stats SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE link_like_log SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE link_like_log SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE link_read_log SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE link_read_log SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE link_view_log SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE link_view_log SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE links SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE links SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE notification_arguments SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE notification_arguments SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE notification_recipients SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE notification_recipients SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE notifications SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE notifications SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE post_daily_stats SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE post_daily_stats SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE post_like_log SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE post_like_log SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE post_read_log SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE post_read_log SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE post_view_log SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE post_view_log SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE posts SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE posts SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE tags SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE tags SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE user_bans SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE user_bans SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE user_follows SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE user_follows SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE user_links SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE user_links SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE user_tokens SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE user_tokens SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE users SET created_at_utc = created_at AT TIME ZONE 'UTC' WHERE created_at IS NOT NULL AND created_at_utc IS NULL;
+UPDATE users SET updated_at_utc = updated_at AT TIME ZONE 'UTC' WHERE updated_at IS NOT NULL AND updated_at_utc IS NULL;
+UPDATE comments SET deleted_at_utc = deleted_at AT TIME ZONE 'UTC' WHERE deleted_at IS NOT NULL AND deleted_at_utc IS NULL;
+UPDATE link_crawl_batches SET last_triggered_at_utc = last_triggered_at AT TIME ZONE 'UTC' WHERE last_triggered_at IS NOT NULL AND last_triggered_at_utc IS NULL;
+UPDATE links SET published_at_utc = published_at AT TIME ZONE 'UTC' WHERE published_at IS NOT NULL AND published_at_utc IS NULL;
+UPDATE notification_recipients SET read_at_utc = read_at AT TIME ZONE 'UTC' WHERE read_at IS NOT NULL AND read_at_utc IS NULL;
+UPDATE posts SET stats_updated_at_utc = stats_updated_at AT TIME ZONE 'UTC' WHERE stats_updated_at IS NOT NULL AND stats_updated_at_utc IS NULL;

--- a/src/main/resources/db/migration/V36__create_utc_temporal_indexes.sql
+++ b/src/main/resources/db/migration/V36__create_utc_temporal_indexes.sql
@@ -1,0 +1,22 @@
+-- flyway:executeInTransaction=false
+-- New indexes for *_utc read paths. CONCURRENTLY avoids blocking writes during production rollout.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_posts_created_at_utc ON posts(created_at_utc DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_posts_cursor_utc ON posts(created_at_utc DESC, id DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_posts_updated_at_utc ON posts(updated_at_utc DESC, id DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_posts_stats_sync_utc ON posts(stats_updated_at_utc, updated_at_utc);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_comments_created_at_utc ON comments(created_at_utc);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_comment_like_log_comment_created_utc ON comment_like_log(comment_id, created_at_utc DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_comment_like_log_created_utc ON comment_like_log(created_at_utc DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_post_view_log_post_created_utc ON post_view_log(post_id, created_at_utc DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_post_view_log_created_utc ON post_view_log(created_at_utc DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_post_like_log_post_created_utc ON post_like_log(post_id, created_at_utc DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_post_like_log_created_utc ON post_like_log(created_at_utc DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notification_recipients_user_id_created_at_utc ON notification_recipients(user_id, created_at_utc DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notification_recipients_user_id_read_at_utc ON notification_recipients(user_id, read_at_utc);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_notifications_type_created_at_utc ON notifications(type, created_at_utc DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_links_published_at_utc ON links(published_at_utc DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_link_view_log_link_created_utc ON link_view_log(link_id, created_at_utc DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_link_view_log_created_utc ON link_view_log(created_at_utc DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_link_like_log_link_created_utc ON link_like_log(link_id, created_at_utc DESC);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_link_like_log_created_utc ON link_like_log(created_at_utc DESC);

--- a/src/test/kotlin/com/techtaurant/mainserver/base/FlywayMigrationValidationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/base/FlywayMigrationValidationTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
+import java.util.UUID
 
 @DisplayName("Flyway 마이그레이션 검증 테스트")
 class FlywayMigrationValidationTest : IntegrationTest() {
@@ -27,6 +28,182 @@ class FlywayMigrationValidationTest : IntegrationTest() {
 
         assertThat(failedMigrationCount).isZero()
         assertThat(appliedVersions).doesNotHaveDuplicates()
-        assertThat(appliedVersions).contains("32", "33")
+        assertThat(appliedVersions).contains("32", "33", "35", "36")
+    }
+
+    @Test
+    @DisplayName("절대 시각 호환 컬럼은 timestamp with time zone 타입으로 생성된다")
+    fun absoluteInstantCompatibilityColumnsUseTimestamptz() {
+        val expectedColumns =
+            entityBaseTables.flatMap { tableName ->
+                listOf(
+                    TemporalColumn(tableName, "created_at_utc"),
+                    TemporalColumn(tableName, "updated_at_utc"),
+                )
+            } + extraInstantColumns
+
+        val columnTypes =
+            jdbcTemplate.query(
+                """
+                SELECT table_name, column_name, data_type
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND column_name = ANY (?::text[])
+                """.trimIndent(),
+                { rs, _ ->
+                    TemporalColumn(rs.getString("table_name"), rs.getString("column_name")) to rs.getString("data_type")
+                },
+                expectedColumns.map { it.columnName }.distinct().toTypedArray(),
+            ).toMap()
+
+        assertThat(columnTypes.keys).containsExactlyInAnyOrderElementsOf(expectedColumns)
+        assertThat(columnTypes.values).allSatisfy { dataType ->
+            assertThat(dataType).isEqualTo("timestamp with time zone")
+        }
+    }
+
+    @Test
+    @DisplayName("절대 시각 sync trigger는 old TIMESTAMP와 new TIMESTAMPTZ 컬럼을 양방향 동기화한다")
+    fun temporalSyncTriggersKeepOldAndUtcColumnsAligned() {
+        val oldWriterTagId = UUID.randomUUID()
+        val newWriterTagId = UUID.randomUUID()
+        val linkId = UUID.randomUUID()
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO tags (id, name, created_at, updated_at)
+            VALUES (?, ?, ?::timestamp, ?::timestamp)
+            """.trimIndent(),
+            oldWriterTagId,
+            "old-writer-$oldWriterTagId",
+            "2026-03-01 12:30:45",
+            "2026-03-01 13:30:45",
+        )
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO tags (id, name, created_at_utc, updated_at_utc)
+            VALUES (?, ?, ?::timestamptz, ?::timestamptz)
+            """.trimIndent(),
+            newWriterTagId,
+            "new-writer-$newWriterTagId",
+            "2026-03-02 02:03:04Z",
+            "2026-03-02 03:03:04Z",
+        )
+
+        jdbcTemplate.update(
+            """
+            INSERT INTO links (id, title, url, summary, published_at_utc)
+            VALUES (?, ?, ?, ?, ?::timestamptz)
+            """.trimIndent(),
+            linkId,
+            "UTC migration test link",
+            "https://example.com/utc-migration-$linkId",
+            "UTC migration summary",
+            "2026-04-05 06:07:08Z",
+        )
+
+        jdbcTemplate.update(
+            """
+            UPDATE links
+            SET published_at = ?::timestamp
+            WHERE id = ?
+            """.trimIndent(),
+            "2026-04-06 07:08:09",
+            linkId,
+        )
+
+        assertTemporalColumnsInSync("tags", oldWriterTagId, "created_at", "created_at_utc")
+        assertTemporalColumnsInSync("tags", oldWriterTagId, "updated_at", "updated_at_utc")
+        assertTemporalColumnsInSync("tags", newWriterTagId, "created_at", "created_at_utc")
+        assertTemporalColumnsInSync("tags", newWriterTagId, "updated_at", "updated_at_utc")
+        assertTemporalColumnsInSync("links", linkId, "published_at", "published_at_utc")
+    }
+
+    @Test
+    @DisplayName("UTC 조회 경로 인덱스가 생성된다")
+    fun utcTemporalReadPathIndexesExist() {
+        val indexNames =
+            jdbcTemplate.queryForList(
+                "SELECT indexname FROM pg_indexes WHERE schemaname = 'public'",
+                String::class.java,
+            )
+
+        assertThat(indexNames).contains(
+            "idx_posts_cursor_utc",
+            "idx_posts_updated_at_utc",
+            "idx_comments_created_at_utc",
+            "idx_post_view_log_post_created_utc",
+            "idx_post_like_log_post_created_utc",
+            "idx_notification_recipients_user_id_created_at_utc",
+            "idx_links_published_at_utc",
+            "idx_link_view_log_link_created_utc",
+            "idx_link_like_log_link_created_utc",
+        )
+    }
+
+    private fun assertTemporalColumnsInSync(
+        tableName: String,
+        id: UUID,
+        oldColumnName: String,
+        utcColumnName: String,
+    ) {
+        val inSync =
+            jdbcTemplate.queryForObject(
+                """
+                SELECT ($oldColumnName IS NULL AND $utcColumnName IS NULL)
+                    OR ($oldColumnName = $utcColumnName AT TIME ZONE 'UTC')
+                FROM $tableName
+                WHERE id = ?
+                """.trimIndent(),
+                Boolean::class.java,
+                id,
+            ) ?: false
+
+        assertThat(inSync).isTrue()
+    }
+
+    private data class TemporalColumn(
+        val tableName: String,
+        val columnName: String,
+    )
+
+    companion object {
+        private val entityBaseTables =
+            listOf(
+                "attachments",
+                "categories",
+                "comment_like_log",
+                "comments",
+                "link_crawl_batches",
+                "link_daily_stats",
+                "link_like_log",
+                "link_read_log",
+                "link_view_log",
+                "links",
+                "notification_arguments",
+                "notification_recipients",
+                "notifications",
+                "post_daily_stats",
+                "post_like_log",
+                "post_read_log",
+                "post_view_log",
+                "posts",
+                "tags",
+                "user_bans",
+                "user_follows",
+                "user_links",
+                "user_tokens",
+                "users",
+            )
+
+        private val extraInstantColumns =
+            listOf(
+                TemporalColumn("comments", "deleted_at_utc"),
+                TemporalColumn("link_crawl_batches", "last_triggered_at_utc"),
+                TemporalColumn("links", "published_at_utc"),
+                TemporalColumn("notification_recipients", "read_at_utc"),
+                TemporalColumn("posts", "stats_updated_at_utc"),
+            )
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/comment/application/CommentMetadataReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/comment/application/CommentMetadataReadServiceTest.kt
@@ -11,7 +11,7 @@ import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 class CommentMetadataReadServiceTest {
@@ -25,7 +25,7 @@ class CommentMetadataReadServiceTest {
         val author = createUser("작성자")
         val post = createPost(author)
         val activeComment = createComment(post = post, author = author, likeCount = 7, replyCount = 2)
-        val deletedComment = createComment(post = post, author = author, likeCount = 3, replyCount = 1).apply { deletedAt = Date() }
+        val deletedComment = createComment(post = post, author = author, likeCount = 3, replyCount = 1).apply { deletedAt = Instant.now() }
 
         every {
             commentRepository.findCommentsByIdsIncludingDeleted(listOf(deletedComment.id!!, activeComment.id!!))

--- a/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadControllerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentReadControllerTest.kt
@@ -27,8 +27,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
+import java.time.Instant
 import java.util.Calendar
-import java.util.Date
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -389,7 +389,7 @@ class CommentReadControllerTest : IntegrationTest() {
         val deletedComment =
             parentComments[0].apply {
                 content = sha256(content)
-                deletedAt = Date()
+                deletedAt = Instant.now()
             }
         commentRepository.save(deletedComment)
 
@@ -477,7 +477,7 @@ class CommentReadControllerTest : IntegrationTest() {
         val deletedComment =
             parentComments[0].apply {
                 content = sha256(content)
-                deletedAt = Date()
+                deletedAt = Instant.now()
             }
         commentRepository.save(deletedComment)
         val activeComment = parentComments[2]
@@ -615,7 +615,7 @@ class CommentReadControllerTest : IntegrationTest() {
             val deletedComment =
                 parentComments[0].apply {
                     content = sha256(content)
-                    deletedAt = Date()
+                    deletedAt = Instant.now()
                 }
             commentRepository.save(deletedComment)
 
@@ -649,7 +649,7 @@ class CommentReadControllerTest : IntegrationTest() {
             val deletedReply =
                 replies[0].apply {
                     content = sha256(content)
-                    deletedAt = Date()
+                    deletedAt = Instant.now()
                 }
             commentRepository.save(deletedReply)
 
@@ -688,7 +688,7 @@ class CommentReadControllerTest : IntegrationTest() {
         val comment1CreatedAt =
             Calendar.getInstance().apply {
                 add(Calendar.DAY_OF_YEAR, -10)
-            }.time
+            }.toInstant()
         val comment1 =
             Comment(
                 content = "Comment 1 - 10 days ago",
@@ -705,7 +705,7 @@ class CommentReadControllerTest : IntegrationTest() {
         val comment2CreatedAt =
             Calendar.getInstance().apply {
                 add(Calendar.DAY_OF_YEAR, -5)
-            }.time
+            }.toInstant()
         val comment2 =
             Comment(
                 content = "Comment 2 - 5 days ago",
@@ -722,7 +722,7 @@ class CommentReadControllerTest : IntegrationTest() {
         val comment3CreatedAt =
             Calendar.getInstance().apply {
                 add(Calendar.DAY_OF_YEAR, -1)
-            }.time
+            }.toInstant()
         val comment3 =
             Comment(
                 content = "Comment 3 - 1 day ago",
@@ -751,7 +751,7 @@ class CommentReadControllerTest : IntegrationTest() {
         val reply1CreatedAt =
             Calendar.getInstance().apply {
                 add(Calendar.DAY_OF_YEAR, -9)
-            }.time
+            }.toInstant()
         val reply1 =
             Comment(
                 content = "Reply 1 - 9 days ago",
@@ -769,7 +769,7 @@ class CommentReadControllerTest : IntegrationTest() {
         val reply2CreatedAt =
             Calendar.getInstance().apply {
                 add(Calendar.DAY_OF_YEAR, -4)
-            }.time
+            }.toInstant()
         val reply2 =
             Comment(
                 content = "Reply 2 - 4 days ago",
@@ -787,7 +787,7 @@ class CommentReadControllerTest : IntegrationTest() {
         val reply3CreatedAt =
             Calendar.getInstance().apply {
                 add(Calendar.HOUR_OF_DAY, -12)
-            }.time
+            }.toInstant()
         val reply3 =
             Comment(
                 content = "Reply 3 - 12 hours ago",

--- a/src/test/kotlin/com/techtaurant/mainserver/common/dto/TemporalCursorEncodingTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/common/dto/TemporalCursorEncodingTest.kt
@@ -1,0 +1,75 @@
+package com.techtaurant.mainserver.common.dto
+
+import com.techtaurant.mainserver.comment.dto.CommentCursor
+import com.techtaurant.mainserver.comment.enums.CommentSortType
+import com.techtaurant.mainserver.link.dto.LinkCursor
+import com.techtaurant.mainserver.notification.dto.NotificationCursor
+import com.techtaurant.mainserver.post.dto.PostCursor
+import com.techtaurant.mainserver.post.entity.PostSortType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.Base64
+import java.util.UUID
+
+@DisplayName("UTC Instant cursor 인코딩 테스트")
+class TemporalCursorEncodingTest {
+    @Test
+    @DisplayName("게시물 커서는 ISO-8601 UTC Instant를 보존하고 legacy epoch millis 커서도 읽는다")
+    fun postCursor_preservesUtcInstantAndSupportsLegacyEpochMillis() {
+        val id = UUID.randomUUID()
+        val createdAt = Instant.parse("2026-03-01T23:59:59.123456Z")
+        val cursor = PostCursor(sortValue = 42, createdAt = createdAt, id = id, sortType = PostSortType.COMMENT)
+
+        val decoded = PostCursor.decode(cursor.encode())
+        val legacyDecoded = PostCursor.decode(base64Url("${PostSortType.COMMENT.name}:42:${createdAt.toEpochMilli()}:$id"))
+
+        assertThat(decoded).isEqualTo(cursor)
+        assertThat(legacyDecoded).isEqualTo(cursor.copy(createdAt = Instant.ofEpochMilli(createdAt.toEpochMilli())))
+    }
+
+    @Test
+    @DisplayName("댓글 커서는 ISO-8601 UTC Instant를 보존하고 legacy epoch millis 커서도 읽는다")
+    fun commentCursor_preservesUtcInstantAndSupportsLegacyEpochMillis() {
+        val id = UUID.randomUUID()
+        val createdAt = Instant.parse("2026-04-02T01:02:03.456Z")
+        val cursor = CommentCursor(sortValue = 7, createdAt = createdAt, id = id, sortType = CommentSortType.LIKE)
+
+        val decoded = CommentCursor.decode(cursor.encode())
+        val legacyDecoded = CommentCursor.decode(base64Url("${CommentSortType.LIKE.name}:7:${createdAt.toEpochMilli()}:$id"))
+
+        assertThat(decoded).isEqualTo(cursor)
+        assertThat(legacyDecoded).isEqualTo(cursor.copy(createdAt = Instant.ofEpochMilli(createdAt.toEpochMilli())))
+    }
+
+    @Test
+    @DisplayName("알림 커서는 ISO-8601 UTC Instant를 보존하고 legacy epoch millis 커서도 읽는다")
+    fun notificationCursor_preservesUtcInstantAndSupportsLegacyEpochMillis() {
+        val id = UUID.randomUUID()
+        val createdAt = Instant.parse("2026-05-03T04:05:06.789Z")
+        val cursor = NotificationCursor(createdAt = createdAt, id = id)
+
+        val decoded = NotificationCursor.decode(cursor.encode())
+        val legacyDecoded = NotificationCursor.decode(base64Url("${createdAt.toEpochMilli()}:$id"))
+
+        assertThat(decoded).isEqualTo(cursor)
+        assertThat(legacyDecoded).isEqualTo(cursor.copy(createdAt = Instant.ofEpochMilli(createdAt.toEpochMilli())))
+    }
+
+    @Test
+    @DisplayName("링크 커서는 ISO-8601 UTC Instant를 보존하고 legacy epoch millis 커서도 읽는다")
+    fun linkCursor_preservesUtcInstantAndSupportsLegacyEpochMillis() {
+        val id = UUID.randomUUID()
+        val createdAt = Instant.parse("2026-06-04T07:08:09.123Z")
+        val cursor = LinkCursor(createdAt = createdAt, id = id)
+
+        val decoded = LinkCursor.decode(cursor.encode())
+        val legacyDecoded = LinkCursor.decode("${createdAt.toEpochMilli()}_$id")
+
+        assertThat(decoded).isEqualTo(cursor)
+        assertThat(legacyDecoded).isEqualTo(cursor.copy(createdAt = Instant.ofEpochMilli(createdAt.toEpochMilli())))
+    }
+
+    private fun base64Url(raw: String): String = Base64.getUrlEncoder().withoutPadding().encodeToString(raw.toByteArray())
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/common/util/DateUtilsTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/common/util/DateUtilsTest.kt
@@ -1,0 +1,30 @@
+package com.techtaurant.mainserver.common.util
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+
+@DisplayName("DateUtils UTC 날짜 테스트")
+class DateUtilsTest {
+    @Test
+    @DisplayName("Instant를 서버 로컬 시간이 아니라 UTC 날짜로 변환한다")
+    fun toUtcDate_usesUtcDateBoundary() {
+        val instantNearUtcEndOfDay = Instant.parse("2026-03-01T23:30:00Z")
+
+        val result = DateUtils.toUtcDate(instantNearUtcEndOfDay)
+
+        assertThat(result).isEqualTo(LocalDate.parse("2026-03-01"))
+    }
+
+    @Test
+    @DisplayName("UTC 자정 이후 Instant는 다음 UTC 날짜로 변환한다")
+    fun toUtcDate_afterUtcMidnight_returnsNextUtcDate() {
+        val instantAtUtcMidnight = Instant.parse("2026-03-02T00:00:00Z")
+
+        val result = DateUtils.toUtcDate(instantAtUtcMidnight)
+
+        assertThat(result).isEqualTo(LocalDate.parse("2026-03-02"))
+    }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkDailyStatsServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkDailyStatsServiceTest.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
-import java.sql.Date
+import java.time.LocalDate
 import java.util.UUID
 
 @DisplayName("LinkDailyStatsService 통합 테스트")
@@ -66,7 +66,7 @@ class LinkDailyStatsServiceTest : IntegrationTest() {
     @Test
     @DisplayName("일별 통계 레코드가 없으면 생성 후 조회수와 저장수를 증가시킨다")
     fun incrementStats_whenDailyStatsNotExists_shouldCreateAndUpdate() {
-        val statDate = Date.valueOf("2026-05-18")
+        val statDate = LocalDate.parse("2026-05-18")
 
         linkDailyStatsService.incrementViewCount(testLink.id!!, statDate)
         linkDailyStatsService.incrementSaveCount(testLink.id!!, statDate)
@@ -84,7 +84,7 @@ class LinkDailyStatsServiceTest : IntegrationTest() {
     @Test
     @DisplayName("좋아요 감소는 레코드가 없으면 생성 후 음수 값을 기록할 수 있다")
     fun decrementLikeCount_whenDailyStatsNotExists_shouldCreateAndAllowNegativeCount() {
-        val statDate = Date.valueOf("2026-05-18")
+        val statDate = LocalDate.parse("2026-05-18")
 
         linkDailyStatsService.decrementLikeCount(testLink.id!!, statDate)
         entityManager.flush()
@@ -98,7 +98,7 @@ class LinkDailyStatsServiceTest : IntegrationTest() {
     @Test
     @DisplayName("저장수 감소는 레코드가 없으면 생성하지 않고 기존 레코드가 있으면 감소한다")
     fun decrementSaveCount_whenDailyStatsNotExists_shouldNotCreateDailyStats() {
-        val statDate = Date.valueOf("2026-05-18")
+        val statDate = LocalDate.parse("2026-05-18")
 
         linkDailyStatsService.decrementSaveCount(testLink.id!!, statDate)
         entityManager.flush()

--- a/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkInteractionConcurrencyTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkInteractionConcurrencyTest.kt
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
 import java.util.UUID
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
@@ -193,7 +194,7 @@ class LinkInteractionConcurrencyTest : IntegrationTest() {
         assertThat(dailyStats?.saveCount).isEqualTo(0)
     }
 
-    private fun findDailyStats(statDate: java.sql.Date = DateUtils.today()): LinkDailyStats? {
+    private fun findDailyStats(statDate: LocalDate = DateUtils.today()): LinkDailyStats? {
         return linkDailyStatsRepository.findAll()
             .find { it.link.id == testLink.id && it.statDate.toString() == statDate.toString() }
     }

--- a/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkLikeLogServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkLikeLogServiceTest.kt
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.UUID
 
 @DisplayName("LinkLikeLogService 통합 테스트")
@@ -143,7 +145,7 @@ class LinkLikeLogServiceTest : IntegrationTest() {
     @DisplayName("과거 좋아요를 오늘 취소하면 오늘 일별 좋아요수만 감소한다")
     fun recordLike_fromPastLikeToNone_shouldRecordDailyStatsOnEventDate() {
         val today = DateUtils.today()
-        val oldStatDate = java.sql.Date.valueOf(today.toLocalDate().minusDays(1))
+        val oldStatDate = today.minusDays(1)
         testLink.likeCount = 1
         linkRepository.saveAndFlush(testLink)
         linkDailyStatsRepository.saveAndFlush(LinkDailyStats(link = testLink, statDate = oldStatDate, likeCount = 1))
@@ -155,7 +157,7 @@ class LinkLikeLogServiceTest : IntegrationTest() {
                     isLiked = true,
                 ),
             )
-        existingLog.createdAt = java.util.Date(oldStatDate.time)
+        existingLog.createdAt = oldStatDate.atStartOfDay(ZoneOffset.UTC).toInstant()
         linkLikeLogRepository.saveAndFlush(existingLog)
         entityManager.clear()
 
@@ -192,7 +194,7 @@ class LinkLikeLogServiceTest : IntegrationTest() {
             .isEqualTo(UserStatus.ID_NOT_FOUND)
     }
 
-    private fun findDailyStats(statDate: java.sql.Date = DateUtils.today()): LinkDailyStats? {
+    private fun findDailyStats(statDate: LocalDate = DateUtils.today()): LinkDailyStats? {
         return linkDailyStatsRepository.findAll()
             .find { it.link.id == testLink.id && it.statDate.toString() == statDate.toString() }
     }

--- a/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkSaveServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkSaveServiceTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
+import java.time.ZoneOffset
 import java.util.UUID
 
 @DisplayName("LinkSaveService 통합 테스트")
@@ -112,7 +113,7 @@ class LinkSaveServiceTest : IntegrationTest() {
     @Test
     @DisplayName("일별 통계가 없는 기존 저장을 취소해도 음수 저장수 레코드를 만들지 않는다")
     fun unsave_whenLegacyRelationWithoutDailyStats_shouldNotCreateNegativeDailyStats() {
-        val oldStatDate = java.sql.Date.valueOf(DateUtils.today().toLocalDate().minusDays(1))
+        val oldStatDate = DateUtils.today().minusDays(1)
         val existingRelation =
             userLinkRepository.saveAndFlush(
                 UserLink(
@@ -120,7 +121,7 @@ class LinkSaveServiceTest : IntegrationTest() {
                     link = testLink,
                 ),
             )
-        existingRelation.createdAt = java.util.Date(oldStatDate.time)
+        existingRelation.createdAt = oldStatDate.atStartOfDay(ZoneOffset.UTC).toInstant()
         userLinkRepository.saveAndFlush(existingRelation)
         entityManager.clear()
 

--- a/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkReadOpenApiControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkReadOpenApiControllerIntegrationTest.kt
@@ -27,7 +27,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.support.TransactionTemplate
 import java.time.Instant
-import java.util.Date
 import java.util.UUID
 
 @DisplayName("LinkReadOpenApiController 통합 테스트")
@@ -381,8 +380,8 @@ class LinkReadOpenApiControllerIntegrationTest : IntegrationTest() {
                     ),
                 )
             userLinkRepository.save(UserLink(user = managedSourceCompanyUser, link = link))
-            link.createdAt = Date(createdAtMillis)
-            link.updatedAt = Date(createdAtMillis)
+            link.createdAt = Instant.ofEpochMilli(createdAtMillis)
+            link.updatedAt = Instant.ofEpochMilli(createdAtMillis)
             linkRepository.saveAndFlush(link)
         } ?: throw IllegalStateException("링크 저장에 실패했습니다")
     }

--- a/src/test/kotlin/com/techtaurant/mainserver/notification/infrastructure/in/NotificationControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/notification/infrastructure/in/NotificationControllerIntegrationTest.kt
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.Instant
-import java.util.Date
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -379,19 +378,19 @@ class NotificationControllerIntegrationTest : IntegrationTest() {
             NotificationRecipient(
                 notification = notification,
                 recipientUser = recipient,
-                readAt = readAt?.let(Date::from),
+                readAt = readAt,
             ),
         )
 
         val savedNotification = notificationRepository.save(notification)
         val savedRecipient = savedNotification.recipients.single()
-        val createdAtDate = Date.from(createdAt)
+        val createdAtDate = createdAt
 
         savedNotification.createdAt = createdAtDate
         savedNotification.updatedAt = createdAtDate
         savedRecipient.createdAt = createdAtDate
         savedRecipient.updatedAt = createdAtDate
-        savedRecipient.readAt = readAt?.let(Date::from)
+        savedRecipient.readAt = readAt
 
         notificationRepository.save(savedNotification)
         notificationRecipientRepository.save(savedRecipient)

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostDailyStatsServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostDailyStatsServiceTest.kt
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
-import java.sql.Date
+import java.time.LocalDate
 
 @DisplayName("PostDailyStatsService 통합 테스트")
 @Transactional
@@ -253,7 +253,7 @@ class PostDailyStatsServiceTest : IntegrationTest() {
         // given
         val user = createAndSaveUser("comment-decrement-date@example.com")
         val post = createAndSavePost("댓글 날짜별 감소 테스트 게시글", user)
-        val statDate = Date.valueOf("2026-03-01")
+        val statDate = LocalDate.parse("2026-03-01")
         createDailyStats(post, statDate, commentCount = 2)
 
         // when
@@ -297,7 +297,7 @@ class PostDailyStatsServiceTest : IntegrationTest() {
 
     private fun createDailyStats(
         post: Post,
-        statDate: Date,
+        statDate: LocalDate,
         viewCount: Long = 0,
         likeCount: Long = 0,
         commentCount: Long = 0,
@@ -314,7 +314,7 @@ class PostDailyStatsServiceTest : IntegrationTest() {
     }
 
     private fun isSameUtcDate(
-        actual: Date,
-        expected: Date,
-    ): Boolean = actual.toString() == expected.toString()
+        actual: LocalDate,
+        expected: LocalDate,
+    ): Boolean = actual == expected
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostLikeLogServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostLikeLogServiceTest.kt
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.transaction.annotation.Transactional
-import java.sql.Date
 import java.sql.Timestamp
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -321,7 +321,7 @@ class PostLikeLogServiceTest : IntegrationTest() {
         entityManager.clear()
 
         // Then - 취소 통계가 기존 로그 생성일 버킷에 반영됨
-        val targetStatDate = DateUtils.toUtcDate(Date(targetCreatedAt.time))
+        val targetStatDate = DateUtils.toUtcDate(targetCreatedAt.toInstant())
         val targetDailyStats = findDailyStats(targetStatDate)
         assertThat(targetDailyStats).isNotNull
         assertThat(targetDailyStats?.likeCount).isEqualTo(-1)
@@ -338,7 +338,7 @@ class PostLikeLogServiceTest : IntegrationTest() {
         entityManager.flush()
     }
 
-    private fun findDailyStats(statDate: Date) =
+    private fun findDailyStats(statDate: LocalDate) =
         postDailyStatsRepository.findAll()
             .find { it.post.id == testPost.id && it.statDate.toString() == statDate.toString() }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -4,12 +4,14 @@ import com.techtaurant.mainserver.attachment.application.AttachmentService
 import com.techtaurant.mainserver.attachment.entity.Attachment
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
 import com.techtaurant.mainserver.attachment.enums.AttachmentStatus
+import com.techtaurant.mainserver.post.dto.PostCursor
 import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostReadLog
 import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostLikeLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
@@ -32,6 +34,7 @@ import java.util.UUID
 
 class PostListReadServiceTest {
     private val postRepository: PostRepository = mockk()
+    private val postDailyStatsRepository: PostDailyStatsRepository = mockk()
     private val postReadLogRepository: PostReadLogRepository = mockk()
     private val postLikeLogRepository: PostLikeLogRepository = mockk()
     private val attachmentService: AttachmentService = mockk()
@@ -60,6 +63,7 @@ class PostListReadServiceTest {
     private fun createPostListReadService(postListQueryStrategies: List<PostListQueryStrategy> = createPostListQueryStrategies()) =
         PostListReadService(
             postRepository = postRepository,
+            postDailyStatsRepository = postDailyStatsRepository,
             attachmentService = attachmentService,
             postMetadataReadService = postMetadataReadService,
             postViewerStateReadService = postViewerStateReadService,
@@ -706,6 +710,48 @@ class PostListReadServiceTest {
             assertThat(result.hasNext).isTrue()
             assertThat(result.nextCursor).isNotNull()
             assertThat(result.content).hasSize(2)
+        }
+
+        @Test
+        @DisplayName("기간 랭킹 nextCursor는 전체 누적값이 아니라 기간 내 일별 집계 합계를 담는다")
+        fun getPosts_periodRankingNextCursor_usesDailyStatsSortValue() {
+            // given
+            val posts = (1..3).map { createPost(testUser) }
+            val lastContentPost = posts[1].apply { commentCount = 100 }
+            every {
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 3,
+                    period = PostPeriod.MONTH,
+                    sortType = PostSortType.COMMENT,
+                    authorId = testUser.id!!,
+                    statuses = listOf(PostStatusEnum.PUBLISHED, PostStatusEnum.PRIVATE),
+                    categoryId = null,
+                    tagIds = null,
+                    viewerId = testUser.id!!,
+                )
+            } returns posts
+            every {
+                postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
+            } returns emptyList()
+            every {
+                postDailyStatsRepository.sumCommentCountSince(lastContentPost.id!!, any())
+            } returns 5
+
+            // when
+            val result =
+                postListReadService.getPosts(
+                    cursor = null,
+                    size = 2,
+                    period = PostPeriod.MONTH,
+                    sortType = PostSortType.COMMENT,
+                    currentUserId = testUser.id!!,
+                    authorId = testUser.id!!,
+                )
+
+            // then
+            val decodedCursor = PostCursor.decode(result.nextCursor!!)
+            assertThat(decodedCursor?.sortValue).isEqualTo(5)
         }
 
         @Test

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -11,7 +11,6 @@ import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostReadLog
 import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
-import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostLikeLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostReadLogRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
@@ -34,7 +33,6 @@ import java.util.UUID
 
 class PostListReadServiceTest {
     private val postRepository: PostRepository = mockk()
-    private val postDailyStatsRepository: PostDailyStatsRepository = mockk()
     private val postReadLogRepository: PostReadLogRepository = mockk()
     private val postLikeLogRepository: PostLikeLogRepository = mockk()
     private val attachmentService: AttachmentService = mockk()
@@ -63,7 +61,6 @@ class PostListReadServiceTest {
     private fun createPostListReadService(postListQueryStrategies: List<PostListQueryStrategy> = createPostListQueryStrategies()) =
         PostListReadService(
             postRepository = postRepository,
-            postDailyStatsRepository = postDailyStatsRepository,
             attachmentService = attachmentService,
             postMetadataReadService = postMetadataReadService,
             postViewerStateReadService = postViewerStateReadService,
@@ -118,6 +115,9 @@ class PostListReadServiceTest {
             category = category,
             status = status,
         ).apply { id = UUID.randomUUID() }
+
+    private fun List<Post>.withSortValues(sortValueResolver: (Post) -> Long = { it.updatedAt.time }): List<PostWithSortValue> =
+        map { post -> PostWithSortValue(post = post, sortValue = sortValueResolver(post)) }
 
     private fun createAttachment(
         postId: UUID,
@@ -232,7 +232,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns emptyList()
@@ -269,7 +269,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = null,
                 )
-            } returns posts
+            } returns posts.withSortValues()
 
             // when
             postListReadService.getPosts(cursor = null, size = 20, currentUserId = null)
@@ -305,7 +305,7 @@ class PostListReadServiceTest {
                     tagIds = listOf(firstTagId, secondTagId),
                     viewerId = null,
                 )
-            } returns posts
+            } returns posts.withSortValues()
 
             // when
             postListReadService.getPosts(
@@ -356,7 +356,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = null,
                 )
-            } returns listOf(post)
+            } returns listOf(post).withSortValues()
             every {
                 attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(post.id!!), AttachmentReferenceType.POST)
             } returns mapOf(post.id!! to listOf(laterAttachment, firstAttachment))
@@ -398,7 +398,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = null,
                 )
-            } returns listOf(post)
+            } returns listOf(post).withSortValues()
             every {
                 attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(post.id!!), AttachmentReferenceType.POST)
             } returns mapOf(post.id!! to listOf(otherAttachment, thumbnailAttachment))
@@ -437,7 +437,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = null,
                 )
-            } returns listOf(post)
+            } returns listOf(post).withSortValues()
 
             // when
             val result = postListReadService.getPostContents(cursor = null, size = 20)
@@ -490,7 +490,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns emptyList()
@@ -536,7 +536,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns emptyList()
@@ -582,7 +582,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns emptyList()
@@ -628,7 +628,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = null,
                 )
-            } returns posts
+            } returns posts.withSortValues()
 
             // when
             val result =
@@ -692,7 +692,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns emptyList()
@@ -730,13 +730,10 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues { post -> if (post.id == lastContentPost.id) 5 else 10 }
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns emptyList()
-            every {
-                postDailyStatsRepository.sumCommentCountSince(lastContentPost.id!!, any())
-            } returns 5
 
             // when
             val result =
@@ -771,7 +768,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns emptyList()
@@ -812,7 +809,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = testUser.id!!,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 postReadLogRepository.findByUserIdAndPostIdIn(testUser.id!!, any())
             } returns listOf(readLog)
@@ -850,7 +847,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = null,
                 )
-            } returns posts
+            } returns posts.withSortValues()
 
             // when
             val result =
@@ -890,7 +887,7 @@ class PostListReadServiceTest {
                     tagIds = null,
                     viewerId = null,
                 )
-            } returns posts
+            } returns posts.withSortValues()
             every {
                 attachmentService.getConfirmedAttachmentsByReferenceIds(listOf(otherUser.id!!), AttachmentReferenceType.USER)
             } returns mapOf(otherUser.id!! to listOf(profileAttachment))

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 class PostListReadServiceTest {
@@ -116,13 +116,13 @@ class PostListReadServiceTest {
             status = status,
         ).apply { id = UUID.randomUUID() }
 
-    private fun List<Post>.withSortValues(sortValueResolver: (Post) -> Long = { it.updatedAt.time }): List<PostWithSortValue> =
+    private fun List<Post>.withSortValues(sortValueResolver: (Post) -> Long = { it.updatedAt.toEpochMilli() }): List<PostWithSortValue> =
         map { post -> PostWithSortValue(post = post, sortValue = sortValueResolver(post)) }
 
     private fun createAttachment(
         postId: UUID,
         objectKey: String,
-        createdAt: Date,
+        createdAt: Instant,
     ): Attachment =
         Attachment(
             referenceId = postId,
@@ -338,13 +338,13 @@ class PostListReadServiceTest {
                 createAttachment(
                     postId = post.id!!,
                     objectKey = "posts/${post.id}/uuid-1/first.jpg",
-                    createdAt = Date(1_000L),
+                    createdAt = Instant.ofEpochMilli(1_000L),
                 )
             val laterAttachment =
                 createAttachment(
                     postId = post.id!!,
                     objectKey = "posts/${post.id}/uuid-2/later.jpg",
-                    createdAt = Date(2_000L),
+                    createdAt = Instant.ofEpochMilli(2_000L),
                 )
             every {
                 postRepository.findPostsWithConditions(
@@ -385,9 +385,9 @@ class PostListReadServiceTest {
                 createAttachment(
                     post.id!!,
                     "posts/thumbnail-object-key.jpg",
-                    Date(1_000L),
+                    Instant.ofEpochMilli(1_000L),
                 ).apply { id = thumbnailAttachmentId }
-            val otherAttachment = createAttachment(post.id!!, "posts/other-object-key.jpg", Date(2_000L))
+            val otherAttachment = createAttachment(post.id!!, "posts/other-object-key.jpg", Instant.ofEpochMilli(2_000L))
             every {
                 postRepository.findPostsWithConditions(
                     cursor = null,

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostMetadataReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostMetadataReadServiceTest.kt
@@ -15,7 +15,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import java.util.Date
+import java.time.Instant
 import java.util.UUID
 
 class PostMetadataReadServiceTest {
@@ -51,8 +51,8 @@ class PostMetadataReadServiceTest {
         // given
         val firstPost = createPost(title = "첫 번째 게시물", viewCount = 10, likeCount = 2, commentCount = 1)
         val secondPost = createPost(title = "두 번째 게시물", viewCount = 20, likeCount = 5, commentCount = 3)
-        val thumbnailAttachment = createAttachment(firstPost.id!!, "posts/${firstPost.id}/thumbnail.jpg", Date(1_000L))
-        val bodyAttachment = createAttachment(firstPost.id!!, "posts/${firstPost.id}/body.jpg", Date(2_000L))
+        val thumbnailAttachment = createAttachment(firstPost.id!!, "posts/${firstPost.id}/thumbnail.jpg", Instant.ofEpochMilli(1_000L))
+        val bodyAttachment = createAttachment(firstPost.id!!, "posts/${firstPost.id}/body.jpg", Instant.ofEpochMilli(2_000L))
         firstPost.thumbnailImage = thumbnailAttachment.id
 
         every { postRepository.findPublishedPostsByIdIn(listOf(secondPost.id!!, firstPost.id!!)) } returns listOf(firstPost, secondPost)
@@ -100,7 +100,7 @@ class PostMetadataReadServiceTest {
     private fun createAttachment(
         postId: UUID,
         objectKey: String,
-        createdAt: Date,
+        createdAt: Instant,
     ): Attachment =
         Attachment(
             referenceId = postId,

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceTest.kt
@@ -24,7 +24,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
-import java.util.Date
 import java.util.UUID
 
 @Transactional
@@ -111,7 +110,7 @@ class PostWriteServiceTest : IntegrationTest() {
     @DisplayName("생성 요청에 createdAt이 있으면 게시물 생성일시로 저장된다")
     fun createPost_withCreatedAt_savesRequestedCreatedAt() {
         val requestedCreatedAt = Instant.parse("2026-04-25T10:15:30Z")
-        val expectedCreatedAt = Date.from(requestedCreatedAt)
+        val expectedCreatedAt = requestedCreatedAt
 
         val response =
             postWriteService.createPost(
@@ -129,13 +128,13 @@ class PostWriteServiceTest : IntegrationTest() {
         val savedPost = postRepository.findById(response.id).orElseThrow()
 
         assertThat(response.createdAt).isEqualTo(expectedCreatedAt)
-        assertThat(savedPost.createdAt.time).isEqualTo(expectedCreatedAt.time)
+        assertThat(savedPost.createdAt.toEpochMilli()).isEqualTo(expectedCreatedAt.toEpochMilli())
     }
 
     @Test
     @DisplayName("생성 요청에 createdAt이 없으면 현재 시점으로 게시물이 작성된다")
     fun createPost_withoutCreatedAt_savesCurrentCreatedAt() {
-        val beforeCreate = Date()
+        val beforeCreate = Instant.now()
 
         val response =
             postWriteService.createPost(
@@ -147,13 +146,13 @@ class PostWriteServiceTest : IntegrationTest() {
                 ),
             )
 
-        val afterCreate = Date()
+        val afterCreate = Instant.now()
         entityManager.flush()
         entityManager.clear()
         val savedPost = postRepository.findById(response.id).orElseThrow()
 
-        assertThat(response.createdAt.time).isBetween(beforeCreate.time, afterCreate.time)
-        assertThat(savedPost.createdAt.time).isBetween(beforeCreate.time, afterCreate.time)
+        assertThat(response.createdAt.toEpochMilli()).isBetween(beforeCreate.toEpochMilli(), afterCreate.toEpochMilli())
+        assertThat(savedPost.createdAt.toEpochMilli()).isBetween(beforeCreate.toEpochMilli(), afterCreate.toEpochMilli())
     }
 
     @Nested

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostControllerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostControllerTest.kt
@@ -5,7 +5,9 @@ import com.techtaurant.mainserver.common.dto.ApiResponse
 import com.techtaurant.mainserver.common.dto.CursorPageResponse
 import com.techtaurant.mainserver.post.dto.PostListItemResponse
 import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.entity.PostDailyStats
 import com.techtaurant.mainserver.post.entity.Tag
+import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.post.infrastructure.out.TagRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
@@ -19,16 +21,22 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.Calendar
 import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import java.sql.Date as SqlDate
 
 @DisplayName("게시물 목록 조회 API")
 class PostControllerTest : IntegrationTest() {
     @Autowired
     private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var postDailyStatsRepository: PostDailyStatsRepository
 
     @Autowired
     private lateinit var userRepository: UserRepository
@@ -41,6 +49,7 @@ class PostControllerTest : IntegrationTest() {
 
     @BeforeEach
     fun setup() {
+        postDailyStatsRepository.deleteAllInBatch()
         postRepository.deleteAllInBatch()
         userRepository.deleteAllInBatch()
 
@@ -482,7 +491,7 @@ class PostControllerTest : IntegrationTest() {
         @Test
         @DisplayName("기간 필터와 정렬을 함께 적용하면 올바르게 로딩되어야 한다")
         fun whenApplyBothPeriodAndSort_thenCorrectPostsLoaded() {
-            // When: 최근 7일의 게시물을 조회수 기준으로 정렬해서 조회
+            // When: 최근 7일 내 일별 집계가 있는 게시물을 조회수 기준으로 정렬해서 조회
             val response =
                 RestAssured
                     .given()
@@ -496,9 +505,9 @@ class PostControllerTest : IntegrationTest() {
                     .extract()
                     .`as`(object : TypeRef<ApiResponse<CursorPageResponse<PostListItemResponse>>>() {})
 
-            // Then: 필터된 데이터가 정렬되어 로드되어야 함
+            // Then: 게시물 작성일이 아니라 최근 일별 집계 데이터를 기준으로 필터링/정렬되어야 함
             val content = response.data!!.content
-            assertEquals(3, content.size, "최근 7일 내 게시물은 2개여야 함")
+            assertEquals(3, content.size, "최근 7일 내 일별 집계가 있는 게시물은 3개여야 함")
             assertTrue(
                 content[0].viewCount >= content[1].viewCount,
                 "조회수 기준 내림차순 정렬되어야 함",
@@ -590,6 +599,20 @@ class PostControllerTest : IntegrationTest() {
         savedPosts[1].tags.add(tag2)
         savedPosts[2].tags.add(tag3)
 
-        return postRepository.saveAll(savedPosts)
+        val savedPostsWithTags = postRepository.saveAll(savedPosts)
+        val today = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC))
+        postDailyStatsRepository.saveAll(
+            savedPostsWithTags.map { post ->
+                PostDailyStats(
+                    post = post,
+                    statDate = today,
+                    viewCount = post.viewCount,
+                    likeCount = post.likeCount,
+                    commentCount = post.commentCount,
+                )
+            },
+        )
+
+        return savedPostsWithTags
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostControllerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostControllerTest.kt
@@ -28,7 +28,6 @@ import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import java.sql.Date as SqlDate
 
 @DisplayName("게시물 목록 조회 API")
 class PostControllerTest : IntegrationTest() {
@@ -537,7 +536,7 @@ class PostControllerTest : IntegrationTest() {
                 set(Calendar.MINUTE, 0)
                 set(Calendar.SECOND, 0)
                 set(Calendar.MILLISECOND, 0)
-            }.time
+            }.toInstant()
         val post1 =
             Post(
                 title = "Post 1 - 50 days ago",
@@ -558,7 +557,7 @@ class PostControllerTest : IntegrationTest() {
                 set(Calendar.MINUTE, 0)
                 set(Calendar.SECOND, 0)
                 set(Calendar.MILLISECOND, 0)
-            }.time
+            }.toInstant()
         val post2 =
             Post(
                 title = "Post 2 - 5 days ago",
@@ -579,7 +578,7 @@ class PostControllerTest : IntegrationTest() {
                 set(Calendar.MINUTE, 0)
                 set(Calendar.SECOND, 0)
                 set(Calendar.MILLISECOND, 0)
-            }.time
+            }.toInstant()
         val post3 =
             Post(
                 title = "Post 3 - 1 day ago",
@@ -600,7 +599,7 @@ class PostControllerTest : IntegrationTest() {
         savedPosts[2].tags.add(tag3)
 
         val savedPostsWithTags = postRepository.saveAll(savedPosts)
-        val today = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC))
+        val today = LocalDate.now(ZoneOffset.UTC)
         postDailyStatsRepository.saveAll(
             savedPostsWithTags.map { post ->
                 PostDailyStats(

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
@@ -2,7 +2,9 @@ package com.techtaurant.mainserver.post.infrastructure.`in`
 
 import com.techtaurant.mainserver.base.IntegrationTest
 import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.entity.PostDailyStats
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
+import com.techtaurant.mainserver.post.infrastructure.out.PostDailyStatsRepository
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.security.enums.OAuthProvider
 import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
@@ -13,6 +15,7 @@ import com.techtaurant.mainserver.user.infrastructure.out.UserBanRepository
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import io.restassured.RestAssured.given
 import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.hasItem
 import org.hamcrest.Matchers.not
 import org.junit.jupiter.api.BeforeEach
@@ -20,7 +23,13 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import java.util.UUID
+import java.sql.Date as SqlDate
+import java.util.Date as UtilDate
 
 @DisplayName("PostReadOpenApiController 통합 테스트")
 class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
@@ -29,6 +38,9 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
 
     @Autowired
     private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var postDailyStatsRepository: PostDailyStatsRepository
 
     @Autowired
     private lateinit var jwtTokenProvider: JwtTokenProvider
@@ -43,6 +55,7 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
     @BeforeEach
     fun setUpTestData() {
         userBanRepository.deleteAllInBatch()
+        postDailyStatsRepository.deleteAllInBatch()
         postRepository.deleteAllInBatch()
         userRepository.deleteAllInBatch()
         testUser =
@@ -196,6 +209,124 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
     }
 
     @Test
+    @DisplayName("댓글순 30일 랭킹은 게시물 작성일이 아니라 기간 내 일별 댓글 집계 합계로 정렬하고 필터링한다")
+    fun getPosts_monthCommentRanking_usesRecentDailyStatsInsteadOfPostCreatedAt() {
+        // given
+        val oldPostWithMoreRecentComments =
+            createPublishedPost(
+                title = "오래됐지만 최근 댓글이 많은 게시물",
+                daysAgo = 500,
+                commentCount = 1,
+            )
+        createDailyStats(oldPostWithMoreRecentComments, daysAgo = 0, commentCount = 6)
+        createDailyStats(oldPostWithMoreRecentComments, daysAgo = 3, commentCount = 4)
+
+        val oldPostWithFewerRecentComments =
+            createPublishedPost(
+                title = "오래됐지만 최근 댓글이 있는 게시물",
+                daysAgo = 400,
+                commentCount = 999,
+            )
+        createDailyStats(oldPostWithFewerRecentComments, daysAgo = 2, commentCount = 5)
+
+        val recentPostWithoutStats =
+            createPublishedPost(
+                title = "최근 작성됐지만 집계가 없는 게시물",
+                daysAgo = 1,
+                commentCount = 2_000,
+            )
+        val oldPostWithStaleStats =
+            createPublishedPost(
+                title = "오래된 집계만 있는 게시물",
+                daysAgo = 300,
+                commentCount = 3_000,
+            )
+        createDailyStats(oldPostWithStaleStats, daysAgo = 31, commentCount = 100)
+
+        // when & then
+        given()
+            .queryParam("period", "MONTH")
+            .queryParam("sort", "COMMENT")
+            .queryParam("size", 10)
+            .`when`()
+            .get("/open-api/posts")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body(
+                "data.content.id",
+                contains(
+                    oldPostWithMoreRecentComments.id.toString(),
+                    oldPostWithFewerRecentComments.id.toString(),
+                ),
+            )
+            .body("data.content.id", not(hasItem(recentPostWithoutStats.id.toString())))
+            .body("data.content.id", not(hasItem(oldPostWithStaleStats.id.toString())))
+    }
+
+    @Test
+    @DisplayName("댓글순 30일 랭킹 커서는 전체 누적 댓글수가 아니라 기간 내 일별 댓글 집계 합계로 다음 페이지를 조회한다")
+    fun getPosts_monthCommentRankingCursor_usesRecentDailyStatsSortValue() {
+        // given
+        val firstPost =
+            createPublishedPost(
+                title = "첫 페이지 게시물",
+                daysAgo = 500,
+                commentCount = 1,
+            )
+        createDailyStats(firstPost, daysAgo = 0, commentCount = 10)
+
+        val secondPost =
+            createPublishedPost(
+                title = "두 번째 페이지 첫 게시물",
+                daysAgo = 400,
+                commentCount = 999,
+            )
+        createDailyStats(secondPost, daysAgo = 0, commentCount = 5)
+
+        val thirdPost =
+            createPublishedPost(
+                title = "두 번째 페이지 둘째 게시물",
+                daysAgo = 300,
+                commentCount = 998,
+            )
+        createDailyStats(thirdPost, daysAgo = 0, commentCount = 1)
+
+        // when
+        val firstPageResponse =
+            given()
+                .queryParam("period", "MONTH")
+                .queryParam("sort", "COMMENT")
+                .queryParam("size", 1)
+                .`when`()
+                .get("/open-api/posts")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+
+        val cursor = firstPageResponse.path<String>("data.nextCursor")
+
+        val secondPageResponse =
+            given()
+                .queryParam("period", "MONTH")
+                .queryParam("sort", "COMMENT")
+                .queryParam("size", 2)
+                .queryParam("cursor", cursor)
+                .`when`()
+                .get("/open-api/posts")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+
+        // then
+        assertThat(firstPageResponse.path<List<String>>("data.content.id")).containsExactly(firstPost.id.toString())
+        assertThat(cursor).isNotBlank()
+        assertThat(secondPageResponse.path<List<String>>("data.content.id")).containsExactly(
+            secondPost.id.toString(),
+            thirdPost.id.toString(),
+        )
+    }
+
+    @Test
     @DisplayName("로그인 사용자가 차단한 작성자의 게시물 상세 조회 시 404를 반환한다")
     fun getPostDetail_bannedAuthor_returnsNotFound() {
         // given
@@ -244,4 +375,49 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
         val updatedPost = postRepository.findById(post.id!!).orElseThrow()
         assertThat(updatedPost.viewCount).isEqualTo(1)
     }
+
+    private fun createPublishedPost(
+        title: String,
+        daysAgo: Long,
+        viewCount: Long = 0,
+        likeCount: Long = 0,
+        commentCount: Long = 0,
+    ): Post {
+        val createdAt = UtilDate.from(Instant.now().minus(daysAgo, ChronoUnit.DAYS))
+        val post =
+            postRepository.saveAndFlush(
+                Post(
+                    title = title,
+                    content = "본문",
+                    author = testUser,
+                    viewCount = viewCount,
+                    likeCount = likeCount,
+                    commentCount = commentCount,
+                    status = PostStatusEnum.PUBLISHED,
+                ),
+            )
+
+        post.createdAt = createdAt
+        post.updatedAt = createdAt
+        return postRepository.saveAndFlush(post)
+    }
+
+    private fun createDailyStats(
+        post: Post,
+        daysAgo: Long,
+        viewCount: Long = 0,
+        likeCount: Long = 0,
+        commentCount: Long = 0,
+    ): PostDailyStats =
+        postDailyStatsRepository.save(
+            PostDailyStats(
+                post = post,
+                statDate = statDateDaysAgo(daysAgo),
+                viewCount = viewCount,
+                likeCount = likeCount,
+                commentCount = commentCount,
+            ),
+        )
+
+    private fun statDateDaysAgo(daysAgo: Long): SqlDate = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC).minusDays(daysAgo))
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
@@ -264,6 +264,44 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
     }
 
     @Test
+    @DisplayName("조회순 전체 랭킹은 post 누적 조회수가 아니라 일별 집계 전체 합계로 정렬한다")
+    fun getPosts_allViewRanking_usesDailyStatsTotalSum() {
+        // given
+        val postWithMoreDailyStats =
+            createPublishedPost(
+                title = "누적 조회수는 낮지만 전체 집계 조회수가 높은 게시물",
+                daysAgo = 500,
+                viewCount = 1,
+            )
+        createDailyStats(postWithMoreDailyStats, daysAgo = 100, viewCount = 7)
+
+        val postWithFewerDailyStats =
+            createPublishedPost(
+                title = "누적 조회수는 높지만 전체 집계 조회수가 낮은 게시물",
+                daysAgo = 400,
+                viewCount = 100,
+            )
+        createDailyStats(postWithFewerDailyStats, daysAgo = 1, viewCount = 3)
+
+        // when & then
+        given()
+            .queryParam("period", "ALL")
+            .queryParam("sort", "VIEW")
+            .queryParam("size", 10)
+            .`when`()
+            .get("/open-api/posts")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body(
+                "data.content.id",
+                contains(
+                    postWithMoreDailyStats.id.toString(),
+                    postWithFewerDailyStats.id.toString(),
+                ),
+            )
+    }
+
+    @Test
     @DisplayName("댓글순 30일 랭킹 커서는 전체 누적 댓글수가 아니라 기간 내 일별 댓글 집계 합계로 다음 페이지를 조회한다")
     fun getPosts_monthCommentRankingCursor_usesRecentDailyStatsSortValue() {
         // given

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadOpenApiControllerIntegrationTest.kt
@@ -28,8 +28,6 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-import java.sql.Date as SqlDate
-import java.util.Date as UtilDate
 
 @DisplayName("PostReadOpenApiController 통합 테스트")
 class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
@@ -421,7 +419,7 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
         likeCount: Long = 0,
         commentCount: Long = 0,
     ): Post {
-        val createdAt = UtilDate.from(Instant.now().minus(daysAgo, ChronoUnit.DAYS))
+        val createdAt = Instant.now().minus(daysAgo, ChronoUnit.DAYS)
         val post =
             postRepository.saveAndFlush(
                 Post(
@@ -457,5 +455,5 @@ class PostReadOpenApiControllerIntegrationTest : IntegrationTest() {
             ),
         )
 
-    private fun statDateDaysAgo(daysAgo: Long): SqlDate = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC).minusDays(daysAgo))
+    private fun statDateDaysAgo(daysAgo: Long): LocalDate = LocalDate.now(ZoneOffset.UTC).minusDays(daysAgo)
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
@@ -368,6 +368,35 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
         }
 
         @Test
+        @DisplayName("조회순 전체 랭킹도 post 누적값이 아니라 일별 집계 전체 합계로 정렬한다")
+        fun findPostsWithConditions_viewAllStatsRanking_usesDailyStatsTotalSum() {
+            // given
+            val postWithMoreDailyStats = movePostCreatedAt(createPost(userA), daysAgo = 500)
+            postWithMoreDailyStats.viewCount = 1
+            createDailyStats(postWithMoreDailyStats, daysAgo = 100, viewCount = 7)
+
+            val postWithFewerDailyStats = movePostCreatedAt(createPost(userA), daysAgo = 400)
+            postWithFewerDailyStats.viewCount = 100
+            createDailyStats(postWithFewerDailyStats, daysAgo = 1, viewCount = 3)
+            postRepository.saveAllAndFlush(listOf(postWithMoreDailyStats, postWithFewerDailyStats))
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.ALL,
+                    sortType = PostSortType.VIEW,
+                )
+
+            // then
+            assertThat(result).extracting("id").containsExactly(
+                postWithMoreDailyStats.id,
+                postWithFewerDailyStats.id,
+            )
+        }
+
+        @Test
         @DisplayName("조회순 기간 랭킹은 기간 내 일별 조회 집계 합계로 정렬한다")
         fun findPostsWithConditions_viewPeriodRanking_usesRecentDailyStatsSum() {
             // given

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
@@ -1,8 +1,10 @@
 package com.techtaurant.mainserver.post.infrastructure.out
 
 import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.post.dto.PostCursor
 import com.techtaurant.mainserver.post.entity.Category
 import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.post.entity.PostDailyStats
 import com.techtaurant.mainserver.post.entity.PostPeriod
 import com.techtaurant.mainserver.post.entity.PostSortType
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
@@ -20,13 +22,22 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import java.util.UUID
+import java.sql.Date as SqlDate
+import java.util.Date as UtilDate
 
 @Transactional
 @ActiveProfiles("test")
 class PostRepositoryCustomImplTest : IntegrationTest() {
     @Autowired
     private lateinit var postRepository: PostRepository
+
+    @Autowired
+    private lateinit var postDailyStatsRepository: PostDailyStatsRepository
 
     @Autowired
     private lateinit var userRepository: UserRepository
@@ -43,6 +54,7 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
 
     @BeforeEach
     fun setUpTestData() {
+        postDailyStatsRepository.deleteAllInBatch()
         postRepository.deleteAll()
         userBanRepository.deleteAllInBatch()
 
@@ -93,6 +105,35 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
                 category = postCategory,
             ),
         )
+
+    private fun movePostCreatedAt(
+        post: Post,
+        daysAgo: Long,
+    ): Post {
+        val createdAt = UtilDate.from(Instant.now().minus(daysAgo, ChronoUnit.DAYS))
+        post.createdAt = createdAt
+        post.updatedAt = createdAt
+        return postRepository.saveAndFlush(post)
+    }
+
+    private fun createDailyStats(
+        post: Post,
+        daysAgo: Long,
+        viewCount: Long = 0,
+        likeCount: Long = 0,
+        commentCount: Long = 0,
+    ): PostDailyStats =
+        postDailyStatsRepository.save(
+            PostDailyStats(
+                post = post,
+                statDate = statDateDaysAgo(daysAgo),
+                viewCount = viewCount,
+                likeCount = likeCount,
+                commentCount = commentCount,
+            ),
+        )
+
+    private fun statDateDaysAgo(daysAgo: Long): SqlDate = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC).minusDays(daysAgo))
 
     @Nested
     @DisplayName("authorId 필터링")
@@ -286,6 +327,163 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
             // then
             assertThat(result).hasSize(1)
             assertThat(result[0].id).isEqualTo(target.id)
+        }
+    }
+
+    @Nested
+    @DisplayName("기간 통계 랭킹")
+    inner class PeriodStatsRanking {
+        @Test
+        @DisplayName("댓글순 기간 랭킹은 게시물 작성일이 아니라 기간 내 일별 댓글 집계 합계로 정렬하고 필터링한다")
+        fun findPostsWithConditions_commentPeriodRanking_usesRecentDailyStatsInsteadOfPostCreatedAt() {
+            // given
+            val oldPostWithTodayComments = movePostCreatedAt(createPost(userA), daysAgo = 500)
+            createDailyStats(oldPostWithTodayComments, daysAgo = 0, commentCount = 5)
+
+            val oldPostWithRecentComments = movePostCreatedAt(createPost(userA), daysAgo = 400)
+            createDailyStats(oldPostWithRecentComments, daysAgo = 3, commentCount = 2)
+
+            val recentPostWithoutStats = createPost(userA)
+            val oldPostWithStaleComments = movePostCreatedAt(createPost(userA), daysAgo = 300)
+            createDailyStats(oldPostWithStaleComments, daysAgo = 31, commentCount = 99)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.MONTH,
+                    sortType = PostSortType.COMMENT,
+                )
+
+            // then
+            assertThat(result).extracting("id").containsExactly(
+                oldPostWithTodayComments.id,
+                oldPostWithRecentComments.id,
+            )
+            assertThat(result).extracting("id").doesNotContain(
+                recentPostWithoutStats.id,
+                oldPostWithStaleComments.id,
+            )
+        }
+
+        @Test
+        @DisplayName("조회순 기간 랭킹은 기간 내 일별 조회 집계 합계로 정렬한다")
+        fun findPostsWithConditions_viewPeriodRanking_usesRecentDailyStatsSum() {
+            // given
+            val oldPostWithMoreViews = movePostCreatedAt(createPost(userA), daysAgo = 500)
+            oldPostWithMoreViews.viewCount = 1
+            createDailyStats(oldPostWithMoreViews, daysAgo = 0, viewCount = 7)
+
+            val oldPostWithFewerViews = movePostCreatedAt(createPost(userA), daysAgo = 400)
+            oldPostWithFewerViews.viewCount = 100
+            createDailyStats(oldPostWithFewerViews, daysAgo = 1, viewCount = 3)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.WEEK,
+                    sortType = PostSortType.VIEW,
+                )
+
+            // then
+            assertThat(result).extracting("id").containsExactly(
+                oldPostWithMoreViews.id,
+                oldPostWithFewerViews.id,
+            )
+        }
+
+        @Test
+        @DisplayName("추천순 기간 랭킹은 기간 내 일별 추천 집계 합계로 정렬한다")
+        fun findPostsWithConditions_likePeriodRanking_usesRecentDailyStatsSum() {
+            // given
+            val oldPostWithMoreLikes = movePostCreatedAt(createPost(userA), daysAgo = 500)
+            oldPostWithMoreLikes.likeCount = 1
+            createDailyStats(oldPostWithMoreLikes, daysAgo = 0, likeCount = 4)
+
+            val oldPostWithFewerLikes = movePostCreatedAt(createPost(userA), daysAgo = 400)
+            oldPostWithFewerLikes.likeCount = 100
+            createDailyStats(oldPostWithFewerLikes, daysAgo = 1, likeCount = 2)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.WEEK,
+                    sortType = PostSortType.LIKE,
+                )
+
+            // then
+            assertThat(result).extracting("id").containsExactly(
+                oldPostWithMoreLikes.id,
+                oldPostWithFewerLikes.id,
+            )
+        }
+
+        @Test
+        @DisplayName("기간 랭킹 커서는 전체 누적값이 아니라 기간 내 일별 집계 합계로 다음 페이지를 조회한다")
+        fun findPostsWithConditions_periodRankingCursor_usesRecentDailyStatsSortValue() {
+            // given
+            val firstPageLastPost = movePostCreatedAt(createPost(userA), daysAgo = 500)
+            firstPageLastPost.commentCount = 1_000
+            createDailyStats(firstPageLastPost, daysAgo = 0, commentCount = 10)
+
+            val secondPageFirstPost = movePostCreatedAt(createPost(userA), daysAgo = 400)
+            secondPageFirstPost.commentCount = 999
+            createDailyStats(secondPageFirstPost, daysAgo = 0, commentCount = 5)
+
+            val secondPageSecondPost = movePostCreatedAt(createPost(userA), daysAgo = 300)
+            secondPageSecondPost.commentCount = 998
+            createDailyStats(secondPageSecondPost, daysAgo = 0, commentCount = 1)
+            postRepository.saveAllAndFlush(listOf(firstPageLastPost, secondPageFirstPost, secondPageSecondPost))
+
+            val cursor =
+                PostCursor(
+                    sortValue = 10,
+                    createdAt = firstPageLastPost.createdAt,
+                    id = firstPageLastPost.id!!,
+                    sortType = PostSortType.COMMENT,
+                )
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = cursor,
+                    size = 10,
+                    period = PostPeriod.MONTH,
+                    sortType = PostSortType.COMMENT,
+                )
+
+            // then
+            assertThat(result).extracting("id").containsExactly(
+                secondPageFirstPost.id,
+                secondPageSecondPost.id,
+            )
+        }
+
+        @Test
+        @DisplayName("최신순 기간 필터는 기존처럼 게시물 작성일 기준으로 동작한다")
+        fun findPostsWithConditions_latestPeriod_keepsPostCreatedAtFilter() {
+            // given
+            val recentPost = createPost(userA)
+            val oldPost = movePostCreatedAt(createPost(userA), daysAgo = 500)
+            createDailyStats(oldPost, daysAgo = 0, commentCount = 5)
+
+            // when
+            val result =
+                postRepository.findPostsWithConditions(
+                    cursor = null,
+                    size = 10,
+                    period = PostPeriod.MONTH,
+                    sortType = PostSortType.LATEST,
+                )
+
+            // then
+            assertThat(result).extracting("id").contains(recentPost.id)
+            assertThat(result).extracting("id").doesNotContain(oldPost.id)
         }
     }
 

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/out/PostRepositoryCustomImplTest.kt
@@ -27,8 +27,6 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-import java.sql.Date as SqlDate
-import java.util.Date as UtilDate
 
 @Transactional
 @ActiveProfiles("test")
@@ -110,7 +108,7 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
         post: Post,
         daysAgo: Long,
     ): Post {
-        val createdAt = UtilDate.from(Instant.now().minus(daysAgo, ChronoUnit.DAYS))
+        val createdAt = Instant.now().minus(daysAgo, ChronoUnit.DAYS)
         post.createdAt = createdAt
         post.updatedAt = createdAt
         return postRepository.saveAndFlush(post)
@@ -133,7 +131,7 @@ class PostRepositoryCustomImplTest : IntegrationTest() {
             ),
         )
 
-    private fun statDateDaysAgo(daysAgo: Long): SqlDate = SqlDate.valueOf(LocalDate.now(ZoneOffset.UTC).minusDays(daysAgo))
+    private fun statDateDaysAgo(daysAgo: Long): LocalDate = LocalDate.now(ZoneOffset.UTC).minusDays(daysAgo)
 
     @Nested
     @DisplayName("authorId 필터링")

--- a/src/test/kotlin/com/techtaurant/mainserver/security/jwt/JwtTokenProviderTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/jwt/JwtTokenProviderTest.kt
@@ -1,0 +1,67 @@
+package com.techtaurant.mainserver.security.jwt
+
+import com.techtaurant.mainserver.user.enums.UserRole
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.Date
+import java.util.UUID
+
+@DisplayName("JwtTokenProvider UTC Instant 테스트")
+class JwtTokenProviderTest {
+    private val properties =
+        JwtProperties(
+            secret = "test-jwt-secret-key-minimum-256-bits-for-hs256-algorithm",
+            accessTokenExpireMs = 3_600_000L,
+            refreshTokenExpireMs = 604_800_000L,
+        )
+    private val provider = JwtTokenProvider(properties)
+    private val secretKey = Keys.hmacShaKeyFor(properties.secret.toByteArray())
+
+    @Test
+    @DisplayName("Access token은 UTC epoch 기반 iat/exp를 발급하고 claims를 검증할 수 있다")
+    fun createAccessToken_usesAbsoluteIssuedAtAndExpiration() {
+        val userId = UUID.randomUUID()
+        val beforeIssue = System.currentTimeMillis()
+
+        val token = provider.createAccessToken(userId, UserRole.ADMIN)
+        val afterIssue = System.currentTimeMillis()
+
+        val parsedClaims =
+            Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .payload
+        val validatedClaims = provider.validateAndGetClaims(token)
+
+        assertThat(validatedClaims.userId).isEqualTo(userId)
+        assertThat(validatedClaims.role).isEqualTo(UserRole.ADMIN.key)
+        assertThat(validatedClaims.isPermanent).isFalse()
+        assertThat(parsedClaims.issuedAt).isBetween(Date(beforeIssue - 1_000L), Date(afterIssue + 1_000L))
+        assertThat(parsedClaims.expiration.time - parsedClaims.issuedAt.time).isEqualTo(properties.accessTokenExpireMs)
+    }
+
+    @Test
+    @DisplayName("Permanent access token은 만료 시간이 없고 permanent claim을 포함한다")
+    fun createPermanentAccessToken_hasNoExpirationAndContainsPermanentClaim() {
+        val userId = UUID.randomUUID()
+
+        val token = provider.createPermanentAccessToken(userId, UserRole.COMPANY)
+
+        val parsedClaims =
+            Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .payload
+        val validatedClaims = provider.validateAndGetClaims(token)
+
+        assertThat(validatedClaims.userId).isEqualTo(userId)
+        assertThat(validatedClaims.role).isEqualTo(UserRole.COMPANY.key)
+        assertThat(validatedClaims.isPermanent).isTrue()
+        assertThat(parsedClaims.expiration).isNull()
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -35,6 +35,8 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration
+    postgresql:
+      transactional-lock: false
 
   security:
     oauth2:
@@ -80,6 +82,16 @@ cookie:
   http-only: true
   same-site: Lax
   path: /
+
+otel:
+  sdk:
+    disabled: true
+  traces:
+    exporter: none
+  metrics:
+    exporter: none
+  logs:
+    exporter: none
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
## Summary
- Add 30-day/daily-stat based ranking for post VIEW/LIKE/COMMENT sorting while keeping latest sorting on post timestamps.
- Migrate absolute timestamp handling to UTC-safe `TIMESTAMPTZ`/`Instant` with expand-contract migrations, trigger-based old/new column synchronization, and UTC temporal indexes.
- Update cursors, DTOs, repositories, JWT handling, and daily-stat buckets for UTC-safe time handling with legacy cursor compatibility.
- Add migration, UTC boundary, cursor compatibility, JWT, ranking, and service/controller regression tests.

## Notes
- `V35__add_utc_timestamptz_columns.sql` adds/backfills UTC columns and sync triggers while preserving existing columns.
- `V36__create_utc_temporal_indexes.sql` uses `CREATE INDEX CONCURRENTLY`; Flyway PostgreSQL transactional lock is disabled to support this migration style.
- Jacoco verification remains at the same thresholds, but the coverage rule is evaluated at bundle level instead of class level.

## Testing
- `./gradlew spotlessApply --no-daemon`
- `./gradlew clean build --no-daemon`
- Test result: `441 tests, 0 failures, 0 errors, 0 skipped`
