### PR TITLE
feat(link): 목록에 생성일 없으면 아티클 상세 페이지에서 생성일 수집

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkBatchRunService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkBatchRunService.kt
@@ -256,7 +256,7 @@ class LinkBatchRunService(
 
         val summary = batch.summarySelector?.let { resolveText(item, it) }.orEmpty()
         val createdAt =
-            parseCreatedAt(firstResolvedValue(item, batch.createdAtSelectors))
+            resolveCreatedAt(item, absoluteUrl, batch)
                 ?: throw ApiException(LinkStatus.LINK_CRAWL_BATCH_CREATED_AT_REQUIRED)
 
         return LinkSnapshot(
@@ -265,6 +265,47 @@ class LinkBatchRunService(
             summary = summary,
             createdAt = createdAt,
         )
+    }
+
+    /**
+     * 생성일을 목록 카드에서 먼저 찾고, 없으면 아티클 상세 페이지를 조회해 추출한다.
+     * 토스테크처럼 목록에는 날짜가 없고 상세 페이지에만 날짜가 있는 블로그를 지원한다.
+     *
+     * @param item 목록 페이지에서 선택된 카드 엘리먼트
+     * @param articleUrl 카드에서 추출한 아티클 상세 페이지의 절대 URL
+     * @param batch 생성일 셀렉터를 포함한 크롤 배치 설정
+     * @return 파싱된 생성일, 목록과 상세 페이지 어디에서도 찾지 못하면 null
+     */
+    private fun resolveCreatedAt(
+        item: Element,
+        articleUrl: String,
+        batch: LinkCrawlBatch,
+    ): Instant? {
+        val createdAtFromListItem = parseCreatedAt(firstResolvedValue(item, batch.createdAtSelectors))
+        if (createdAtFromListItem != null) {
+            return createdAtFromListItem
+        }
+
+        return parseCreatedAtFromArticlePage(articleUrl, batch.createdAtSelectors)
+    }
+
+    /**
+     * 아티클 상세 페이지를 조회해 생성일을 추출한다.
+     *
+     * @param articleUrl 조회할 아티클 상세 페이지의 절대 URL
+     * @param createdAtSelectors 줄바꿈으로 구분된 생성일 셀렉터 목록
+     * @return 파싱된 생성일, 셀렉터가 비었거나 상세 페이지 조회/파싱에 실패하면 null
+     */
+    private fun parseCreatedAtFromArticlePage(
+        articleUrl: String,
+        createdAtSelectors: String?,
+    ): Instant? {
+        if (createdAtSelectors.isNullOrBlank()) {
+            return null
+        }
+
+        val articleDocument = fetchPageOrNull(articleUrl) ?: return null
+        return parseCreatedAt(firstResolvedValue(articleDocument, createdAtSelectors))
     }
 
     private fun resolveLinkTagNames(rawTagNames: String?): List<String> =

--- a/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkBatchRunServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkBatchRunServiceTest.kt
@@ -61,6 +61,36 @@ class LinkBatchRunServiceTest {
     }
 
     @Test
+    @DisplayName("목록에 생성일이 없으면 아티클 상세 페이지에서 생성일을 수집한다")
+    fun validateCrawlablePassesWhenCreatedAtOnlyExistsOnArticlePage() {
+        val batch = createBatch(createdAtSelectors = ".created-date")
+        linkDocumentFetcher.setHtml("https://example.com/articles?page=1", listHtmlWithoutCreatedAt())
+        linkDocumentFetcher.setHtml("https://example.com/article/metric-review", articleDetailHtml())
+
+        linkBatchRunService.validateCrawlable(batch)
+
+        verify(exactly = 0) { linkRepository.save(any()) }
+    }
+
+    @Test
+    @DisplayName("목록과 상세 페이지 모두 생성일이 없으면 검증이 실패한다")
+    fun validateCrawlableFailsWhenCreatedAtMissingOnBothListAndArticlePage() {
+        val batch = createBatch(createdAtSelectors = ".created-date")
+        linkDocumentFetcher.setHtml("https://example.com/articles?page=1", listHtmlWithoutCreatedAt())
+        linkDocumentFetcher.setHtml(
+            "https://example.com/article/metric-review",
+            "<html><body><div class=\"title\">상세</div></body></html>",
+        )
+
+        val exception =
+            assertFailsWith<ApiException> {
+                linkBatchRunService.validateCrawlable(batch)
+            }
+
+        assertEquals(LinkStatus.LINK_CRAWL_BATCH_CREATED_AT_REQUIRED, exception.status)
+    }
+
+    @Test
     @DisplayName("첫 페이지에 수집 가능한 항목이 없으면 검증이 실패한다")
     fun validateCrawlableFailsWhenNoItemCanBeCrawled() {
         val batch = createBatch(createdAtSelectors = ".created-date")
@@ -147,11 +177,45 @@ class LinkBatchRunServiceTest {
             """.trimIndent()
     }
 
+    private fun listHtmlWithoutCreatedAt(): String {
+        return """
+            <html>
+              <body>
+                <div class="article-card">
+                  <a class="article-link" href="/article/metric-review">
+                    <div class="title">Metric Review, 실행을 이끌다</div>
+                    <div class="summary">지표 리뷰로 실행 리듬을 만든 이야기입니다.</div>
+                  </a>
+                </div>
+              </body>
+            </html>
+            """.trimIndent()
+    }
+
+    private fun articleDetailHtml(createdAtText: String = "2026년 4월 20일"): String {
+        return """
+            <html>
+              <body>
+                <h1>Metric Review, 실행을 이끌다</h1>
+                <div class="created-date">$createdAtText</div>
+              </body>
+            </html>
+            """.trimIndent()
+    }
+
     private class StubLinkDocumentFetcher : LinkDocumentFetcher {
         var html: String = ""
+        private val htmlByUrl = mutableMapOf<String, String>()
+
+        fun setHtml(
+            url: String,
+            value: String,
+        ) {
+            htmlByUrl[url] = value
+        }
 
         override fun fetch(url: String): Document {
-            return Jsoup.parse(html, url)
+            return Jsoup.parse(htmlByUrl[url] ?: html, url)
         }
     }
 }


### PR DESCRIPTION
## 배경
토스테크(toss.tech)처럼 **목록 페이지에는 발행일이 없고 아티클 상세 페이지에만** 발행일(`div.o6bzluc`)이 있는 블로그는 링크 수집 배치 등록 시 `validateCrawlable`에서 `LINK_CRAWL_BATCH_CREATED_AT_REQUIRED`(400)로 거부되어 등록이 불가능했다.

## 변경 사항
- `LinkBatchRunService.extractSnapshot`에서 생성일 추출 로직을 `resolveCreatedAt`로 분리하고, **목록 카드에서 생성일을 찾지 못하면 아티클 상세 페이지를 조회해 `publishedAtSelectors`로 생성일을 추출**하는 fallback을 추가
- 제목·요약·링크는 기존대로 목록 카드에서만 읽음
- 목록에 생성일이 있는 기존 블로그 동작은 변하지 않음 (목록 우선)

## 테스트
- 목록에 생성일이 없으면 아티클 상세 페이지에서 생성일을 수집한다 ✅
- 목록과 상세 페이지 모두 생성일이 없으면 검증이 실패한다 ✅
- 기존 테스트 포함 `LinkBatchRunServiceTest` 7개 전부 통과