### PR TITLE
feat(link): 회사 링크 공개 조회 API 추가

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
@@ -122,8 +122,15 @@ class AttachmentService(
     ) {
         if (attachmentIds.isEmpty()) return
 
+        val distinctAttachmentIds = attachmentIds.distinct()
+        val attachmentsById = attachmentRepository.findAllById(distinctAttachmentIds).associateBy { it.id!! }
+
+        if (attachmentsById.size != distinctAttachmentIds.size) {
+            throw ApiException(DefaultStatus.NOT_FOUND, "첨부파일을 찾을 수 없습니다")
+        }
+
         val tmpAttachments =
-            attachmentRepository.findAllById(attachmentIds.distinct())
+            distinctAttachmentIds.mapNotNull(attachmentsById::get)
                 .filter { attachment ->
                     attachment.status == AttachmentStatus.TMP && attachment.referenceType == referenceType
                 }

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkReadService.kt
@@ -56,6 +56,21 @@ class LinkReadService(
         )
     }
 
+    fun getPublicCompanyLinkContents(
+        companyUserId: UUID,
+        cursor: String?,
+        size: Int,
+    ): CursorPageResponse<LinkContentListItemResponse> {
+        validateCompany(companyUserId)
+
+        return getPublicLinkContents(
+            cursor = cursor,
+            size = size,
+            sourceCompanyUserId = companyUserId,
+            tag = null,
+        )
+    }
+
     fun getPublicLinkContentDetail(linkId: UUID): LinkContentDetailResponse {
         val link =
             linkRepository.findByIdWithTags(linkId)

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/CompanyLinkReadOpenApiController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/CompanyLinkReadOpenApiController.kt
@@ -1,0 +1,40 @@
+package com.techtaurant.mainserver.link.infrastructure.`in`
+
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.dto.CursorPageResponse
+import com.techtaurant.mainserver.common.swagger.ApiErrorResponses
+import com.techtaurant.mainserver.link.application.LinkReadService
+import com.techtaurant.mainserver.link.dto.LinkContentListItemResponse
+import com.techtaurant.mainserver.security.SecurityConstants
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("${SecurityConstants.OPEN_API_PREFIX}/companies")
+@Validated
+class CompanyLinkReadOpenApiController(
+    private val linkReadService: LinkReadService,
+) : CompanyLinkReadOpenApiControllerDocs {
+    @ApiErrorResponses(includeValidationError = true)
+    @GetMapping("/{companyUserId}/links")
+    override fun getCompanyLinkContents(
+        @PathVariable companyUserId: UUID,
+        @RequestParam(required = false) cursor: String?,
+        @RequestParam(defaultValue = "20") @Min(1) @Max(100) size: Int,
+    ): ApiResponse<CursorPageResponse<LinkContentListItemResponse>> {
+        return ApiResponse.ok(
+            linkReadService.getPublicCompanyLinkContents(
+                companyUserId = companyUserId,
+                cursor = cursor,
+                size = size,
+            ),
+        )
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/CompanyLinkReadOpenApiControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/CompanyLinkReadOpenApiControllerDocs.kt
@@ -1,0 +1,35 @@
+package com.techtaurant.mainserver.link.infrastructure.`in`
+
+import com.techtaurant.mainserver.common.dto.ApiResponse
+import com.techtaurant.mainserver.common.dto.CursorPageResponse
+import com.techtaurant.mainserver.common.swagger.ApiCommonBadRequestAndUnknown
+import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponse
+import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponses
+import com.techtaurant.mainserver.link.dto.LinkContentListItemResponse
+import com.techtaurant.mainserver.link.enums.LinkStatus
+import com.techtaurant.mainserver.user.enums.UserStatus
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import java.util.UUID
+import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
+
+@Tag(name = "링크", description = "링크 API")
+interface CompanyLinkReadOpenApiControllerDocs {
+    @Operation(summary = "회사 링크 목록 조회", description = "회사가 수집한 링크 목록을 커서 기반으로 조회합니다")
+    @SwaggerApiResponse(responseCode = "200", description = "회사 링크 목록 조회 성공")
+    @ApiCommonBadRequestAndUnknown
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(UserStatus::class, ["COMPANY_NOT_FOUND"]),
+            ApiErrorCodeResponse(LinkStatus::class, ["INVALID_LINK_CURSOR"]),
+        ],
+    )
+    fun getCompanyLinkContents(
+        @Parameter(description = "회사 사용자 ID") companyUserId: UUID,
+        @Parameter(description = "이전 응답의 nextCursor (첫 페이지는 생략)") cursor: String?,
+        @Parameter(description = "페이지 크기 (1-100, 기본값 20)") @Min(1) @Max(100) size: Int,
+    ): ApiResponse<CursorPageResponse<LinkContentListItemResponse>>
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentServiceTest.kt
@@ -7,6 +7,7 @@ import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
 import com.techtaurant.mainserver.attachment.enums.AttachmentStatus
 import com.techtaurant.mainserver.attachment.infrastructure.out.AttachmentRepository
 import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.common.status.DefaultStatus
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 
 class AttachmentServiceTest {
@@ -140,6 +142,49 @@ class AttachmentServiceTest {
             )
 
             // then
+            verify(exactly = 0) { s3StorageService.copyObject(any(), any()) }
+        }
+
+        @Test
+        @DisplayName("요청한 Attachment를 찾지 못하면 404 예외를 던진다")
+        fun confirmAttachmentsByIds_missingAttachment_throwsNotFound() {
+            // given
+            val missingAttachmentId = UUID.randomUUID()
+            every { attachmentRepository.findAllById(listOf(missingAttachmentId)) } returns emptyList()
+
+            // when & then
+            val exception =
+                assertThrows<ApiException> {
+                    attachmentService.confirmAttachmentsByIds(
+                        referenceId = postId,
+                        referenceType = AttachmentReferenceType.POST,
+                        attachmentIds = listOf(missingAttachmentId),
+                    )
+                }
+
+            assertThat(exception.status).isEqualTo(DefaultStatus.NOT_FOUND)
+            assertThat(exception).hasMessage("첨부파일을 찾을 수 없습니다")
+        }
+
+        @Test
+        @DisplayName("요청한 Attachment 중 일부를 찾지 못해도 404 예외를 던진다")
+        fun confirmAttachmentsByIds_partiallyMissingAttachment_throwsNotFound() {
+            // given
+            val missingAttachmentId = UUID.randomUUID()
+            every { attachmentRepository.findAllById(listOf(tmpAttachment.id!!, missingAttachmentId)) } returns listOf(tmpAttachment)
+
+            // when & then
+            val exception =
+                assertThrows<ApiException> {
+                    attachmentService.confirmAttachmentsByIds(
+                        referenceId = postId,
+                        referenceType = AttachmentReferenceType.POST,
+                        attachmentIds = listOf(tmpAttachment.id!!, missingAttachmentId),
+                    )
+                }
+
+            assertThat(exception.status).isEqualTo(DefaultStatus.NOT_FOUND)
+            assertThat(exception).hasMessage("첨부파일을 찾을 수 없습니다")
             verify(exactly = 0) { s3StorageService.copyObject(any(), any()) }
         }
 

--- a/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkReadOpenApiControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkReadOpenApiControllerIntegrationTest.kt
@@ -246,6 +246,57 @@ class LinkReadOpenApiControllerIntegrationTest : IntegrationTest() {
     }
 
     @Test
+    @DisplayName("공개 회사 링크 목록은 인증 없이 회사별 링크를 커서 기반으로 조회한다")
+    fun getCompanyLinkContents_paginatesCompanyLinksWithoutAuthentication() {
+        val oldest = saveLink("Oldest Company Link", "https://example.com/company-oldest", firstCompany, 1_000)
+        val middle = saveLink("Middle Company Link", "https://example.com/company-middle", firstCompany, 2_000)
+        val newest = saveLink("Newest Company Link", "https://example.com/company-newest", firstCompany, 3_000)
+        val otherCompanyLink = saveLink("Other Company Link", "https://example.com/company-other", secondCompany, 4_000)
+
+        val nextCursor =
+            given()
+                .queryParam("size", 2)
+                .`when`()
+                .get("/open-api/companies/${firstCompany.id}/links")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("data.content", hasSize<Any>(2))
+                .body("data.content[0].id", equalTo(newest.id.toString()))
+                .body("data.content[1].id", equalTo(middle.id.toString()))
+                .body("data.content.id", not(hasItem(otherCompanyLink.id.toString())))
+                .body("data.nextCursor", notNullValue())
+                .body("data.hasNext", equalTo(true))
+                .body("data.size", equalTo(2))
+                .extract()
+                .path<String>("data.nextCursor")
+
+        given()
+            .queryParam("cursor", nextCursor)
+            .queryParam("size", 2)
+            .`when`()
+            .get("/open-api/companies/${firstCompany.id}/links")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.content", hasSize<Any>(1))
+            .body("data.content[0].id", equalTo(oldest.id.toString()))
+            .body("data.nextCursor", nullValue())
+            .body("data.hasNext", equalTo(false))
+            .body("data.size", equalTo(1))
+    }
+
+    @Test
+    @DisplayName("공개 회사 링크 목록은 없는 회사 ID면 COMPANY_NOT_FOUND를 반환한다")
+    fun getCompanyLinkContents_missingCompany_returnsCompanyNotFound() {
+        given()
+            .`when`()
+            .get("/open-api/companies/${UUID.randomUUID()}/links")
+            .then()
+            .statusCode(HttpStatus.NOT_FOUND.value())
+            .body("status", equalTo(1010))
+            .body("message", equalTo("회사를 찾을 수 없습니다"))
+    }
+
+    @Test
     @DisplayName("공개 링크 목록은 결과가 없으면 빈 커서 페이지를 반환한다")
     fun getLinkContents_returnsEmptyPageForNoMatches() {
         saveLink("Valid Link", "https://example.com/valid-link", firstCompany, 1_000)


### PR DESCRIPTION
## 어떤 작업인가요?
- 회사가 수집한 링크 목록을 인증 없는 `/open-api/companies/{companyUserId}/links` 경로로 조회할 수 있게 추가합니다.

## 어떻게 해결했나요?
**회사 링크 공개 조회 API**
- `CompanyLinkReadOpenApiController`와 OpenAPI 문서 인터페이스를 추가했습니다.
- `LinkReadService`에서 회사 사용자 검증 후 기존 공개 링크 목록 조회 로직을 재사용하도록 구성했습니다.

**Attachment 404 처리**
- `AttachmentService.confirmAttachmentsByIds`에서 요청한 attachment ID 전체 존재 여부를 먼저 검증합니다.
- 누락된 attachment가 있으면 S3 작업 전에 `DefaultStatus.NOT_FOUND`를 반환하도록 테스트를 추가했습니다.

## 중요한 변경 사항은 무엇인가요?
### 공개 회사 링크 조회

**path-style 공개 API 추가**
- **변경 이유**: 회사별 수집 링크 목록을 Open API 경로에서 직접 조회하기 위해
- **수정 파일**: `CompanyLinkReadOpenApiController.kt`, `CompanyLinkReadOpenApiControllerDocs.kt`, `LinkReadService.kt`

### Attachment 확정 검증

**누락 attachment 404 반환**
- **변경 이유**: 요청한 attachment가 존재하지 않는 경우 조용히 skip하지 않고 404를 반환하기 위해
- **수정 파일**: `AttachmentService.kt`, `AttachmentServiceTest.kt`

Co-Authored-By: Codex <codex@openai.com>