### PR TITLE
feat(swagger): actuator health endpoint를 Swagger 문서에 노출

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/security/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/config/SwaggerConfig.kt
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.models.security.SecurityRequirement
 import io.swagger.v3.oas.models.security.SecurityScheme
 import io.swagger.v3.oas.models.servers.Server
 import org.springdoc.core.customizers.OpenApiCustomizer
+import org.springdoc.core.models.GroupedOpenApi
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
@@ -51,6 +52,36 @@ class SwaggerConfig(
                 }
             }
         }
+    }
+
+    /**
+     * 기존 애플리케이션 API 그룹.
+     *
+     * GroupedOpenApi Bean을 정의하면 SpringDoc은 기본 단일 문서 대신 그룹별 문서를 제공한다.
+     * 따라서 actuator 그룹을 추가할 때 기존 엔드포인트가 사라지지 않도록 별도 그룹으로 명시한다.
+     * (actuator 경로는 actuatorOpenApi에서 다루므로 여기서는 제외한다.)
+     */
+    @Bean
+    fun apiOpenApi(): GroupedOpenApi {
+        return GroupedOpenApi
+            .builder()
+            .group("api")
+            .pathsToMatch("/**")
+            .pathsToExclude("/actuator/**")
+            .build()
+    }
+
+    /**
+     * actuator 그룹. health endpoint만 Swagger 문서에 노출한다.
+     * prometheus 등 다른 actuator endpoint는 문서에 드러나지 않도록 health 경로만 매칭한다.
+     */
+    @Bean
+    fun actuatorOpenApi(): GroupedOpenApi {
+        return GroupedOpenApi
+            .builder()
+            .group("actuator")
+            .pathsToMatch("/actuator/health", "/actuator/health/**")
+            .build()
     }
 
     private fun apiInfo(): Info {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -135,6 +135,9 @@ cookie:
 
 # Springdoc OpenAPI
 springdoc:
+    # actuator endpoint(/actuator/health 등)를 OpenAPI 문서에 포함시킨다.
+    # 노출 범위는 SwaggerConfig의 GroupedOpenApi에서 health로 제한한다.
+    show-actuator: true
     swagger-ui:
         # Cookie 전송을 위한 withCredentials 활성화
         request-interceptor: >

--- a/src/test/kotlin/com/techtaurant/mainserver/config/ActuatorSwaggerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/config/ActuatorSwaggerIntegrationTest.kt
@@ -1,0 +1,67 @@
+package com.techtaurant.mainserver.config
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.techtaurant.mainserver.base.IntegrationTest
+import io.restassured.RestAssured
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+@DisplayName("actuator Swagger 문서")
+class ActuatorSwaggerIntegrationTest : IntegrationTest() {
+    private val objectMapper = jacksonObjectMapper()
+
+    @Test
+    @DisplayName("actuator 그룹 문서는 health endpoint를 노출한다")
+    fun actuatorGroup_exposesHealthEndpoint() {
+        val paths = getOpenApiDocs(group = "actuator").path("paths")
+
+        assertTrue(
+            paths.has("/actuator/health"),
+            "actuator 그룹 문서에 /actuator/health 경로가 있어야 한다: ${paths.fieldNames().asSequence().toList()}",
+        )
+    }
+
+    @Test
+    @DisplayName("actuator 그룹 문서는 health 외 다른 actuator endpoint(prometheus 등)를 노출하지 않는다")
+    fun actuatorGroup_doesNotExposeNonHealthEndpoints() {
+        val paths = getOpenApiDocs(group = "actuator").path("paths")
+
+        val nonHealthPaths =
+            paths
+                .fieldNames()
+                .asSequence()
+                .filter { !it.startsWith("/actuator/health") }
+                .toList()
+
+        assertTrue(nonHealthPaths.isEmpty(), "actuator 그룹에는 health 경로만 있어야 한다: $nonHealthPaths")
+    }
+
+    @Test
+    @DisplayName("기본 api 그룹 문서에는 actuator 경로가 포함되지 않는다")
+    fun apiGroup_excludesActuatorPaths() {
+        val paths = getOpenApiDocs(group = "api").path("paths")
+
+        val actuatorPaths =
+            paths
+                .fieldNames()
+                .asSequence()
+                .filter { it.startsWith("/actuator") }
+                .toList()
+
+        assertTrue(actuatorPaths.isEmpty(), "api 그룹에는 actuator 경로가 없어야 한다: $actuatorPaths")
+    }
+
+    private fun getOpenApiDocs(group: String): JsonNode =
+        objectMapper.readTree(
+            RestAssured
+                .given()
+                .`when`()
+                .get("/v3/api-docs/$group")
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString(),
+        )
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/notification/infrastructure/in/NotificationControllerSwaggerIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/notification/infrastructure/in/NotificationControllerSwaggerIntegrationTest.kt
@@ -72,7 +72,7 @@ class NotificationControllerSwaggerIntegrationTest : IntegrationTest() {
             RestAssured
                 .given()
                 .`when`()
-                .get("/v3/api-docs")
+                .get("/v3/api-docs/api")
                 .then()
                 .statusCode(200)
                 .extract()


### PR DESCRIPTION
## 무엇을

`/actuator/health`를 Swagger UI에 노출한다. 별도 REST 컨트롤러를 만들지 않고 SpringDoc 내장 기능을 사용한다.

## 어떻게

- `application.yml`: `springdoc.show-actuator: true`
- `SwaggerConfig.kt`: `GroupedOpenApi` 2개로 노출 범위 제어
  - `actuator` 그룹 → `/actuator/health`(+하위 probe)만 노출. prometheus 등은 문서에서 제외
  - `api` 그룹 → 기존 전체 API에서 `/actuator/**` 제외

## ⚠️ 부수효과 (리뷰 포인트)

`GroupedOpenApi` Bean을 정의하면 SpringDoc이 **기본 단일 `/v3/api-docs`를 그룹별 문서로 전환**한다.
- Swagger UI에 그룹 드롭다운(`api` / `actuator`) 생성
- `GET /v3/api-docs` → `GET /v3/api-docs/api`, `GET /v3/api-docs/actuator` 로 분리
- 기존 단일 문서를 호출하던 `NotificationControllerSwaggerIntegrationTest`를 `/v3/api-docs/api`로 수정
- **FE/외부 툴이 `/v3/api-docs`를 직접 참조 중이라면 그룹 URL로 변경 필요**

## 테스트

- `ActuatorSwaggerIntegrationTest` (신규): actuator 그룹 health 노출 / 비health(prometheus 등) 차단 / api 그룹 actuator 제외 검증
- `./gradlew compileKotlin compileTestKotlin` → 성공
- ⚠️ 통합 테스트는 Testcontainers(PostgreSQL) → **Docker 필요**. 작성 환경(Docker 미가용)에서는 미실행. 리뷰어/CI에서 Docker 기동 후 검증 요망.

## 📸 스크린샷 (보류)

요청하신 "다른 포트로 띄워 호출결과 스크린샷 첨부"는 작성 환경에 **Docker/PostgreSQL이 없어 앱을 부팅할 수 없어 자동 캡처하지 못했습니다.** 아래 런북으로 재현 후 이 PR에 드래그&드롭으로 첨부 예정입니다.

```bash
# DB 기동
docker run -d --name pg-health -e POSTGRES_DB=techtaurant -e POSTGRES_USER=app -e POSTGRES_PASSWORD=app -p 5432:5432 postgres:15-alpine
# 8080이 아닌 18080으로 앱 기동
SERVER_PORT=18080 APP_NAME=techtaurant-be DB_NAME=techtaurant DB_USERNAME=app DB_PASSWORD=app \
  JWT_SECRET=dev-secret CORS_ORIGINS=http://localhost:3000 \
  GOOGLE_CLIENT_ID=dummy GOOGLE_CLIENT_SECRET=dummy \
  ./gradlew bootRun
# 호출결과
curl -s http://localhost:18080/actuator/health   # {"status":"UP",...}
# Swagger: http://localhost:18080/swagger-ui/index.html → 그룹 'actuator' 선택 → /actuator/health 캡처
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)