### PR TITLE
feat(link): add user link write APIs

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/common/util/HtmlSanitizer.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/common/util/HtmlSanitizer.kt
@@ -1,5 +1,7 @@
 package com.techtaurant.mainserver.common.util
 
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.common.status.StatusIfs
 import org.jsoup.Jsoup
 import org.jsoup.safety.Cleaner
 import org.jsoup.safety.Safelist
@@ -97,5 +99,24 @@ object HtmlSanitizer {
      */
     fun sanitizeTitle(text: String): String {
         return Jsoup.clean(text, Safelist.none())
+    }
+
+    /**
+     * 모든 HTML 태그를 제거하고 공백을 정리한 필수 plain text를 반환합니다.
+     * sanitize 결과가 비어 있으면 전달받은 상태 코드로 예외를 던집니다.
+     *
+     * @param text sanitize할 문자열
+     * @param blankStatus sanitize 결과가 공백일 때 던질 상태 코드
+     * @return 태그가 제거되고 trim된 비어 있지 않은 plain text
+     */
+    fun sanitizeRequiredPlainText(
+        text: String,
+        blankStatus: StatusIfs,
+    ): String {
+        val sanitized = sanitizeTitle(text).trim()
+        if (sanitized.isBlank()) {
+            throw ApiException(blankStatus)
+        }
+        return sanitized
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkReadService.kt
@@ -29,6 +29,7 @@ class LinkReadService(
     private val userLinkRepository: UserLinkRepository,
     private val linkReadLogRepository: LinkReadLogRepository,
     private val userRepository: UserRepository,
+    private val linkSourceService: LinkSourceService,
 ) {
     fun getPublicLinkContents(
         cursor: String?,
@@ -301,8 +302,7 @@ class LinkReadService(
         }
 
         return linkIds.associateWith { linkId ->
-            userLinkRepository.findFirstSourceByLinkId(linkId, PageRequest.of(0, 1)).firstOrNull()?.user?.id
-                ?: throw ApiException(LinkStatus.LINK_NOT_FOUND)
+            linkSourceService.getSourceUserId(linkId)
         }
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkSaveService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkSaveService.kt
@@ -8,7 +8,6 @@ import com.techtaurant.mainserver.link.infrastructure.out.LinkRepository
 import com.techtaurant.mainserver.link.infrastructure.out.UserLinkRepository
 import com.techtaurant.mainserver.user.enums.UserStatus
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
-import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -48,24 +47,16 @@ class LinkSaveService(
         linkId: UUID,
         userId: UUID,
     ) {
-        val existingRelation = userLinkRepository.findByUserIdAndLinkIdForUpdate(userId, linkId)
-        if (existingRelation != null) {
-            if (isFirstSource(linkId, userId)) {
-                throw ApiException(LinkStatus.CANNOT_UNSAVE_OWN_LINK)
-            }
-            val statDate = DateUtils.toUtcDate(existingRelation.createdAt)
-            userLinkRepository.delete(existingRelation)
-            linkDailyStatsService.decrementSaveCount(linkId, statDate)
+        val existingRelation = userLinkRepository.findByUserIdAndLinkIdForUpdate(userId, linkId) ?: return
+
+        val statDate = DateUtils.toUtcDate(existingRelation.createdAt)
+        userLinkRepository.delete(existingRelation)
+        linkDailyStatsService.decrementSaveCount(linkId, statDate)
+
+        // 마지막 저장자가 취소하면 고아 링크가 되므로 삭제한다.
+        // 다른 저장자가 남아 있으면 source(첫 번째 등록자)는 createdAt 순서상 다음 저장자로 자연스럽게 이전된다.
+        if (!userLinkRepository.existsByLinkId(linkId)) {
+            linkRepository.deleteById(linkId)
         }
     }
-
-    private fun isFirstSource(
-        linkId: UUID,
-        userId: UUID,
-    ): Boolean =
-        userLinkRepository
-            .findFirstSourceByLinkId(linkId, PageRequest.of(0, 1))
-            .firstOrNull()
-            ?.user
-            ?.id == userId
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkSaveService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkSaveService.kt
@@ -8,6 +8,7 @@ import com.techtaurant.mainserver.link.infrastructure.out.LinkRepository
 import com.techtaurant.mainserver.link.infrastructure.out.UserLinkRepository
 import com.techtaurant.mainserver.user.enums.UserStatus
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.UUID
@@ -49,9 +50,22 @@ class LinkSaveService(
     ) {
         val existingRelation = userLinkRepository.findByUserIdAndLinkIdForUpdate(userId, linkId)
         if (existingRelation != null) {
+            if (isFirstSource(linkId, userId)) {
+                throw ApiException(LinkStatus.CANNOT_UNSAVE_OWN_LINK)
+            }
             val statDate = DateUtils.toUtcDate(existingRelation.createdAt)
             userLinkRepository.delete(existingRelation)
             linkDailyStatsService.decrementSaveCount(linkId, statDate)
         }
     }
+
+    private fun isFirstSource(
+        linkId: UUID,
+        userId: UUID,
+    ): Boolean =
+        userLinkRepository
+            .findFirstSourceByLinkId(linkId, PageRequest.of(0, 1))
+            .firstOrNull()
+            ?.user
+            ?.id == userId
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkSourceService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkSourceService.kt
@@ -1,0 +1,46 @@
+package com.techtaurant.mainserver.link.application
+
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.link.enums.LinkStatus
+import com.techtaurant.mainserver.link.infrastructure.out.UserLinkRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+/**
+ * 링크의 첫 번째 등록자(source)를 조회/검증하는 공통 서비스.
+ *
+ * 저장 순서상 가장 먼저 링크를 등록한 사용자를 source로 간주한다.
+ */
+@Service
+class LinkSourceService(
+    private val userLinkRepository: UserLinkRepository,
+) {
+    /**
+     * 링크의 첫 번째 등록자 ID를 반환한다. 등록자가 없으면 null.
+     */
+    fun findSourceUserId(linkId: UUID): UUID? =
+        userLinkRepository
+            .findFirstSourceByLinkId(linkId, PageRequest.of(0, 1))
+            .firstOrNull()
+            ?.user
+            ?.id
+
+    /**
+     * 링크의 첫 번째 등록자 ID를 반환한다. 등록자가 없으면 LINK_NOT_FOUND.
+     */
+    fun getSourceUserId(linkId: UUID): UUID = findSourceUserId(linkId) ?: throw ApiException(LinkStatus.LINK_NOT_FOUND)
+
+    /**
+     * 주어진 사용자가 링크의 첫 번째 등록자(source)인지 검증한다.
+     * source가 아니면 CANNOT_MODIFY_LINK.
+     */
+    fun validateSource(
+        linkId: UUID,
+        userId: UUID,
+    ) {
+        if (getSourceUserId(linkId) != userId) {
+            throw ApiException(LinkStatus.CANNOT_MODIFY_LINK)
+        }
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkWriteService.kt
@@ -20,7 +20,6 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.net.URI
-import java.time.Instant
 import java.util.UUID
 
 @Service
@@ -42,15 +41,17 @@ class LinkWriteService(
 
         val link =
             existingLink
-                ?: linkRepository.save(
-                    Link(
-                        title = sanitizeRequiredTitle(request.title),
-                        url = url,
-                        summary = sanitizeRequiredSummary(request.summary),
-                        tags = resolveLinkTags(request.tags).toMutableSet(),
-                        createdAt = request.createdAt ?: Instant.now(),
-                    ),
-                )
+                ?: linkRepository
+                    .save(
+                        Link(
+                            title = sanitizeRequiredTitle(request.title),
+                            url = url,
+                            summary = sanitizeRequiredSummary(request.summary),
+                            tags = resolveLinkTags(request.tags).toMutableSet(),
+                        ),
+                    ).also { savedLink ->
+                        request.createdAt?.let { savedLink.createdAt = it }
+                    }
 
         connectUserToLink(user, link)
 

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkWriteService.kt
@@ -1,0 +1,166 @@
+package com.techtaurant.mainserver.link.application
+
+import com.github.f4b6a3.uuid.UuidCreator
+import com.techtaurant.mainserver.common.exception.ApiException
+import com.techtaurant.mainserver.common.util.DateUtils
+import com.techtaurant.mainserver.common.util.HtmlSanitizer
+import com.techtaurant.mainserver.link.dto.CreateLinkRequest
+import com.techtaurant.mainserver.link.dto.LinkContentDetailResponse
+import com.techtaurant.mainserver.link.dto.UpdateLinkRequest
+import com.techtaurant.mainserver.link.entity.Link
+import com.techtaurant.mainserver.link.enums.LinkStatus
+import com.techtaurant.mainserver.link.infrastructure.out.LinkRepository
+import com.techtaurant.mainserver.link.infrastructure.out.UserLinkRepository
+import com.techtaurant.mainserver.post.application.TagWriteService
+import com.techtaurant.mainserver.post.entity.Tag
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserStatus
+import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.net.URI
+import java.time.Instant
+import java.util.UUID
+
+@Service
+class LinkWriteService(
+    private val linkRepository: LinkRepository,
+    private val userLinkRepository: UserLinkRepository,
+    private val userRepository: UserRepository,
+    private val tagWriteService: TagWriteService,
+    private val linkDailyStatsService: LinkDailyStatsService,
+) {
+    @Transactional
+    fun createLink(
+        userId: UUID,
+        request: CreateLinkRequest,
+    ): LinkContentDetailResponse {
+        val user = findUser(userId)
+        val url = normalizeUrl(request.url)
+        val existingLink = linkRepository.findByUrl(url)
+
+        val link =
+            existingLink
+                ?: linkRepository.save(
+                    Link(
+                        title = sanitizeRequiredTitle(request.title),
+                        url = url,
+                        summary = sanitizeRequiredSummary(request.summary),
+                        tags = resolveLinkTags(request.tags).toMutableSet(),
+                        createdAt = request.createdAt ?: Instant.now(),
+                    ),
+                )
+
+        connectUserToLink(user, link)
+
+        return LinkContentDetailResponse.from(
+            link = link,
+            sourceCompanyUserId = findFirstSourceUserId(link.id!!),
+        )
+    }
+
+    @Transactional
+    fun updateLink(
+        linkId: UUID,
+        userId: UUID,
+        request: UpdateLinkRequest,
+    ): LinkContentDetailResponse {
+        val link =
+            linkRepository.findByIdWithTags(linkId)
+                ?: throw ApiException(LinkStatus.LINK_NOT_FOUND)
+
+        validateFirstSource(linkId, userId)
+
+        request.title?.let { link.title = sanitizeRequiredTitle(it) }
+        request.url?.let { requestedUrl ->
+            val nextUrl = normalizeUrl(requestedUrl)
+            if (nextUrl != link.url) {
+                linkRepository.findByUrl(nextUrl)?.let {
+                    throw ApiException(LinkStatus.LINK_URL_ALREADY_EXISTS)
+                }
+                link.url = nextUrl
+            }
+        }
+        request.summary?.let { link.summary = sanitizeRequiredSummary(it) }
+        request.tags?.let { link.replaceTags(resolveLinkTags(it)) }
+        request.createdAt?.let { link.createdAt = it }
+
+        return LinkContentDetailResponse.from(
+            link = link,
+            sourceCompanyUserId = findFirstSourceUserId(linkId),
+        )
+    }
+
+    private fun findUser(userId: UUID): User =
+        userRepository.findById(userId).orElseThrow {
+            ApiException(UserStatus.USER_NOT_FOUND)
+        }
+
+    private fun connectUserToLink(
+        user: User,
+        link: Link,
+    ) {
+        val inserted =
+            userLinkRepository.insertIfAbsent(
+                id = UuidCreator.getTimeOrderedEpoch(),
+                userId = user.id!!,
+                linkId = link.id!!,
+            )
+
+        if (inserted == 1) {
+            linkDailyStatsService.incrementSaveCount(link.id!!, DateUtils.today())
+        }
+    }
+
+    private fun validateFirstSource(
+        linkId: UUID,
+        userId: UUID,
+    ) {
+        if (findFirstSourceUserId(linkId) != userId) {
+            throw ApiException(LinkStatus.CANNOT_MODIFY_LINK)
+        }
+    }
+
+    private fun findFirstSourceUserId(linkId: UUID): UUID =
+        userLinkRepository.findFirstSourceByLinkId(linkId, PageRequest.of(0, 1)).firstOrNull()?.user?.id
+            ?: throw ApiException(LinkStatus.LINK_NOT_FOUND)
+
+    private fun sanitizeRequiredTitle(title: String): String {
+        val sanitizedTitle = HtmlSanitizer.sanitizeTitle(title).trim()
+        if (sanitizedTitle.isBlank()) {
+            throw ApiException(LinkStatus.LINK_TITLE_REQUIRED)
+        }
+        return sanitizedTitle
+    }
+
+    private fun sanitizeRequiredSummary(summary: String): String {
+        val sanitizedSummary = HtmlSanitizer.sanitizeTitle(summary).trim()
+        if (sanitizedSummary.isBlank()) {
+            throw ApiException(LinkStatus.LINK_SUMMARY_REQUIRED)
+        }
+        return sanitizedSummary
+    }
+
+    private fun resolveLinkTags(tagNames: List<String>?): Set<Tag> = tagWriteService.resolveTags(tagNames.orEmpty().map(String::lowercase))
+
+    private fun normalizeUrl(url: String): String {
+        val normalizedUrl = url.trim()
+        if (normalizedUrl.isBlank()) {
+            throw ApiException(LinkStatus.LINK_URL_REQUIRED)
+        }
+
+        val uri =
+            runCatching { URI.create(normalizedUrl) }.getOrNull()
+                ?: throw ApiException(LinkStatus.INVALID_LINK_URL)
+        val scheme = uri.scheme?.lowercase()
+        if (scheme != "http" && scheme != "https") {
+            throw ApiException(LinkStatus.INVALID_LINK_URL)
+        }
+        if (uri.host.isNullOrBlank()) {
+            throw ApiException(LinkStatus.INVALID_LINK_URL)
+        }
+
+        return normalizedUrl
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/LinkWriteService.kt
@@ -16,7 +16,6 @@ import com.techtaurant.mainserver.post.entity.Tag
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.enums.UserStatus
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
-import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.net.URI
@@ -29,6 +28,7 @@ class LinkWriteService(
     private val userRepository: UserRepository,
     private val tagWriteService: TagWriteService,
     private val linkDailyStatsService: LinkDailyStatsService,
+    private val linkSourceService: LinkSourceService,
 ) {
     @Transactional
     fun createLink(
@@ -41,23 +41,20 @@ class LinkWriteService(
 
         val link =
             existingLink
-                ?: linkRepository
-                    .save(
-                        Link(
-                            title = sanitizeRequiredTitle(request.title),
-                            url = url,
-                            summary = sanitizeRequiredSummary(request.summary),
-                            tags = resolveLinkTags(request.tags).toMutableSet(),
-                        ),
-                    ).also { savedLink ->
-                        request.createdAt?.let { savedLink.createdAt = it }
-                    }
+                ?: linkRepository.save(
+                    Link(
+                        title = HtmlSanitizer.sanitizeRequiredPlainText(request.title, LinkStatus.LINK_TITLE_REQUIRED),
+                        url = url,
+                        summary = HtmlSanitizer.sanitizeRequiredPlainText(request.summary, LinkStatus.LINK_SUMMARY_REQUIRED),
+                        tags = resolveLinkTags(request.tags).toMutableSet(),
+                    ),
+                )
 
         connectUserToLink(user, link)
 
         return LinkContentDetailResponse.from(
             link = link,
-            sourceCompanyUserId = findFirstSourceUserId(link.id!!),
+            sourceCompanyUserId = linkSourceService.getSourceUserId(link.id!!),
         )
     }
 
@@ -71,9 +68,9 @@ class LinkWriteService(
             linkRepository.findByIdWithTags(linkId)
                 ?: throw ApiException(LinkStatus.LINK_NOT_FOUND)
 
-        validateFirstSource(linkId, userId)
+        linkSourceService.validateSource(linkId, userId)
 
-        request.title?.let { link.title = sanitizeRequiredTitle(it) }
+        request.title?.let { link.title = HtmlSanitizer.sanitizeRequiredPlainText(it, LinkStatus.LINK_TITLE_REQUIRED) }
         request.url?.let { requestedUrl ->
             val nextUrl = normalizeUrl(requestedUrl)
             if (nextUrl != link.url) {
@@ -83,13 +80,13 @@ class LinkWriteService(
                 link.url = nextUrl
             }
         }
-        request.summary?.let { link.summary = sanitizeRequiredSummary(it) }
+        request.summary?.let { link.summary = HtmlSanitizer.sanitizeRequiredPlainText(it, LinkStatus.LINK_SUMMARY_REQUIRED) }
         request.tags?.let { link.replaceTags(resolveLinkTags(it)) }
         request.createdAt?.let { link.createdAt = it }
 
         return LinkContentDetailResponse.from(
             link = link,
-            sourceCompanyUserId = findFirstSourceUserId(linkId),
+            sourceCompanyUserId = linkSourceService.getSourceUserId(linkId),
         )
     }
 
@@ -112,35 +109,6 @@ class LinkWriteService(
         if (inserted == 1) {
             linkDailyStatsService.incrementSaveCount(link.id!!, DateUtils.today())
         }
-    }
-
-    private fun validateFirstSource(
-        linkId: UUID,
-        userId: UUID,
-    ) {
-        if (findFirstSourceUserId(linkId) != userId) {
-            throw ApiException(LinkStatus.CANNOT_MODIFY_LINK)
-        }
-    }
-
-    private fun findFirstSourceUserId(linkId: UUID): UUID =
-        userLinkRepository.findFirstSourceByLinkId(linkId, PageRequest.of(0, 1)).firstOrNull()?.user?.id
-            ?: throw ApiException(LinkStatus.LINK_NOT_FOUND)
-
-    private fun sanitizeRequiredTitle(title: String): String {
-        val sanitizedTitle = HtmlSanitizer.sanitizeTitle(title).trim()
-        if (sanitizedTitle.isBlank()) {
-            throw ApiException(LinkStatus.LINK_TITLE_REQUIRED)
-        }
-        return sanitizedTitle
-    }
-
-    private fun sanitizeRequiredSummary(summary: String): String {
-        val sanitizedSummary = HtmlSanitizer.sanitizeTitle(summary).trim()
-        if (sanitizedSummary.isBlank()) {
-            throw ApiException(LinkStatus.LINK_SUMMARY_REQUIRED)
-        }
-        return sanitizedSummary
     }
 
     private fun resolveLinkTags(tagNames: List<String>?): Set<Tag> = tagWriteService.resolveTags(tagNames.orEmpty().map(String::lowercase))

--- a/src/main/kotlin/com/techtaurant/mainserver/link/dto/CreateLinkRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/dto/CreateLinkRequest.kt
@@ -1,0 +1,28 @@
+package com.techtaurant.mainserver.link.dto
+
+import com.techtaurant.mainserver.post.entity.TaggedContent
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import java.time.Instant
+
+@Schema(description = "링크 등록 요청")
+data class CreateLinkRequest(
+    @field:NotBlank(message = "제목은 필수입니다")
+    @field:Size(max = 200, message = "제목은 최대 200자까지 가능합니다")
+    @field:Schema(description = "링크 제목", example = "Spring Boot 시작하기", maxLength = 200)
+    val title: String,
+    @field:NotBlank(message = "URL은 필수입니다")
+    @field:Size(max = 2048, message = "URL은 최대 2048자까지 가능합니다")
+    @field:Schema(description = "원문 URL", example = "https://tech.example.com/articles/spring-boot", maxLength = 2048)
+    val url: String,
+    @field:NotBlank(message = "요약은 필수입니다")
+    @field:Schema(description = "짧은 설명", example = "Spring Boot를 빠르게 시작하는 방법을 소개합니다.")
+    val summary: String,
+    @field:Size(max = TaggedContent.MAX_TAG_COUNT, message = "태그는 최대 10개까지 설정할 수 있습니다")
+    @field:ArraySchema(maxItems = TaggedContent.MAX_TAG_COUNT, schema = Schema(description = "태그명", example = "spring"))
+    val tags: List<String>? = null,
+    @field:Schema(description = "링크 생성일시 (ISO-8601 UTC, 입력하지 않으면 서버 시간이 사용됨)", example = "2026-06-01T00:00:00Z")
+    val createdAt: Instant? = null,
+)

--- a/src/main/kotlin/com/techtaurant/mainserver/link/dto/CreateLinkRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/dto/CreateLinkRequest.kt
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
-import java.time.Instant
 
 @Schema(description = "링크 등록 요청")
 data class CreateLinkRequest(
@@ -23,6 +22,4 @@ data class CreateLinkRequest(
     @field:Size(max = TaggedContent.MAX_TAG_COUNT, message = "태그는 최대 10개까지 설정할 수 있습니다")
     @field:ArraySchema(maxItems = TaggedContent.MAX_TAG_COUNT, schema = Schema(description = "태그명", example = "spring"))
     val tags: List<String>? = null,
-    @field:Schema(description = "링크 생성일시 (ISO-8601 UTC, 입력하지 않으면 서버 시간이 사용됨)", example = "2026-06-01T00:00:00Z")
-    val createdAt: Instant? = null,
 )

--- a/src/main/kotlin/com/techtaurant/mainserver/link/dto/UpdateLinkRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/dto/UpdateLinkRequest.kt
@@ -1,0 +1,24 @@
+package com.techtaurant.mainserver.link.dto
+
+import com.techtaurant.mainserver.post.entity.TaggedContent
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.Size
+import java.time.Instant
+
+@Schema(description = "링크 수정 요청")
+data class UpdateLinkRequest(
+    @field:Size(max = 200, message = "제목은 최대 200자까지 가능합니다")
+    @field:Schema(description = "링크 제목", example = "Spring Boot 시작하기", maxLength = 200)
+    val title: String? = null,
+    @field:Size(max = 2048, message = "URL은 최대 2048자까지 가능합니다")
+    @field:Schema(description = "원문 URL", example = "https://tech.example.com/articles/spring-boot", maxLength = 2048)
+    val url: String? = null,
+    @field:Schema(description = "짧은 설명", example = "Spring Boot를 빠르게 시작하는 방법을 소개합니다.")
+    val summary: String? = null,
+    @field:Size(max = TaggedContent.MAX_TAG_COUNT, message = "태그는 최대 10개까지 설정할 수 있습니다")
+    @field:ArraySchema(maxItems = TaggedContent.MAX_TAG_COUNT, schema = Schema(description = "태그명", example = "spring"))
+    val tags: List<String>? = null,
+    @field:Schema(description = "링크 생성일시 (ISO-8601 UTC)", example = "2026-06-01T00:00:00Z")
+    val createdAt: Instant? = null,
+)

--- a/src/main/kotlin/com/techtaurant/mainserver/link/enums/LinkStatus.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/enums/LinkStatus.kt
@@ -14,6 +14,12 @@ enum class LinkStatus(
     INVALID_LINK_CURSOR(HttpStatus.BAD_REQUEST.value(), 6005, "유효한 링크 커서가 아닙니다"),
     LINK_CRAWL_BATCH_CREATED_AT_REQUIRED(HttpStatus.BAD_REQUEST.value(), 6006, "링크 수집 배치에서 생성일을 수집할 수 없습니다"),
     LINK_CRAWL_BATCH_NOT_CRAWLABLE(HttpStatus.BAD_REQUEST.value(), 6007, "링크 수집 배치를 크롤링할 수 없습니다"),
+    CANNOT_MODIFY_LINK(HttpStatus.FORBIDDEN.value(), 6008, "첫 번째 등록자만 링크를 수정할 수 있습니다"),
+    LINK_TITLE_REQUIRED(HttpStatus.BAD_REQUEST.value(), 6009, "링크 제목은 필수입니다"),
+    LINK_URL_REQUIRED(HttpStatus.BAD_REQUEST.value(), 6010, "링크 URL은 필수입니다"),
+    LINK_SUMMARY_REQUIRED(HttpStatus.BAD_REQUEST.value(), 6011, "링크 요약은 필수입니다"),
+    INVALID_LINK_URL(HttpStatus.BAD_REQUEST.value(), 6012, "유효한 링크 URL이 아닙니다"),
+    LINK_URL_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), 6013, "이미 등록된 링크 URL입니다"),
     ;
 
     override fun getHttpStatusCode(): Int {

--- a/src/main/kotlin/com/techtaurant/mainserver/link/enums/LinkStatus.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/enums/LinkStatus.kt
@@ -20,7 +20,6 @@ enum class LinkStatus(
     LINK_SUMMARY_REQUIRED(HttpStatus.BAD_REQUEST.value(), 6011, "링크 요약은 필수입니다"),
     INVALID_LINK_URL(HttpStatus.BAD_REQUEST.value(), 6012, "유효한 링크 URL이 아닙니다"),
     LINK_URL_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), 6013, "이미 등록된 링크 URL입니다"),
-    CANNOT_UNSAVE_OWN_LINK(HttpStatus.FORBIDDEN.value(), 6014, "첫 번째 등록자는 링크 저장을 취소할 수 없습니다"),
     ;
 
     override fun getHttpStatusCode(): Int {

--- a/src/main/kotlin/com/techtaurant/mainserver/link/enums/LinkStatus.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/enums/LinkStatus.kt
@@ -20,6 +20,7 @@ enum class LinkStatus(
     LINK_SUMMARY_REQUIRED(HttpStatus.BAD_REQUEST.value(), 6011, "링크 요약은 필수입니다"),
     INVALID_LINK_URL(HttpStatus.BAD_REQUEST.value(), 6012, "유효한 링크 URL이 아닙니다"),
     LINK_URL_ALREADY_EXISTS(HttpStatus.CONFLICT.value(), 6013, "이미 등록된 링크 URL입니다"),
+    CANNOT_UNSAVE_OWN_LINK(HttpStatus.FORBIDDEN.value(), 6014, "첫 번째 등록자는 링크 저장을 취소할 수 없습니다"),
     ;
 
     override fun getHttpStatusCode(): Int {

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkController.kt
@@ -7,9 +7,13 @@ import com.techtaurant.mainserver.link.application.LinkLikeLogService
 import com.techtaurant.mainserver.link.application.LinkReadLogService
 import com.techtaurant.mainserver.link.application.LinkReadService
 import com.techtaurant.mainserver.link.application.LinkSaveService
+import com.techtaurant.mainserver.link.application.LinkWriteService
+import com.techtaurant.mainserver.link.dto.CreateLinkRequest
+import com.techtaurant.mainserver.link.dto.LinkContentDetailResponse
 import com.techtaurant.mainserver.link.dto.LinkListItemResponse
 import com.techtaurant.mainserver.link.dto.RecordLinkLikeRequest
 import com.techtaurant.mainserver.link.dto.RecordLinkReadRequest
+import com.techtaurant.mainserver.link.dto.UpdateLinkRequest
 import jakarta.validation.Valid
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
@@ -18,6 +22,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -35,6 +40,7 @@ class LinkController(
     private val linkSaveService: LinkSaveService,
     private val linkReadLogService: LinkReadLogService,
     private val linkLikeLogService: LinkLikeLogService,
+    private val linkWriteService: LinkWriteService,
 ) : LinkControllerDocs {
     @ApiErrorResponses(includeAuthenticationErrors = true)
     @GetMapping("/companies/{companyUserId}/links")
@@ -46,6 +52,26 @@ class LinkController(
         @RequestParam(required = false) tag: String?,
     ): ApiResponse<CursorPageResponse<LinkListItemResponse>> {
         return ApiResponse.ok(linkReadService.getCompanyLinks(companyUserId, userId, cursor, size, tag))
+    }
+
+    @ApiErrorResponses(includeAuthenticationErrors = true, includeValidationError = true)
+    @PostMapping("/links")
+    @ResponseStatus(HttpStatus.CREATED)
+    override fun createLink(
+        @AuthenticationPrincipal userId: UUID,
+        @Valid @RequestBody request: CreateLinkRequest,
+    ): ApiResponse<LinkContentDetailResponse> {
+        return ApiResponse.created(linkWriteService.createLink(userId, request))
+    }
+
+    @ApiErrorResponses(includeAuthenticationErrors = true, includeValidationError = true)
+    @PatchMapping("/links/{linkId}")
+    override fun updateLink(
+        @AuthenticationPrincipal userId: UUID,
+        @PathVariable linkId: UUID,
+        @Valid @RequestBody request: UpdateLinkRequest,
+    ): ApiResponse<LinkContentDetailResponse> {
+        return ApiResponse.ok(linkWriteService.updateLink(linkId, userId, request))
     }
 
     @ApiErrorResponses(includeAuthenticationErrors = true)

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkControllerDocs.kt
@@ -93,14 +93,7 @@ interface LinkControllerDocs {
         @Parameter(description = "링크 ID") linkId: UUID,
     ): ApiResponse<Unit>
 
-    @Operation(summary = "링크 저장 취소", description = "사용자가 저장한 링크를 해제합니다. 단, 첫 번째 등록자는 저장을 취소할 수 없습니다")
-    @ApiErrorCodeResponses(
-        [
-            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED"]),
-            ApiErrorCodeResponse(LinkStatus::class, ["CANNOT_UNSAVE_OWN_LINK"]),
-            ApiErrorCodeResponse(DefaultStatus::class, ["UNKNOWN_EXCEPTION"]),
-        ],
-    )
+    @Operation(summary = "링크 저장 취소", description = "사용자가 저장한 링크를 해제합니다. 마지막 저장자가 취소하면 링크가 삭제됩니다")
     fun unsaveLink(
         userId: UUID,
         @Parameter(description = "링크 ID") linkId: UUID,

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkControllerDocs.kt
@@ -5,9 +5,12 @@ import com.techtaurant.mainserver.common.dto.CursorPageResponse
 import com.techtaurant.mainserver.common.status.DefaultStatus
 import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponse
 import com.techtaurant.mainserver.common.swagger.ApiErrorCodeResponses
+import com.techtaurant.mainserver.link.dto.CreateLinkRequest
+import com.techtaurant.mainserver.link.dto.LinkContentDetailResponse
 import com.techtaurant.mainserver.link.dto.LinkListItemResponse
 import com.techtaurant.mainserver.link.dto.RecordLinkLikeRequest
 import com.techtaurant.mainserver.link.dto.RecordLinkReadRequest
+import com.techtaurant.mainserver.link.dto.UpdateLinkRequest
 import com.techtaurant.mainserver.link.enums.LinkStatus
 import com.techtaurant.mainserver.security.jwt.JwtStatus
 import com.techtaurant.mainserver.user.enums.UserStatus
@@ -20,7 +23,7 @@ import jakarta.validation.constraints.Min
 import java.util.UUID
 import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 
-@Tag(name = "링크", description = "회사 링크 조회 및 사용자 상호작용 API")
+@Tag(name = "링크", description = "회사 링크 조회, 사용자 링크 등록/수정 및 상호작용 API")
 interface LinkControllerDocs {
     @Operation(summary = "회사 링크 목록 조회", description = "회사가 수집한 링크 목록을 커서 기반으로 조회합니다")
     @SwaggerApiResponse(responseCode = "200", description = "링크 목록 조회 성공")
@@ -39,6 +42,50 @@ interface LinkControllerDocs {
         @Parameter(description = "페이지 크기 (1~100)") @Min(1) @Max(100) size: Int,
         tag: String?,
     ): ApiResponse<CursorPageResponse<LinkListItemResponse>>
+
+    @Operation(summary = "링크 등록", description = "인증된 사용자가 링크를 직접 등록합니다. 등록한 사용자는 해당 링크의 첫 번째 등록자가 됩니다.")
+    @SwaggerApiResponse(responseCode = "201", description = "링크 등록 성공")
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED"]),
+            ApiErrorCodeResponse(
+                LinkStatus::class,
+                ["LINK_TITLE_REQUIRED", "LINK_URL_REQUIRED", "LINK_SUMMARY_REQUIRED", "INVALID_LINK_URL"],
+            ),
+            ApiErrorCodeResponse(UserStatus::class, ["USER_NOT_FOUND"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["BAD_REQUEST", "UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun createLink(
+        userId: UUID,
+        @Valid request: CreateLinkRequest,
+    ): ApiResponse<LinkContentDetailResponse>
+
+    @Operation(summary = "링크 수정", description = "링크의 첫 번째 등록자만 제목, URL, 요약, 태그, 생성일을 수정할 수 있습니다.")
+    @SwaggerApiResponse(responseCode = "200", description = "링크 수정 성공")
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED"]),
+            ApiErrorCodeResponse(
+                LinkStatus::class,
+                [
+                    "LINK_NOT_FOUND",
+                    "CANNOT_MODIFY_LINK",
+                    "LINK_TITLE_REQUIRED",
+                    "LINK_URL_REQUIRED",
+                    "LINK_SUMMARY_REQUIRED",
+                    "INVALID_LINK_URL",
+                    "LINK_URL_ALREADY_EXISTS",
+                ],
+            ),
+            ApiErrorCodeResponse(DefaultStatus::class, ["BAD_REQUEST", "UNKNOWN_EXCEPTION"]),
+        ],
+    )
+    fun updateLink(
+        userId: UUID,
+        @Parameter(description = "링크 ID") linkId: UUID,
+        @Valid request: UpdateLinkRequest,
+    ): ApiResponse<LinkContentDetailResponse>
 
     @Operation(summary = "링크 저장", description = "사용자가 링크를 저장합니다. 이미 저장된 경우에도 멱등하게 처리합니다")
     fun saveLink(

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkControllerDocs.kt
@@ -93,7 +93,14 @@ interface LinkControllerDocs {
         @Parameter(description = "링크 ID") linkId: UUID,
     ): ApiResponse<Unit>
 
-    @Operation(summary = "링크 저장 취소", description = "사용자가 저장한 링크를 해제합니다")
+    @Operation(summary = "링크 저장 취소", description = "사용자가 저장한 링크를 해제합니다. 단, 첫 번째 등록자는 저장을 취소할 수 없습니다")
+    @ApiErrorCodeResponses(
+        [
+            ApiErrorCodeResponse(JwtStatus::class, ["AUTHENTICATION_REQUIRED"]),
+            ApiErrorCodeResponse(LinkStatus::class, ["CANNOT_UNSAVE_OWN_LINK"]),
+            ApiErrorCodeResponse(DefaultStatus::class, ["UNKNOWN_EXCEPTION"]),
+        ],
+    )
     fun unsaveLink(
         userId: UUID,
         @Parameter(description = "링크 ID") linkId: UUID,

--- a/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/UserLinkRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/infrastructure/out/UserLinkRepository.kt
@@ -34,6 +34,8 @@ interface UserLinkRepository : JpaRepository<UserLink, UUID> {
 
     fun findAllByUserId(userId: UUID): List<UserLink>
 
+    fun existsByLinkId(linkId: UUID): Boolean
+
     fun deleteAllByLink(link: Link): Long
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkInteractionConcurrencyTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkInteractionConcurrencyTest.kt
@@ -5,6 +5,7 @@ import com.techtaurant.mainserver.common.enums.LikeStatus
 import com.techtaurant.mainserver.common.util.DateUtils
 import com.techtaurant.mainserver.link.entity.Link
 import com.techtaurant.mainserver.link.entity.LinkDailyStats
+import com.techtaurant.mainserver.link.entity.UserLink
 import com.techtaurant.mainserver.link.infrastructure.out.LinkDailyStatsRepository
 import com.techtaurant.mainserver.link.infrastructure.out.LinkLikeLogRepository
 import com.techtaurant.mainserver.link.infrastructure.out.LinkRepository
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import java.time.LocalDate
+import java.time.ZoneOffset
 import java.util.UUID
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
@@ -181,6 +183,7 @@ class LinkInteractionConcurrencyTest : IntegrationTest() {
     @Test
     @DisplayName("동시 저장 취소는 한 번만 저장수를 감소시킨다")
     fun unsave_whenConcurrentRequests_shouldDecrementDailySaveCountOnce() {
+        registerFirstSource(companyUser)
         linkSaveService.save(testLink.id!!, normalUser.id!!)
 
         runConcurrently {
@@ -192,6 +195,18 @@ class LinkInteractionConcurrencyTest : IntegrationTest() {
 
         assertThat(userLink).isNull()
         assertThat(dailyStats?.saveCount).isEqualTo(0)
+    }
+
+    private fun registerFirstSource(user: User) {
+        val relation =
+            userLinkRepository.saveAndFlush(
+                UserLink(
+                    user = user,
+                    link = testLink,
+                ),
+            )
+        relation.createdAt = DateUtils.today().minusDays(2).atStartOfDay(ZoneOffset.UTC).toInstant()
+        userLinkRepository.saveAndFlush(relation)
     }
 
     private fun findDailyStats(statDate: LocalDate = DateUtils.today()): LinkDailyStats? {

--- a/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkSaveServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkSaveServiceTest.kt
@@ -1,10 +1,12 @@
 package com.techtaurant.mainserver.link.application
 
 import com.techtaurant.mainserver.base.IntegrationTest
+import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.common.util.DateUtils
 import com.techtaurant.mainserver.link.entity.Link
 import com.techtaurant.mainserver.link.entity.LinkDailyStats
 import com.techtaurant.mainserver.link.entity.UserLink
+import com.techtaurant.mainserver.link.enums.LinkStatus
 import com.techtaurant.mainserver.link.infrastructure.out.LinkDailyStatsRepository
 import com.techtaurant.mainserver.link.infrastructure.out.LinkRepository
 import com.techtaurant.mainserver.link.infrastructure.out.UserLinkRepository
@@ -14,6 +16,7 @@ import com.techtaurant.mainserver.user.enums.UserRole
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -96,8 +99,9 @@ class LinkSaveServiceTest : IntegrationTest() {
     }
 
     @Test
-    @DisplayName("링크 저장 취소는 기존 저장 일자의 일별 저장수를 감소시킨다")
-    fun unsave_whenExistingRelation_shouldDecrementDailySaveCount() {
+    @DisplayName("첫 등록자가 아닌 사용자의 저장 취소는 기존 저장 일자의 일별 저장수를 감소시킨다")
+    fun unsave_whenNotFirstSource_shouldDecrementDailySaveCount() {
+        registerFirstSource(companyUser)
         linkSaveService.save(testLink.id!!, normalUser.id!!)
         entityManager.flush()
         entityManager.clear()
@@ -111,8 +115,24 @@ class LinkSaveServiceTest : IntegrationTest() {
     }
 
     @Test
+    @DisplayName("첫 등록자는 링크 저장을 취소할 수 없다")
+    fun unsave_whenFirstSource_shouldThrow() {
+        linkSaveService.save(testLink.id!!, normalUser.id!!)
+        entityManager.flush()
+        entityManager.clear()
+
+        assertThatThrownBy { linkSaveService.unsave(testLink.id!!, normalUser.id!!) }
+            .isInstanceOf(ApiException::class.java)
+            .extracting { (it as ApiException).status }
+            .isEqualTo(LinkStatus.CANNOT_UNSAVE_OWN_LINK)
+
+        assertThat(userLinkRepository.findByUserIdAndLinkId(normalUser.id!!, testLink.id!!)).isNotNull()
+    }
+
+    @Test
     @DisplayName("일별 통계가 없는 기존 저장을 취소해도 음수 저장수 레코드를 만들지 않는다")
     fun unsave_whenLegacyRelationWithoutDailyStats_shouldNotCreateNegativeDailyStats() {
+        registerFirstSource(companyUser)
         val oldStatDate = DateUtils.today().minusDays(1)
         val existingRelation =
             userLinkRepository.saveAndFlush(
@@ -131,6 +151,19 @@ class LinkSaveServiceTest : IntegrationTest() {
 
         assertThat(userLinkRepository.findByUserIdAndLinkId(normalUser.id!!, testLink.id!!)).isNull()
         assertThat(linkDailyStatsRepository.findAll()).isEmpty()
+    }
+
+    private fun registerFirstSource(user: User) {
+        val relation =
+            userLinkRepository.saveAndFlush(
+                UserLink(
+                    user = user,
+                    link = testLink,
+                ),
+            )
+        relation.createdAt = DateUtils.today().minusDays(2).atStartOfDay(ZoneOffset.UTC).toInstant()
+        userLinkRepository.saveAndFlush(relation)
+        entityManager.clear()
     }
 
     private fun findDailyStats(): LinkDailyStats? {

--- a/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkSaveServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/application/LinkSaveServiceTest.kt
@@ -1,12 +1,10 @@
 package com.techtaurant.mainserver.link.application
 
 import com.techtaurant.mainserver.base.IntegrationTest
-import com.techtaurant.mainserver.common.exception.ApiException
 import com.techtaurant.mainserver.common.util.DateUtils
 import com.techtaurant.mainserver.link.entity.Link
 import com.techtaurant.mainserver.link.entity.LinkDailyStats
 import com.techtaurant.mainserver.link.entity.UserLink
-import com.techtaurant.mainserver.link.enums.LinkStatus
 import com.techtaurant.mainserver.link.infrastructure.out.LinkDailyStatsRepository
 import com.techtaurant.mainserver.link.infrastructure.out.LinkRepository
 import com.techtaurant.mainserver.link.infrastructure.out.UserLinkRepository
@@ -16,7 +14,6 @@ import com.techtaurant.mainserver.user.enums.UserRole
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import jakarta.persistence.EntityManager
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -30,6 +27,9 @@ import java.util.UUID
 class LinkSaveServiceTest : IntegrationTest() {
     @Autowired
     private lateinit var linkSaveService: LinkSaveService
+
+    @Autowired
+    private lateinit var linkSourceService: LinkSourceService
 
     @Autowired
     private lateinit var linkRepository: LinkRepository
@@ -99,9 +99,9 @@ class LinkSaveServiceTest : IntegrationTest() {
     }
 
     @Test
-    @DisplayName("첫 등록자가 아닌 사용자의 저장 취소는 기존 저장 일자의 일별 저장수를 감소시킨다")
-    fun unsave_whenNotFirstSource_shouldDecrementDailySaveCount() {
-        registerFirstSource(companyUser)
+    @DisplayName("다른 저장자가 남아 있으면 저장 취소는 일별 저장수를 감소시키고 링크는 유지된다")
+    fun unsave_whenOtherSaversRemain_shouldDecrementDailySaveCountAndKeepLink() {
+        registerSource(companyUser, daysAgo = 2)
         linkSaveService.save(testLink.id!!, normalUser.id!!)
         entityManager.flush()
         entityManager.clear()
@@ -112,27 +112,45 @@ class LinkSaveServiceTest : IntegrationTest() {
 
         assertThat(userLinkRepository.findByUserIdAndLinkId(normalUser.id!!, testLink.id!!)).isNull()
         assertThat(findDailyStats()?.saveCount).isEqualTo(0)
+        assertThat(linkRepository.findById(testLink.id!!)).isPresent()
     }
 
     @Test
-    @DisplayName("첫 등록자는 링크 저장을 취소할 수 없다")
-    fun unsave_whenFirstSource_shouldThrow() {
+    @DisplayName("마지막 저장자가 취소하면 링크가 삭제된다")
+    fun unsave_whenLastSaver_shouldDeleteLink() {
         linkSaveService.save(testLink.id!!, normalUser.id!!)
         entityManager.flush()
         entityManager.clear()
 
-        assertThatThrownBy { linkSaveService.unsave(testLink.id!!, normalUser.id!!) }
-            .isInstanceOf(ApiException::class.java)
-            .extracting { (it as ApiException).status }
-            .isEqualTo(LinkStatus.CANNOT_UNSAVE_OWN_LINK)
+        linkSaveService.unsave(testLink.id!!, normalUser.id!!)
+        entityManager.flush()
+        entityManager.clear()
 
-        assertThat(userLinkRepository.findByUserIdAndLinkId(normalUser.id!!, testLink.id!!)).isNotNull()
+        assertThat(userLinkRepository.findByUserIdAndLinkId(normalUser.id!!, testLink.id!!)).isNull()
+        assertThat(linkRepository.findById(testLink.id!!)).isEmpty()
+        assertThat(linkDailyStatsRepository.findAll().any { it.link.id == testLink.id }).isFalse()
+    }
+
+    @Test
+    @DisplayName("첫 등록자가 취소해도 다른 저장자가 있으면 소유권이 다음 저장자로 이전된다")
+    fun unsave_whenFirstSourceWithOtherSavers_shouldTransferOwnership() {
+        registerSource(normalUser, daysAgo = 2)
+        registerSource(companyUser, daysAgo = 1)
+
+        linkSaveService.unsave(testLink.id!!, normalUser.id!!)
+        entityManager.flush()
+        entityManager.clear()
+
+        assertThat(userLinkRepository.findByUserIdAndLinkId(normalUser.id!!, testLink.id!!)).isNull()
+        assertThat(userLinkRepository.findByUserIdAndLinkId(companyUser.id!!, testLink.id!!)).isNotNull()
+        assertThat(linkRepository.findById(testLink.id!!)).isPresent()
+        assertThat(linkSourceService.getSourceUserId(testLink.id!!)).isEqualTo(companyUser.id)
     }
 
     @Test
     @DisplayName("일별 통계가 없는 기존 저장을 취소해도 음수 저장수 레코드를 만들지 않는다")
     fun unsave_whenLegacyRelationWithoutDailyStats_shouldNotCreateNegativeDailyStats() {
-        registerFirstSource(companyUser)
+        registerSource(companyUser, daysAgo = 2)
         val oldStatDate = DateUtils.today().minusDays(1)
         val existingRelation =
             userLinkRepository.saveAndFlush(
@@ -153,7 +171,10 @@ class LinkSaveServiceTest : IntegrationTest() {
         assertThat(linkDailyStatsRepository.findAll()).isEmpty()
     }
 
-    private fun registerFirstSource(user: User) {
+    private fun registerSource(
+        user: User,
+        daysAgo: Long,
+    ) {
         val relation =
             userLinkRepository.saveAndFlush(
                 UserLink(
@@ -161,7 +182,7 @@ class LinkSaveServiceTest : IntegrationTest() {
                     link = testLink,
                 ),
             )
-        relation.createdAt = DateUtils.today().minusDays(2).atStartOfDay(ZoneOffset.UTC).toInstant()
+        relation.createdAt = DateUtils.today().minusDays(daysAgo).atStartOfDay(ZoneOffset.UTC).toInstant()
         userLinkRepository.saveAndFlush(relation)
         entityManager.clear()
     }

--- a/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkControllerIntegrationTest.kt
@@ -241,8 +241,7 @@ class LinkControllerIntegrationTest : IntegrationTest() {
                       "title": "<b>직접 등록한 링크</b>",
                       "url": "https://example.com/articles/direct-link",
                       "summary": "직접 등록한 링크 요약입니다.",
-                      "tags": ["Kotlin", "api"],
-                      "createdAt": "2026-06-01T00:00:00Z"
+                      "tags": ["Kotlin", "api"]
                     }
                     """.trimIndent(),
                 )

--- a/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/infrastructure/in/LinkControllerIntegrationTest.kt
@@ -9,8 +9,11 @@ import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.enums.UserRole
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import io.restassured.RestAssured.given
+import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -34,7 +37,9 @@ class LinkControllerIntegrationTest : IntegrationTest() {
 
     private lateinit var companyUser: User
     private lateinit var normalUser: User
+    private lateinit var anotherUser: User
     private lateinit var accessToken: String
+    private lateinit var anotherAccessToken: String
     private lateinit var firstLink: Link
     private lateinit var secondLink: Link
 
@@ -64,7 +69,20 @@ class LinkControllerIntegrationTest : IntegrationTest() {
                 ),
             )
 
+        anotherUser =
+            userRepository.save(
+                User(
+                    name = "다른사용자",
+                    email = "another-${UUID.randomUUID()}@example.com",
+                    provider = OAuthProvider.GOOGLE,
+                    identifier = "another-user-id-${UUID.randomUUID()}",
+                    role = UserRole.USER,
+                    profileImageUrl = "https://example.com/another.png",
+                ),
+            )
+
         accessToken = jwtTokenProvider.createAccessToken(normalUser.id!!, normalUser.role)
+        anotherAccessToken = jwtTokenProvider.createAccessToken(anotherUser.id!!, anotherUser.role)
 
         firstLink =
             linkRepository.save(
@@ -208,5 +226,122 @@ class LinkControllerIntegrationTest : IntegrationTest() {
             .statusCode(HttpStatus.OK.value())
             .body("data.content.find { it.id == '${firstLink.id}' }.likeCount", equalTo(1))
             .body("data.content.find { it.id == '${firstLink.id}' }.viewCount", equalTo(2))
+    }
+
+    @Test
+    @DisplayName("사용자는 링크를 직접 등록할 수 있다")
+    fun userCanCreateLink() {
+        val createdLinkId =
+            given()
+                .contentType("application/json")
+                .header("Authorization", "Bearer $accessToken")
+                .body(
+                    """
+                    {
+                      "title": "<b>직접 등록한 링크</b>",
+                      "url": "https://example.com/articles/direct-link",
+                      "summary": "직접 등록한 링크 요약입니다.",
+                      "tags": ["Kotlin", "api"],
+                      "createdAt": "2026-06-01T00:00:00Z"
+                    }
+                    """.trimIndent(),
+                )
+                .`when`()
+                .post("/api/links")
+                .then()
+                .statusCode(HttpStatus.CREATED.value())
+                .body("data.title", equalTo("직접 등록한 링크"))
+                .body("data.url", equalTo("https://example.com/articles/direct-link"))
+                .body("data.summary", equalTo("직접 등록한 링크 요약입니다."))
+                .body("data.sourceCompanyUserId", equalTo(normalUser.id.toString()))
+                .body("data.tags", containsInAnyOrder("api", "kotlin"))
+                .extract()
+                .path<String>("data.id")
+
+        val createdLink = linkRepository.findByUrl("https://example.com/articles/direct-link")
+        assertNotNull(createdLink)
+        assertEquals(createdLinkId, createdLink!!.id.toString())
+        assertNotNull(userLinkRepository.findByUserIdAndLinkId(normalUser.id!!, createdLink.id!!))
+    }
+
+    @Test
+    @DisplayName("첫 번째 등록자는 링크를 수정할 수 있다")
+    fun firstSourceCanUpdateLink() {
+        val createdLinkId = createLinkByApi(accessToken, "https://example.com/articles/updatable-link")
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", "Bearer $accessToken")
+            .body(
+                """
+                {
+                  "title": "수정된 링크 제목",
+                  "summary": "수정된 링크 요약입니다.",
+                  "tags": ["Spring", "backend"]
+                }
+                """.trimIndent(),
+            )
+            .`when`()
+            .patch("/api/links/$createdLinkId")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.id", equalTo(createdLinkId))
+            .body("data.title", equalTo("수정된 링크 제목"))
+            .body("data.summary", equalTo("수정된 링크 요약입니다."))
+            .body("data.tags", containsInAnyOrder("backend", "spring"))
+
+        val updatedLink = linkRepository.findByIdWithTags(UUID.fromString(createdLinkId))
+        assertNotNull(updatedLink)
+        assertEquals("수정된 링크 제목", updatedLink!!.title)
+        assertEquals("수정된 링크 요약입니다.", updatedLink.summary)
+        assertEquals(setOf("backend", "spring"), updatedLink.tags.map { it.name }.toSet())
+    }
+
+    @Test
+    @DisplayName("첫 번째 등록자가 아닌 사용자는 링크를 수정할 수 없다")
+    fun nonFirstSourceCannotUpdateLink() {
+        val createdLinkId = createLinkByApi(accessToken, "https://example.com/articles/owned-by-first-user")
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", "Bearer $anotherAccessToken")
+            .body(
+                """
+                {
+                  "title": "권한 없는 수정",
+                  "summary": "수정되면 안 됩니다."
+                }
+                """.trimIndent(),
+            )
+            .`when`()
+            .patch("/api/links/$createdLinkId")
+            .then()
+            .statusCode(HttpStatus.FORBIDDEN.value())
+            .body("status", equalTo(6008))
+    }
+
+    private fun createLinkByApi(
+        token: String,
+        url: String,
+    ): String {
+        return given()
+            .contentType("application/json")
+            .header("Authorization", "Bearer $token")
+            .body(
+                """
+                {
+                  "title": "등록할 링크",
+                  "url": "$url",
+                  "summary": "등록할 링크 요약입니다.",
+                  "tags": ["tech"]
+                }
+                """.trimIndent(),
+            )
+            .`when`()
+            .post("/api/links")
+            .then()
+            .statusCode(HttpStatus.CREATED.value())
+            .extract()
+            .path("data.id")
     }
 }


### PR DESCRIPTION
## Summary
- Add authenticated link creation via `POST /api/links`.
- Add link updates via `PATCH /api/links/{linkId}`.
- Restrict edits to the first user who registered the link and return `403` for other users.
- Cover create, first-registrant update, and forbidden update flows with integration tests.

## Verification
- `./gradlew test --tests com.techtaurant.mainserver.link.infrastructure.in.LinkControllerIntegrationTest -x jacocoTestReport`
- `./gradlew test -x jacocoTestReport`
- `./gradlew spotlessCheck`
- `./gradlew build`
