### PR TITLE
fix(link): PUBLISHED 정렬 기간 필터 적용

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkReadService.kt
@@ -62,7 +62,7 @@ class LinkReadService(
     /**
      * 공개 링크 정적 콘텐츠 목록을 명시적 정렬/기간과 함께 커서 기반으로 조회합니다 (v1).
      *
-     * - PUBLISHED: 링크 생성일 최신순
+     * - PUBLISHED: 기간(period) 내 링크 생성일 최신순
      * - LIKE/SAVE: 기간(period) 윈도우 내 일별 좋아요/저장 집계 합 기준 (period=ALL이면 전체 누적)
      *
      * 커서는 정렬 타입을 포함하며, 요청 sort와 커서의 정렬 타입이 다르면 INVALID_LINK_CURSOR를 반환합니다.

--- a/src/main/kotlin/com/techtaurant/mainserver/link/enums/LinkPeriod.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/enums/LinkPeriod.kt
@@ -3,7 +3,7 @@ package com.techtaurant.mainserver.link.enums
 /**
  * 공개 링크 조회 기간 필터
  *
- * LIKE/SAVE 정렬의 일별 집계 윈도우를 결정합니다. PUBLISHED 정렬에는 적용되지 않습니다.
+ * PUBLISHED 정렬에서는 링크 생성일 필터를, LIKE/SAVE 정렬에서는 일별 집계 윈도우를 결정합니다.
  *
  * @property days 필터링할 일수 (null이면 전체 기간)
  */

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkReadOpenApiV1ControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkReadOpenApiV1ControllerDocs.kt
@@ -25,10 +25,10 @@ interface LinkReadOpenApiV1ControllerDocs {
             "SSG/ISR 캐싱에 적합한 링크 정적 콘텐츠 목록을 명시적 정렬/기간 기준으로 조회합니다. " +
                 "로그인 사용자의 저장/읽음 상태는 포함하지 않습니다.\n\n" +
                 "정렬(sort)\n" +
-                "- PUBLISHED: 링크 생성일 최신순\n" +
+                "- PUBLISHED: 기간 내 링크 생성일 최신순\n" +
                 "- LIKE: 기간 내 일별 좋아요 집계 합 기준\n" +
                 "- SAVE: 기간 내 일별 저장 집계 합 기준\n\n" +
-                "기간(period)은 LIKE/SAVE 정렬의 일별 집계 윈도우를 결정하며 PUBLISHED 정렬에는 적용되지 않습니다. " +
+                "기간(period)은 PUBLISHED 정렬의 링크 생성일 필터와 LIKE/SAVE 정렬의 일별 집계 윈도우를 결정합니다. " +
                 "LIKE/SAVE 정렬은 해당 기간 내 좋아요/저장 기록이 있는 링크만 포함합니다. " +
                 "nextCursor는 요청한 정렬에 종속되며, 다른 정렬로 이어서 요청하면 INVALID_LINK_CURSOR를 반환합니다.",
     )
@@ -43,7 +43,7 @@ interface LinkReadOpenApiV1ControllerDocs {
         @Parameter(description = "이전 응답의 nextCursor (첫 페이지는 생략)") cursor: String?,
         @Parameter(description = "페이지 크기 (1-100, 기본값 20)") @Min(1) @Max(100) size: Int,
         @Parameter(description = "정렬 기준 (PUBLISHED: 생성일순, LIKE: 좋아요순, SAVE: 저장순)") sort: LinkSortType,
-        @Parameter(description = "기간 필터 (WEEK: 7일, MONTH: 30일, YEAR: 365일, ALL: 전체). LIKE/SAVE 정렬에만 적용") period: LinkPeriod,
+        @Parameter(description = "기간 필터 (WEEK: 7일, MONTH: 30일, YEAR: 365일, ALL: 전체)") period: LinkPeriod,
         @Parameter(description = "출처 회사 사용자 ID 필터 (생략 시 전체 조회)") sourceCompanyUserId: UUID?,
         @Parameter(description = "링크 태그명 필터 (생략 시 전체 조회)") tag: String?,
     ): ApiResponse<CursorPageResponse<LinkContentListItemResponse>>

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/LinkRepositoryCustom.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/LinkRepositoryCustom.kt
@@ -18,7 +18,7 @@ interface LinkRepositoryCustom {
      * @param cursor 커서 (null이면 첫 페이지)
      * @param limit 조회 개수 (hasNext 판별을 위해 보통 size + 1을 전달)
      * @param sortType 정렬 타입
-     * @param period 기간 필터 (LIKE/SAVE의 일별 집계 윈도우, PUBLISHED는 미적용)
+     * @param period 기간 필터 (PUBLISHED는 생성일, LIKE/SAVE는 일별 집계 윈도우)
      * @param sourceCompanyUserId 출처 회사 사용자 ID 필터 (null이면 전체)
      * @param tag 태그명 필터 (null이면 전체)
      * @return 정렬 순서를 유지한 ID + 정렬값 목록

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/LinkRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/LinkRepositoryCustomImpl.kt
@@ -26,13 +26,14 @@ import org.springframework.stereotype.Repository
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 /**
  * 공개 링크 동적 정렬/페이지네이션 구현체 (v1)
  *
  * JPA Criteria API와 Metamodel을 사용해 정렬 타입별 키셋 커서 페이지네이션을 지원합니다.
- * - PUBLISHED: 링크 생성일 기준 정렬
+ * - PUBLISHED: 링크 생성일 기간 필터 및 생성일 기준 정렬
  * - LIKE/SAVE: LinkDailyStats를 기간 윈도우로 집계한 합 기준 정렬
  */
 @Repository
@@ -49,7 +50,8 @@ class LinkRepositoryCustomImpl : LinkRepositoryCustom {
         tag: String?,
     ): List<RankedLinkId> =
         when (sortType) {
-            LinkSortType.PUBLISHED -> findCreatedAtRankedIds(cursor, limit, sourceCompanyUserId, tag)
+            LinkSortType.PUBLISHED ->
+                findCreatedAtRankedIds(cursor, limit, period, sourceCompanyUserId, tag)
             LinkSortType.LIKE, LinkSortType.SAVE ->
                 findStatsRankedIds(cursor, limit, sortType, period, sourceCompanyUserId, tag)
         }
@@ -57,6 +59,7 @@ class LinkRepositoryCustomImpl : LinkRepositoryCustom {
     private fun findCreatedAtRankedIds(
         cursor: LinkCursorV1?,
         limit: Int,
+        period: LinkPeriod,
         sourceCompanyUserId: UUID?,
         tag: String?,
     ): List<RankedLinkId> {
@@ -66,6 +69,7 @@ class LinkRepositoryCustomImpl : LinkRepositoryCustom {
         val predicates = mutableListOf<Predicate>()
 
         addBaseConditions(cb, cq, root, sourceCompanyUserId, tag, predicates)
+        addCreatedAtPeriodCondition(cb, root, period, predicates)
         cursor?.let { predicates.add(buildCreatedAtCursorCondition(cb, root, it)) }
 
         cq.select(root.get(EntityBase_.id))
@@ -165,6 +169,20 @@ class LinkRepositoryCustomImpl : LinkRepositoryCustom {
             cb.equal(tagJoin.get(Tag_.name), tag),
         )
         predicates.add(cb.exists(subquery))
+    }
+
+    private fun addCreatedAtPeriodCondition(
+        cb: CriteriaBuilder,
+        root: Root<Link>,
+        period: LinkPeriod,
+        predicates: MutableList<Predicate>,
+    ) {
+        period.days?.let { days ->
+            val cutoffInstant = Instant.now().minus(days.toLong(), ChronoUnit.DAYS)
+            predicates.add(
+                cb.greaterThanOrEqualTo(root.get(EntityBase_.createdAt), cutoffInstant),
+            )
+        }
     }
 
     private fun addStatsJoinCondition(

--- a/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkReadOpenApiV1ControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkReadOpenApiV1ControllerIntegrationTest.kt
@@ -27,6 +27,7 @@ import org.springframework.transaction.support.TransactionTemplate
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 @DisplayName("LinkReadOpenApiV1Controller 통합 테스트")
@@ -117,6 +118,35 @@ class LinkReadOpenApiV1ControllerIntegrationTest : IntegrationTest() {
             .body("data.content[0].id", equalTo(oldest.id.toString()))
             .body("data.nextCursor", nullValue())
             .body("data.hasNext", equalTo(false))
+    }
+
+    @Test
+    @DisplayName("v1 PUBLISHED 정렬은 period 기준 생성일 필터를 적용한다")
+    fun getLinkContents_published_filtersByPeriod() {
+        val recent =
+            saveLink(
+                "Recent",
+                company,
+                createdAtMillis = 1_000,
+                createdAt = Instant.now().minus(1, ChronoUnit.DAYS),
+            )
+        saveLink(
+            "Stale",
+            company,
+            createdAtMillis = 2_000,
+            createdAt = Instant.now().minus(8, ChronoUnit.DAYS),
+        )
+
+        given()
+            .queryParam("sort", "PUBLISHED")
+            .queryParam("period", "WEEK")
+            .queryParam("size", 10)
+            .`when`()
+            .get("/open-api/v1/links")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.content", hasSize<Any>(1))
+            .body("data.content[0].id", equalTo(recent.id.toString()))
     }
 
     @Test

--- a/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/out/LinkRepositoryCustomImplTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/out/LinkRepositoryCustomImplTest.kt
@@ -88,6 +88,26 @@ class LinkRepositoryCustomImplTest : IntegrationTest() {
     }
 
     @Test
+    @DisplayName("PUBLISHED 정렬은 period 기준 생성일 필터를 적용한다")
+    fun findPublicLinkIds_published_filtersByCreatedAtPeriod() {
+        val recent = createLink(createdAtDaysAgo = 1)
+        val stale = createLink(createdAtDaysAgo = 8)
+
+        val result =
+            linkRepository.findPublicLinkIds(
+                cursor = null,
+                limit = 10,
+                sortType = LinkSortType.PUBLISHED,
+                period = LinkPeriod.WEEK,
+                sourceCompanyUserId = null,
+                tag = null,
+            )
+
+        assertThat(result.map { it.linkId }).containsExactly(recent.id)
+        assertThat(result.map { it.linkId }).doesNotContain(stale.id)
+    }
+
+    @Test
     @DisplayName("PUBLISHED 정렬 커서는 생성일 기준으로 다음 페이지를 이어 조회한다")
     fun findPublicLinkIds_published_paginatesByCursor() {
         val newest = createLink(createdAt = Instant.parse("2026-04-03T00:00:00Z"))


### PR DESCRIPTION
## 어떤 작업인가요?
- `/open-api/v1/links`의 `PUBLISHED` 정렬에서 `period`가 무시되어 1주일 이전 링크가 반환되던 문제를 수정합니다.

## 어떻게 해결했나요?
**PUBLISHED 기간 필터 적용**
- `PUBLISHED` 정렬 조회 경로에도 `period` 값을 전달하도록 변경했습니다.
- 링크 생성일 기준으로 `WEEK`, `MONTH`, `YEAR` 기간 조건을 적용하도록 Repository 조건을 추가했습니다.

**회귀 테스트 추가**
- v1 공개 링크 API 통합 테스트에 `PUBLISHED + WEEK` 필터 케이스를 추가했습니다.
- Repository 통합 테스트에 생성일 기간 필터 검증 케이스를 추가했습니다.

## 중요한 변경 사항은 무엇인가요?
### 링크 목록 기간 필터

**PUBLISHED 정렬의 period 적용**
- **변경 이유**: `sort=PUBLISHED&period=WEEK` 요청에서 생성일이 7일보다 오래된 링크가 반환되는 문제를 막기 위해서입니다.
- **수정 파일**: `LinkRepositoryCustomImpl.kt`, `LinkRepositoryCustom.kt`, `LinkPeriod.kt`, `LinkReadService.kt`, `LinkReadOpenApiV1ControllerDocs.kt`

**테스트 보강**
- **변경 이유**: 컨트롤러와 Repository 양쪽에서 동일한 회귀를 방지하기 위해서입니다.
- **수정 파일**: `LinkReadOpenApiV1ControllerIntegrationTest.kt`, `LinkRepositoryCustomImplTest.kt`

Co-Authored-By: Codex <codex@openai.com>
