### PR TITLE
feat(link): 링크 발행일 절대 날짜 파싱 형식 확대

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkBatchRunService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkBatchRunService.kt
@@ -35,7 +35,7 @@ class LinkBatchRunService(
     private val linkDocumentFetcher: LinkDocumentFetcher,
 ) {
     companion object {
-        private val KOREAN_DATE_REGEX = Regex("""^\s*(\d{4})년\s*(\d{1,2})월\s*(\d{1,2})일\s*$""")
+        private val ABSOLUTE_DATE_REGEX = Regex("""^\s*(\d{4})\s*(?:[./-]|년)\s*(\d{1,2})\s*(?:[./-]|월)\s*(\d{1,2})\s*(?:일)?\s*\.?\s*$""")
     }
 
     @Transactional
@@ -330,11 +330,11 @@ class LinkBatchRunService(
             ?: runCatching { ZonedDateTime.parse(rawValue).toInstant() }.getOrNull()
             ?: runCatching { LocalDateTime.parse(rawValue).toInstant(ZoneOffset.UTC) }.getOrNull()
             ?: runCatching { LocalDate.parse(rawValue).atStartOfDay().toInstant(ZoneOffset.UTC) }.getOrNull()
-            ?: parseKoreanDate(rawValue)
+            ?: parseAbsoluteDate(rawValue)
     }
 
-    private fun parseKoreanDate(rawValue: String): Instant? {
-        val match = KOREAN_DATE_REGEX.matchEntire(rawValue) ?: return null
+    private fun parseAbsoluteDate(rawValue: String): Instant? {
+        val match = ABSOLUTE_DATE_REGEX.matchEntire(rawValue) ?: return null
         val (year, month, day) = match.destructured
 
         return runCatching {

--- a/src/main/kotlin/com/techtaurant/mainserver/link/dto/CreateLinkCrawlBatchRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/dto/CreateLinkCrawlBatchRequest.kt
@@ -33,7 +33,13 @@ data class CreateLinkCrawlBatchRequest(
     val titleSelector: String,
     @field:Schema(description = "카드 내부 요약 selector", example = "div._13swo3b8", nullable = true)
     val summarySelector: String? = null,
-    @field:ArraySchema(schema = Schema(description = "발행일 selector. ISO 날짜/시간 또는 '2023년 6월 20일' 형식의 텍스트를 읽습니다.", example = "div.o6bzluc"))
+    @field:ArraySchema(
+        schema =
+            Schema(
+                description = "발행일 selector. ISO 날짜/시간, '2023년 6월 20일', '2023. 6. 20', '2023/6/20' 형식의 텍스트를 읽습니다.",
+                example = "div.o6bzluc",
+            ),
+    )
     val publishedAtSelectors: List<String> = emptyList(),
     @field:Size(max = TaggedContent.MAX_TAG_COUNT, message = "태그는 최대 10개까지 설정할 수 있습니다")
     @field:ArraySchema(maxItems = TaggedContent.MAX_TAG_COUNT, schema = Schema(description = "수집된 링크에 부여할 태그명", example = "toss-tech"))

--- a/src/main/kotlin/com/techtaurant/mainserver/link/dto/UpdateLinkCrawlBatchRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/dto/UpdateLinkCrawlBatchRequest.kt
@@ -26,7 +26,13 @@ data class UpdateLinkCrawlBatchRequest(
     val titleSelector: String? = null,
     @field:Schema(description = "카드 내부 요약 selector", example = "div._13swo3b8", nullable = true)
     val summarySelector: String? = null,
-    @field:ArraySchema(schema = Schema(description = "발행일 selector. ISO 날짜/시간 또는 '2023년 6월 20일' 형식의 텍스트를 읽습니다.", example = "div.o6bzluc"))
+    @field:ArraySchema(
+        schema =
+            Schema(
+                description = "발행일 selector. ISO 날짜/시간, '2023년 6월 20일', '2023. 6. 20', '2023/6/20' 형식의 텍스트를 읽습니다.",
+                example = "div.o6bzluc",
+            ),
+    )
     val publishedAtSelectors: List<String>? = null,
     @field:Size(max = TaggedContent.MAX_TAG_COUNT, message = "태그는 최대 10개까지 설정할 수 있습니다")
     @field:ArraySchema(maxItems = TaggedContent.MAX_TAG_COUNT, schema = Schema(description = "수집된 링크에 부여할 태그명", example = "toss-tech"))

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/AdminLinkCrawlBatchControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/AdminLinkCrawlBatchControllerDocs.kt
@@ -52,7 +52,7 @@ interface AdminLinkCrawlBatchControllerDocs {
         - `body > div...`처럼 페이지 전체 경로 selector는 피합니다.
         - selector는 짧고 재사용 가능해야 합니다.
         - CSR이 아니라 SSR만 대상으로 합니다.
-        - 발행일은 ISO 날짜/시간 또는 `2023년 6월 20일` 형식의 텍스트를 지원합니다.
+        - 발행일은 ISO 날짜/시간, `2023년 6월 20일`, `2023. 6. 20`, `2023/6/20` 형식의 텍스트를 지원합니다.
         """,
     )
     @SwaggerApiResponse(responseCode = "201", description = "배치 등록 성공")

--- a/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkBatchRunServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkBatchRunServiceTest.kt
@@ -50,6 +50,17 @@ class LinkBatchRunServiceTest {
     }
 
     @Test
+    @DisplayName("점 구분 발행일이면 크롤링 가능 검증을 통과한다")
+    fun validateCrawlablePassesWhenPublishedAtUsesDottedDate() {
+        val batch = createBatch(publishedAtSelectors = ".published-date")
+        linkDocumentFetcher.html = crawlableHtml(publishedAtText = "2026. 6. 12")
+
+        linkBatchRunService.validateCrawlable(batch)
+
+        verify(exactly = 0) { linkRepository.save(any()) }
+    }
+
+    @Test
     @DisplayName("첫 페이지에 수집 가능한 항목이 없으면 검증이 실패한다")
     fun validateCrawlableFailsWhenNoItemCanBeCrawled() {
         val batch = createBatch(publishedAtSelectors = ".published-date")
@@ -120,7 +131,7 @@ class LinkBatchRunServiceTest {
         )
     }
 
-    private fun crawlableHtml(): String {
+    private fun crawlableHtml(publishedAtText: String = "2026년 4월 20일"): String {
         return """
             <html>
               <body>
@@ -128,7 +139,7 @@ class LinkBatchRunServiceTest {
                   <a class="article-link" href="/article/metric-review">
                     <div class="title">Metric Review, 실행을 이끌다</div>
                     <div class="summary">지표 리뷰로 실행 리듬을 만든 이야기입니다.</div>
-                    <div class="published-date">2026년 4월 20일</div>
+                    <div class="published-date">$publishedAtText</div>
                   </a>
                 </div>
               </body>


### PR DESCRIPTION
## 어떤 작업인가요?
- 링크 수집 배치가 연도 우선 절대 날짜 텍스트를 더 넓게 파싱하도록 발행일 수집 형식을 확장합니다.

## 어떻게 해결했나요?
**발행일 파서 일반화**
- 한국어 날짜 전용 fallback을 명확한 연월일 패밀리 fallback으로 바꿨습니다.
- `2026년 6월 12일`, `2026. 6. 12`, `2026/6/12`, `2026-6-12` 계열을 UTC 자정 `Instant`로 변환합니다.

**API 문서 동기화**
- create/update DTO와 관리자 배치 Swagger 설명에 지원 날짜 형식을 반영했습니다.

## 중요한 변경 사항은 무엇인가요?
### 링크 수집 배치 발행일 파싱

**연도 우선 절대 날짜 지원 확대**
- **변경 이유**: 카카오페이 기술 블로그처럼 `time` 텍스트가 `2026. 6. 12` 형태인 SSR 목록을 배치로 등록할 수 있게 하기 위함입니다.
- **수정 파일**: `LinkBatchRunService.kt`, `LinkBatchRunServiceTest.kt`

**문서화된 API 계약 갱신**
- **변경 이유**: dev-api 사용자와 batch 생성 도구가 실제 지원 형식을 기준으로 selector plan을 검증할 수 있게 하기 위함입니다.
- **수정 파일**: `CreateLinkCrawlBatchRequest.kt`, `UpdateLinkCrawlBatchRequest.kt`, `AdminLinkCrawlBatchControllerDocs.kt`

Co-Authored-By: OpenAI Codex <codex@openai.com>
