### PR TITLE
modify(link): 링크 수집 배치 크롤링 검증 강화

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkBatchRunService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkBatchRunService.kt
@@ -94,7 +94,7 @@ class LinkBatchRunService(
         var pageResult = emptyPageCrawlResult()
 
         document.select(batch.itemSelector).forEach { item ->
-            pageResult = pageResult.recordCollectionResult(collectLinkItem(item, batch, tagResolver, pageUrl))
+            pageResult = pageResult.recordCollectionResult(collectLinkFromCrawledItem(item, batch, tagResolver, pageUrl))
         }
 
         return pageResult
@@ -147,7 +147,7 @@ class LinkBatchRunService(
             skippedCount = skippedCount + pageResult.skippedCount,
         )
 
-    private fun collectLinkItem(
+    private fun collectLinkFromCrawledItem(
         item: Element,
         batch: LinkCrawlBatch,
         tagResolver: LinkTagResolver,

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkBatchRunService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkBatchRunService.kt
@@ -52,6 +52,18 @@ class LinkBatchRunService(
         return result
     }
 
+    fun validateCrawlable(batch: LinkCrawlBatch) {
+        val pageUrl = buildPageUrl(batch.baseUrl, batch.pageUriTemplate, batch.startPage)
+        val document = fetchPageOrNull(pageUrl) ?: throw ApiException(LinkStatus.LINK_CRAWL_BATCH_NOT_CRAWLABLE)
+        val hasCrawlableItem =
+            document.select(batch.itemSelector)
+                .any { item -> extractSnapshot(item, batch, pageUrl) != null }
+
+        if (!hasCrawlableItem) {
+            throw ApiException(LinkStatus.LINK_CRAWL_BATCH_NOT_CRAWLABLE)
+        }
+    }
+
     private fun crawl(
         batch: LinkCrawlBatch,
         tagResolver: LinkTagResolver,
@@ -188,9 +200,7 @@ class LinkBatchRunService(
         if (snapshot.summary.isNotBlank()) {
             existingLink.summary = snapshot.summary
         }
-        if (snapshot.publishedAt != null) {
-            existingLink.publishedAt = snapshot.publishedAt
-        }
+        existingLink.publishedAt = snapshot.publishedAt
     }
 
     private fun connectUserToLink(
@@ -241,7 +251,9 @@ class LinkBatchRunService(
                 ?: return null
 
         val summary = batch.summarySelector?.let { resolveText(item, it) }.orEmpty()
-        val publishedAt = parsePublishedAt(firstResolvedValue(item, batch.publishedAtSelectors))
+        val publishedAt =
+            parsePublishedAt(firstResolvedValue(item, batch.publishedAtSelectors))
+                ?: throw ApiException(LinkStatus.LINK_CRAWL_BATCH_PUBLISHED_AT_REQUIRED)
 
         return LinkSnapshot(
             title = title,
@@ -344,7 +356,7 @@ class LinkBatchRunService(
         val title: String,
         val url: String,
         val summary: String,
-        val publishedAt: Instant?,
+        val publishedAt: Instant,
     )
 
     private data class LinkPageCrawlResult(

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkCrawlBatchAdminService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkCrawlBatchAdminService.kt
@@ -2,6 +2,7 @@ package com.techtaurant.mainserver.link.application
 
 import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.link.dto.CreateLinkCrawlBatchRequest
+import com.techtaurant.mainserver.link.dto.LinkCrawlBatchListItemResponse
 import com.techtaurant.mainserver.link.dto.LinkCrawlBatchResponse
 import com.techtaurant.mainserver.link.dto.UpdateLinkCrawlBatchRequest
 import com.techtaurant.mainserver.link.entity.LinkCrawlBatch
@@ -20,6 +21,7 @@ import java.util.UUID
 class LinkCrawlBatchAdminService(
     private val linkCrawlBatchRepository: LinkCrawlBatchRepository,
     private val userRepository: UserRepository,
+    private val linkBatchRunService: LinkBatchRunService,
 ) {
     @Transactional
     fun createBatch(
@@ -30,33 +32,33 @@ class LinkCrawlBatchAdminService(
         validateCronExpression(request.cronExpression)
 
         val batch =
-            linkCrawlBatchRepository.save(
-                LinkCrawlBatch(
-                    companyUser = companyUser,
-                    name = request.name.trim(),
-                    baseUrl = request.baseUrl.trim(),
-                    pageUriTemplate = request.pageUriTemplate.trim(),
-                    itemSelector = request.itemSelector.trim(),
-                    articleLinkSelector = request.articleLinkSelector.trim(),
-                    titleSelector = request.titleSelector.trim(),
-                    summarySelector = request.summarySelector?.trim()?.takeIf { it.isNotEmpty() },
-                    publishedAtSelectors = normalizeLines(request.publishedAtSelectors),
-                    tagNames = normalizeLines(request.tagNames),
-                    cronExpression = request.cronExpression.trim(),
-                    startPage = request.startPage,
-                    active = request.active,
-                ),
+            LinkCrawlBatch(
+                companyUser = companyUser,
+                name = request.name.trim(),
+                baseUrl = request.baseUrl.trim(),
+                pageUriTemplate = request.pageUriTemplate.trim(),
+                itemSelector = request.itemSelector.trim(),
+                articleLinkSelector = request.articleLinkSelector.trim(),
+                titleSelector = request.titleSelector.trim(),
+                summarySelector = request.summarySelector?.trim()?.takeIf { it.isNotEmpty() },
+                publishedAtSelectors = normalizeLines(request.publishedAtSelectors),
+                tagNames = normalizeLines(request.tagNames),
+                cronExpression = request.cronExpression.trim(),
+                startPage = request.startPage,
+                active = request.active,
             )
+        linkBatchRunService.validateCrawlable(batch)
+        val savedBatch = linkCrawlBatchRepository.save(batch)
 
-        return LinkCrawlBatchResponse.from(batch)
+        return LinkCrawlBatchResponse.from(savedBatch)
     }
 
     @Transactional(readOnly = true)
-    fun getBatches(companyUserId: UUID): List<LinkCrawlBatchResponse> {
+    fun getBatches(companyUserId: UUID): List<LinkCrawlBatchListItemResponse> {
         getCompanyUser(companyUserId)
         return linkCrawlBatchRepository.findAllByCompanyUserId(companyUserId)
             .sortedBy { it.name }
-            .map(LinkCrawlBatchResponse::from)
+            .map(LinkCrawlBatchListItemResponse::from)
     }
 
     @Transactional
@@ -85,6 +87,8 @@ class LinkCrawlBatchAdminService(
 
         request.startPage?.let { batch.startPage = it }
         request.active?.let { batch.active = it }
+
+        linkBatchRunService.validateCrawlable(batch)
 
         return LinkCrawlBatchResponse.from(batch)
     }

--- a/src/main/kotlin/com/techtaurant/mainserver/link/dto/LinkCrawlBatchListItemResponse.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/dto/LinkCrawlBatchListItemResponse.kt
@@ -1,0 +1,37 @@
+package com.techtaurant.mainserver.link.dto
+
+import com.techtaurant.mainserver.link.entity.LinkCrawlBatch
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.Instant
+import java.util.UUID
+
+@Schema(description = "링크 수집 배치 목록 조회 응답")
+data class LinkCrawlBatchListItemResponse(
+    @field:Schema(description = "배치 ID")
+    val id: UUID,
+    @field:Schema(description = "회사 사용자 ID")
+    val companyUserId: UUID,
+    @field:Schema(description = "배치 이름")
+    val name: String,
+    @field:Schema(description = "기준 base URL")
+    val baseUrl: String,
+    val cronExpression: String,
+    val startPage: Int,
+    val active: Boolean,
+    val lastTriggeredAt: Instant?,
+) {
+    companion object {
+        fun from(batch: LinkCrawlBatch): LinkCrawlBatchListItemResponse {
+            return LinkCrawlBatchListItemResponse(
+                id = batch.id ?: throw IllegalStateException("배치 ID가 없습니다"),
+                companyUserId = batch.companyUser.id ?: throw IllegalStateException("회사 사용자 ID가 없습니다"),
+                name = batch.name,
+                baseUrl = batch.baseUrl,
+                cronExpression = batch.cronExpression,
+                startPage = batch.startPage,
+                active = batch.active,
+                lastTriggeredAt = batch.lastTriggeredAt,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/link/enums/LinkStatus.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/enums/LinkStatus.kt
@@ -12,6 +12,8 @@ enum class LinkStatus(
     LINK_CRAWL_BATCH_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 6002, "링크 수집 배치를 찾을 수 없습니다"),
     INVALID_LINK_CRAWL_BATCH_CRON_EXPRESSION(HttpStatus.BAD_REQUEST.value(), 6004, "유효한 cron 표현식이 아닙니다"),
     INVALID_LINK_CURSOR(HttpStatus.BAD_REQUEST.value(), 6005, "유효한 링크 커서가 아닙니다"),
+    LINK_CRAWL_BATCH_PUBLISHED_AT_REQUIRED(HttpStatus.BAD_REQUEST.value(), 6006, "링크 수집 배치에서 발행일을 수집할 수 없습니다"),
+    LINK_CRAWL_BATCH_NOT_CRAWLABLE(HttpStatus.BAD_REQUEST.value(), 6007, "링크 수집 배치를 크롤링할 수 없습니다"),
     ;
 
     override fun getHttpStatusCode(): Int {

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/AdminLinkCrawlBatchController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/AdminLinkCrawlBatchController.kt
@@ -6,6 +6,7 @@ import com.techtaurant.mainserver.link.application.LinkBatchRunService
 import com.techtaurant.mainserver.link.application.LinkCrawlBatchAdminService
 import com.techtaurant.mainserver.link.dto.CreateLinkCrawlBatchRequest
 import com.techtaurant.mainserver.link.dto.LinkBatchRunResponse
+import com.techtaurant.mainserver.link.dto.LinkCrawlBatchListItemResponse
 import com.techtaurant.mainserver.link.dto.LinkCrawlBatchResponse
 import com.techtaurant.mainserver.link.dto.UpdateLinkCrawlBatchRequest
 import com.techtaurant.mainserver.security.SecurityConstants
@@ -39,7 +40,7 @@ class AdminLinkCrawlBatchController(
     @GetMapping("${SecurityConstants.ADMIN_API_PREFIX}/companies/{companyUserId}/link-crawl-batches")
     override fun getBatches(
         @PathVariable companyUserId: UUID,
-    ): ApiResponse<List<LinkCrawlBatchResponse>> {
+    ): ApiResponse<List<LinkCrawlBatchListItemResponse>> {
         return ApiResponse.ok(linkCrawlBatchAdminService.getBatches(companyUserId))
     }
 

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/AdminLinkCrawlBatchControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/AdminLinkCrawlBatchControllerDocs.kt
@@ -6,6 +6,7 @@ import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponse
 import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponses
 import com.techtaurant.mainserver.link.dto.CreateLinkCrawlBatchRequest
 import com.techtaurant.mainserver.link.dto.LinkBatchRunResponse
+import com.techtaurant.mainserver.link.dto.LinkCrawlBatchListItemResponse
 import com.techtaurant.mainserver.link.dto.LinkCrawlBatchResponse
 import com.techtaurant.mainserver.link.dto.UpdateLinkCrawlBatchRequest
 import com.techtaurant.mainserver.link.enums.LinkStatus
@@ -27,7 +28,7 @@ interface AdminLinkCrawlBatchControllerDocs {
     @Operation(
         summary = "회사 링크 수집 배치 등록",
         description = """
-        관리자가 회사별 SSR 링크 수집 배치를 등록합니다.
+        관리자가 회사별 SSR 링크 수집 배치를 등록합니다. 등록 전 설정된 시작 페이지를 1회 요청해 크롤링 가능 여부를 검증합니다.
 
         selector를 찾는 방법:
         1. 먼저 브라우저의 검사(Inspect)로 보이는 DOM이 아니라, View Page Source 또는 curl로 받은 원본 HTML에 요소가 실제로 있는지 확인합니다.
@@ -59,7 +60,10 @@ interface AdminLinkCrawlBatchControllerDocs {
         [
             ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED", "ACCESS_DENIED"]),
             ApiErrorCodeResponse(UserStatus::class, ["COMPANY_NOT_FOUND"]),
-            ApiErrorCodeResponse(LinkStatus::class, ["INVALID_LINK_CRAWL_BATCH_CRON_EXPRESSION"]),
+            ApiErrorCodeResponse(
+                LinkStatus::class,
+                ["INVALID_LINK_CRAWL_BATCH_CRON_EXPRESSION", "LINK_CRAWL_BATCH_PUBLISHED_AT_REQUIRED", "LINK_CRAWL_BATCH_NOT_CRAWLABLE"],
+            ),
             ApiErrorCodeResponse(DefaultStatus::class, ["BAD_REQUEST", "UNKNOWN_EXCEPTION"]),
         ],
     )
@@ -106,15 +110,40 @@ interface AdminLinkCrawlBatchControllerDocs {
     @Operation(summary = "회사 링크 수집 배치 목록 조회", description = "관리자가 특정 회사의 링크 수집 배치 목록을 조회합니다")
     fun getBatches(
         @Parameter(description = "회사 사용자 ID") companyUserId: UUID,
-    ): ApiResponse<List<LinkCrawlBatchResponse>>
+    ): ApiResponse<List<LinkCrawlBatchListItemResponse>>
 
-    @Operation(summary = "링크 수집 배치 수정", description = "관리자가 링크 수집 배치 설정을 부분 수정합니다")
+    @Operation(summary = "링크 수집 배치 수정", description = "관리자가 링크 수집 배치 설정을 부분 수정합니다. 수정된 설정으로 크롤링 가능 여부를 검증합니다")
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED", "ACCESS_DENIED"]),
+            ApiErrorCodeResponse(
+                LinkStatus::class,
+                [
+                    "LINK_CRAWL_BATCH_NOT_FOUND",
+                    "INVALID_LINK_CRAWL_BATCH_CRON_EXPRESSION",
+                    "LINK_CRAWL_BATCH_PUBLISHED_AT_REQUIRED",
+                    "LINK_CRAWL_BATCH_NOT_CRAWLABLE",
+                ],
+            ),
+            ApiErrorCodeResponse(DefaultStatus::class, ["BAD_REQUEST", "UNKNOWN_EXCEPTION"]),
+        ],
+    )
     fun updateBatch(
         @Parameter(description = "배치 ID") batchId: UUID,
         @Valid request: UpdateLinkCrawlBatchRequest,
     ): ApiResponse<LinkCrawlBatchResponse>
 
-    @Operation(summary = "링크 수집 배치 수동 실행", description = "관리자가 해당 배치를 즉시 실행하여 SSR 목록 페이지에서 링크를 수집합니다")
+    @Operation(
+        summary = "링크 수집 배치 수동 실행",
+        description = "관리자가 해당 배치를 즉시 실행하여 SSR 목록 페이지에서 링크를 수집합니다. 발행일을 수집할 수 없는 항목이 있으면 배치가 실패합니다.",
+    )
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED", "ACCESS_DENIED"]),
+            ApiErrorCodeResponse(LinkStatus::class, ["LINK_CRAWL_BATCH_NOT_FOUND", "LINK_CRAWL_BATCH_PUBLISHED_AT_REQUIRED"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["UNKNOWN_EXCEPTION"]),
+        ],
+    )
     fun runBatch(
         @Parameter(description = "배치 ID") batchId: UUID,
     ): ApiResponse<LinkBatchRunResponse>

--- a/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkBatchRunServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkBatchRunServiceTest.kt
@@ -1,0 +1,146 @@
+package com.techtaurant.mainserver.link.application
+
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.link.entity.LinkCrawlBatch
+import com.techtaurant.mainserver.link.enums.LinkStatus
+import com.techtaurant.mainserver.link.infrastructure.out.LinkCrawlBatchRepository
+import com.techtaurant.mainserver.link.infrastructure.out.LinkRepository
+import com.techtaurant.mainserver.link.infrastructure.out.UserLinkRepository
+import com.techtaurant.mainserver.post.application.TagWriteService
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.Optional
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@DisplayName("LinkBatchRunService 테스트")
+class LinkBatchRunServiceTest {
+    private val linkCrawlBatchRepository: LinkCrawlBatchRepository = mockk()
+    private val linkRepository: LinkRepository = mockk(relaxed = true)
+    private val userLinkRepository: UserLinkRepository = mockk(relaxed = true)
+    private val tagWriteService: TagWriteService = mockk(relaxed = true)
+    private val linkDocumentFetcher = StubLinkDocumentFetcher()
+    private val linkBatchRunService =
+        LinkBatchRunService(
+            linkCrawlBatchRepository = linkCrawlBatchRepository,
+            linkRepository = linkRepository,
+            userLinkRepository = userLinkRepository,
+            tagWriteService = tagWriteService,
+            linkDocumentFetcher = linkDocumentFetcher,
+        )
+
+    @Test
+    @DisplayName("크롤링 가능한 첫 페이지이면 검증을 통과한다")
+    fun validateCrawlablePassesWhenFirstPageCanBeCrawled() {
+        val batch = createBatch(publishedAtSelectors = ".published-date")
+        linkDocumentFetcher.html = crawlableHtml()
+
+        linkBatchRunService.validateCrawlable(batch)
+
+        verify(exactly = 0) { linkRepository.save(any()) }
+    }
+
+    @Test
+    @DisplayName("첫 페이지에 수집 가능한 항목이 없으면 검증이 실패한다")
+    fun validateCrawlableFailsWhenNoItemCanBeCrawled() {
+        val batch = createBatch(publishedAtSelectors = ".published-date")
+        linkDocumentFetcher.html = "<html><body></body></html>"
+
+        val exception =
+            assertFailsWith<ApiException> {
+                linkBatchRunService.validateCrawlable(batch)
+            }
+
+        assertEquals(LinkStatus.LINK_CRAWL_BATCH_NOT_CRAWLABLE, exception.status)
+    }
+
+    @Test
+    @DisplayName("검증 중 발행일을 수집할 수 없으면 검증이 실패한다")
+    fun validateCrawlableFailsWhenPublishedAtCannotBeCollected() {
+        val batch = createBatch(publishedAtSelectors = ".missing-date")
+        linkDocumentFetcher.html = crawlableHtml()
+
+        val exception =
+            assertFailsWith<ApiException> {
+                linkBatchRunService.validateCrawlable(batch)
+            }
+
+        assertEquals(LinkStatus.LINK_CRAWL_BATCH_PUBLISHED_AT_REQUIRED, exception.status)
+    }
+
+    @Test
+    @DisplayName("배치 실행 중 발행일을 수집할 수 없으면 배치를 실패시킨다")
+    fun runFailsWhenPublishedAtCannotBeCollected() {
+        val batchId = UUID.randomUUID()
+        val batch = createBatch(publishedAtSelectors = ".missing-date").apply { id = batchId }
+        linkDocumentFetcher.html = crawlableHtml()
+        every { linkCrawlBatchRepository.findById(batchId) } returns Optional.of(batch)
+
+        val exception =
+            assertFailsWith<ApiException> {
+                linkBatchRunService.run(batchId)
+            }
+
+        assertEquals(LinkStatus.LINK_CRAWL_BATCH_PUBLISHED_AT_REQUIRED, exception.status)
+        verify(exactly = 0) { linkRepository.save(any()) }
+    }
+
+    private fun createBatch(publishedAtSelectors: String): LinkCrawlBatch {
+        return LinkCrawlBatch(
+            companyUser =
+                User(
+                    name = "토스",
+                    email = "company@example.com",
+                    provider = OAuthProvider.SYSTEM,
+                    identifier = "company",
+                    role = UserRole.COMPANY,
+                    profileImageUrl = "https://example.com/company.png",
+                ).apply { id = UUID.randomUUID() },
+            name = "토스 링크 수집",
+            baseUrl = "https://example.com",
+            pageUriTemplate = "/articles?page={page}",
+            itemSelector = ".article-card",
+            articleLinkSelector = "a.article-link",
+            titleSelector = ".title",
+            summarySelector = ".summary",
+            publishedAtSelectors = publishedAtSelectors,
+            cronExpression = "0 0 * * * *",
+            startPage = 1,
+            active = true,
+            tagNames = "engineering",
+        )
+    }
+
+    private fun crawlableHtml(): String {
+        return """
+            <html>
+              <body>
+                <div class="article-card">
+                  <a class="article-link" href="/article/metric-review">
+                    <div class="title">Metric Review, 실행을 이끌다</div>
+                    <div class="summary">지표 리뷰로 실행 리듬을 만든 이야기입니다.</div>
+                    <div class="published-date">2026년 4월 20일</div>
+                  </a>
+                </div>
+              </body>
+            </html>
+            """.trimIndent()
+    }
+
+    private class StubLinkDocumentFetcher : LinkDocumentFetcher {
+        var html: String = ""
+
+        override fun fetch(url: String): Document {
+            return Jsoup.parse(html, url)
+        }
+    }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkCrawlBatchAdminServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkCrawlBatchAdminServiceTest.kt
@@ -1,0 +1,117 @@
+package com.techtaurant.mainserver.link.application
+
+import com.techtaurant.mainserver.link.dto.CreateLinkCrawlBatchRequest
+import com.techtaurant.mainserver.link.dto.UpdateLinkCrawlBatchRequest
+import com.techtaurant.mainserver.link.entity.LinkCrawlBatch
+import com.techtaurant.mainserver.link.infrastructure.out.LinkCrawlBatchRepository
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.Optional
+import java.util.UUID
+import kotlin.test.assertEquals
+
+@DisplayName("LinkCrawlBatchAdminService 테스트")
+class LinkCrawlBatchAdminServiceTest {
+    private val linkCrawlBatchRepository: LinkCrawlBatchRepository = mockk()
+    private val userRepository: UserRepository = mockk()
+    private val linkBatchRunService: LinkBatchRunService = mockk()
+    private val linkCrawlBatchAdminService =
+        LinkCrawlBatchAdminService(
+            linkCrawlBatchRepository = linkCrawlBatchRepository,
+            userRepository = userRepository,
+            linkBatchRunService = linkBatchRunService,
+        )
+
+    @Test
+    @DisplayName("배치 등록 전 크롤링 가능 여부를 검증한다")
+    fun createBatchValidatesCrawlableBatch() {
+        val companyUser = createCompanyUser()
+        val batchId = UUID.randomUUID()
+        every { userRepository.findById(companyUser.id!!) } returns Optional.of(companyUser)
+        every { linkBatchRunService.validateCrawlable(any()) } just runs
+        every { linkCrawlBatchRepository.save(any()) } answers {
+            firstArg<LinkCrawlBatch>().apply { id = batchId }
+        }
+
+        val response =
+            linkCrawlBatchAdminService.createBatch(
+                companyUserId = companyUser.id!!,
+                request =
+                    CreateLinkCrawlBatchRequest(
+                        name = "토스 링크 수집",
+                        baseUrl = "https://example.com",
+                        pageUriTemplate = "/articles?page={page}",
+                        itemSelector = ".article-card",
+                        articleLinkSelector = "a.article-link",
+                        titleSelector = ".title",
+                        summarySelector = ".summary",
+                        publishedAtSelectors = listOf(".published-date"),
+                        tagNames = listOf("engineering"),
+                        cronExpression = "0 0 * * * *",
+                        startPage = 1,
+                        active = true,
+                    ),
+            )
+
+        assertEquals(batchId, response.id)
+        assertEquals("토스 링크 수집", response.name)
+        verify(exactly = 1) { linkBatchRunService.validateCrawlable(any()) }
+    }
+
+    @Test
+    @DisplayName("배치 수정 후 크롤링 가능 여부를 검증한다")
+    fun updateBatchValidatesCrawlableBatch() {
+        val batchId = UUID.randomUUID()
+        val batch = createBatch().apply { id = batchId }
+        every { linkCrawlBatchRepository.findById(batchId) } returns Optional.of(batch)
+        every { linkBatchRunService.validateCrawlable(batch) } just runs
+
+        val response =
+            linkCrawlBatchAdminService.updateBatch(
+                batchId = batchId,
+                request = UpdateLinkCrawlBatchRequest(name = "수정된 배치", active = false),
+            )
+
+        assertEquals("수정된 배치", response.name)
+        assertEquals(false, response.active)
+        verify(exactly = 1) { linkBatchRunService.validateCrawlable(batch) }
+    }
+
+    private fun createBatch(): LinkCrawlBatch {
+        return LinkCrawlBatch(
+            companyUser = createCompanyUser(),
+            name = "토스 링크 수집",
+            baseUrl = "https://example.com",
+            pageUriTemplate = "/articles?page={page}",
+            itemSelector = ".article-card",
+            articleLinkSelector = "a.article-link",
+            titleSelector = ".title",
+            summarySelector = ".summary",
+            publishedAtSelectors = ".published-date",
+            tagNames = "engineering",
+            cronExpression = "0 0 * * * *",
+            startPage = 1,
+            active = true,
+        )
+    }
+
+    private fun createCompanyUser(): User {
+        return User(
+            name = "토스",
+            email = "company@example.com",
+            provider = OAuthProvider.SYSTEM,
+            identifier = "company",
+            role = UserRole.COMPANY,
+            profileImageUrl = "https://example.com/company.png",
+        ).apply { id = UUID.randomUUID() }
+    }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/in/AdminLinkCrawlBatchControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/in/AdminLinkCrawlBatchControllerIntegrationTest.kt
@@ -16,7 +16,9 @@ import com.techtaurant.mainserver.user.enums.UserRole
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import io.restassured.RestAssured.given
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasKey
 import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.not
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -188,9 +190,13 @@ class AdminLinkCrawlBatchControllerIntegrationTest : IntegrationTest() {
                 .then()
                 .statusCode(HttpStatus.CREATED.value())
                 .body("data.name", equalTo("토스 엔지니어링 링크 수집"))
+                .body("data", not(hasKey("canCrawl")))
                 .body("data.tagNames", hasSize<Any>(2))
                 .extract()
                 .path<String>("data.id")
+        assertEquals(1, pageRequestCount(1))
+        assertEquals(0, pageRequestCount(2))
+        assertTrue(linkRepository.findAll().isEmpty())
 
         given()
             .header("Authorization", "Bearer $adminAccessToken")
@@ -229,10 +235,77 @@ class AdminLinkCrawlBatchControllerIntegrationTest : IntegrationTest() {
             .body("data.newLinkCount", equalTo(0))
             .body("data.existingLinkCount", equalTo(2))
 
-        assertEquals(2, pageRequestCount(1))
+        assertEquals(3, pageRequestCount(1))
         assertEquals(1, pageRequestCount(2))
         assertTrue(linkRepository.findAllWithTags().all { link -> link.tags.none { it.name == "new-tag" } })
         assertEquals(null, tagRepository.findByName("new-tag"))
+    }
+
+    @Test
+    @DisplayName("배치 등록 시 발행일을 수집할 수 없으면 등록이 실패한다")
+    fun createBatchFailsWhenPublishedAtCannotBeCollected() {
+        given()
+            .contentType("application/json")
+            .header("Authorization", "Bearer $adminAccessToken")
+            .body(
+                """
+                {
+                  "name": "날짜 selector 오류 배치",
+                  "baseUrl": "$crawlerBaseUrl",
+                  "pageUriTemplate": "/category/engineering?page={page}",
+                  "itemSelector": ".article-card",
+                  "articleLinkSelector": "a.article-link",
+                  "titleSelector": ".title",
+                  "summarySelector": ".summary",
+                  "publishedAtSelectors": [".missing-date"],
+                  "tagNames": ["engineering"],
+                  "cronExpression": "0 0 * * * *",
+                  "startPage": 1,
+                  "active": true
+                }
+                """.trimIndent(),
+            ).`when`()
+            .post("/admin/companies/${companyUser.id}/link-crawl-batches")
+            .then()
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .body("status", equalTo(6006))
+
+        assertEquals(1, pageRequestCount(1))
+        assertTrue(linkCrawlBatchRepository.findAll().isEmpty())
+    }
+
+    @Test
+    @DisplayName("배치 실행 중 발행일을 수집할 수 없으면 배치가 실패한다")
+    fun runBatchFailsWhenPublishedAtCannotBeCollected() {
+        val batch =
+            linkCrawlBatchRepository.save(
+                LinkCrawlBatch(
+                    companyUser = companyUser,
+                    name = "날짜 selector 오류 배치",
+                    baseUrl = crawlerBaseUrl,
+                    pageUriTemplate = "/category/engineering?page={page}",
+                    itemSelector = ".article-card",
+                    articleLinkSelector = "a.article-link",
+                    titleSelector = ".title",
+                    summarySelector = ".summary",
+                    publishedAtSelectors = ".missing-date",
+                    cronExpression = "0 0 * * * *",
+                    startPage = 1,
+                    active = true,
+                    tagNames = "engineering",
+                ),
+            )
+
+        given()
+            .header("Authorization", "Bearer $adminAccessToken")
+            .`when`()
+            .post("/admin/link-crawl-batches/${batch.id}/run")
+            .then()
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .body("status", equalTo(6006))
+
+        assertEquals(1, pageRequestCount(1))
+        assertTrue(linkRepository.findAll().isEmpty())
     }
 
     @Test
@@ -307,7 +380,7 @@ class AdminLinkCrawlBatchControllerIntegrationTest : IntegrationTest() {
                     articleLinkSelector = "a.article-link",
                     titleSelector = ".title",
                     summarySelector = ".summary",
-                    publishedAtSelectors = "time",
+                    publishedAtSelectors = "div.o6bzluc",
                     cronExpression = "0 0 * * * *",
                     startPage = 1,
                     active = true,
@@ -323,6 +396,11 @@ class AdminLinkCrawlBatchControllerIntegrationTest : IntegrationTest() {
             .statusCode(HttpStatus.OK.value())
             .body("data", hasSize<Any>(1))
             .body("data[0].name", equalTo("초기 배치"))
+            .body("data[0].baseUrl", equalTo(crawlerBaseUrl))
+            .body("data[0]", not(hasKey("pageUriTemplate")))
+            .body("data[0]", not(hasKey("itemSelector")))
+            .body("data[0]", not(hasKey("tagNames")))
+            .body("data[0]", not(hasKey("canCrawl")))
 
         given()
             .contentType("application/json")
@@ -341,8 +419,13 @@ class AdminLinkCrawlBatchControllerIntegrationTest : IntegrationTest() {
             .statusCode(HttpStatus.OK.value())
             .body("data.name", equalTo("수정된 배치"))
             .body("data.active", equalTo(false))
+            .body("data", not(hasKey("canCrawl")))
             .body("data.tagNames", hasSize<Any>(1))
             .body("data.tagNames[0]", equalTo("infra"))
+
+        assertEquals(1, pageRequestCount(1))
+        assertEquals(0, pageRequestCount(2))
+        assertTrue(linkRepository.findAll().isEmpty())
     }
 
     private fun resolvePage(query: String?): Int {


### PR DESCRIPTION
## 어떤 작업인가요?
- 링크 수집 배치가 등록, 수정, 실행될 때 발행일을 포함한 실제 크롤링 가능 여부를 더 엄격하게 검증하도록 변경합니다.
- 크롤링 수집 단계에서 호출되는 private 함수명이 역할과 호출 맥락을 더 잘 드러나도록 정리합니다.

## 어떻게 해결했나요?
**배치 설정 검증 강화**
- 배치 등록과 수정 시 시작 페이지를 실제로 요청해 수집 가능한 항목이 있는지 검증합니다.
- 발행일을 수집할 수 없는 항목은 배치 실행 중 실패하도록 처리합니다.

**목록 응답 분리**
- 배치 목록 조회 응답을 요약 전용 DTO로 분리해 상세 selector와 tagNames를 목록에서 제외합니다.

**크롤링 수집 함수명 명확화**
- `collectLinkItem`을 `collectLinkFromCrawledItem`으로 변경해 크롤링된 아이템에서 링크를 수집하는 함수임을 드러냅니다.

**문서와 테스트 보강**
- Swagger 문서에 크롤링 검증 및 발행일 필수 오류를 반영합니다.
- 배치 실행 서비스, 관리자 서비스, 관리자 API 통합 테스트를 보강합니다.

## 중요한 변경 사항은 무엇인가요?
### 크롤링 가능 여부 검증

**등록/수정 전 검증 추가**
- **변경 이유**: 잘못된 selector나 발행일 설정이 저장된 뒤 배치 실행 시점에만 실패하는 문제를 줄이기 위함입니다.
- **수정 파일**: `LinkCrawlBatchAdminService.kt`, `LinkBatchRunService.kt`

**발행일 필수화**
- **변경 이유**: 링크 수집 결과가 발행일 없이 저장되지 않도록 배치 수집 품질을 보장하기 위함입니다.
- **수정 파일**: `LinkBatchRunService.kt`, `LinkStatus.kt`

### 배치 목록 응답 축소

**목록 전용 응답 DTO 추가**
- **변경 이유**: 목록 조회에서는 상세 크롤링 설정 필드를 노출하지 않고 필요한 요약 정보만 반환하기 위함입니다.
- **수정 파일**: `LinkCrawlBatchListItemResponse.kt`, `AdminLinkCrawlBatchController.kt`

### 크롤링 수집 흐름 명확화

**private 함수명 변경**
- **변경 이유**: 함수가 일반 링크 아이템 수집이 아니라 크롤링된 페이지 아이템 처리 흐름에서 사용됨을 명확히 하기 위함입니다.
- **수정 파일**: `LinkBatchRunService.kt`

Co-Authored-By: OpenAI Codex <codex@openai.com>
