### PR TITLE
feat(link): CSR 렌더링 문서 수집 fallback 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ COPY src src
 RUN --mount=type=cache,target=/root/.gradle,sharing=locked \
     ./gradlew bootJar --no-daemon
 
-# Runtime stage: 타겟 플랫폼(arm64)의 JRE 이미지 사용
-FROM eclipse-temurin:17-jre
+# Runtime stage: Playwright와 버전을 맞춘 browser/system dependency 포함 이미지 사용
+FROM mcr.microsoft.com/playwright/java:v1.61.0-noble
 
 WORKDIR /app
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,8 +83,11 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
 
-    // HTML Sanitization
+    // HTML Fetching and Sanitization
     implementation("org.jsoup:jsoup:1.18.3")
+    implementation("com.microsoft.playwright:playwright:1.61.0") {
+        exclude(group = "org.slf4j", module = "slf4j-simple")
+    }
 
     // Observability
     implementation("io.micrometer:micrometer-registry-prometheus")

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/JsoupLinkDocumentFetcher.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/JsoupLinkDocumentFetcher.kt
@@ -5,8 +5,26 @@ import org.jsoup.nodes.Document
 import org.springframework.stereotype.Component
 
 @Component
-class JsoupLinkDocumentFetcher : LinkDocumentFetcher {
+class JsoupLinkDocumentFetcher(
+    private val playwrightLinkDocumentFetcher: PlaywrightLinkDocumentFetcher,
+) : LinkDocumentFetcher {
     override fun fetch(url: String): Document {
-        return Jsoup.connect(url).get()
+        return try {
+            Jsoup.connect(url).get()
+        } catch (jsoupException: Exception) {
+            fetchWithPlaywright(url, jsoupException)
+        }
+    }
+
+    private fun fetchWithPlaywright(
+        url: String,
+        jsoupException: Exception,
+    ): Document {
+        return try {
+            playwrightLinkDocumentFetcher.fetch(url)
+        } catch (playwrightException: Exception) {
+            playwrightException.addSuppressed(jsoupException)
+            throw playwrightException
+        }
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/JsoupLinkDocumentFetcher.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/JsoupLinkDocumentFetcher.kt
@@ -2,11 +2,15 @@ package com.techtaurant.mainserver.link.application
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.Primary
 import org.springframework.stereotype.Component
 
+@Primary
 @Component
 class JsoupLinkDocumentFetcher(
-    private val playwrightLinkDocumentFetcher: PlaywrightLinkDocumentFetcher,
+    @Qualifier("playwrightLinkDocumentFetcher")
+    private val playwrightLinkDocumentFetcher: LinkDocumentFetcher,
 ) : LinkDocumentFetcher {
     override fun fetch(url: String): Document {
         return try {

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/PlaywrightLinkDocumentFetcher.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/PlaywrightLinkDocumentFetcher.kt
@@ -13,8 +13,8 @@ import org.jsoup.nodes.Document
 import org.springframework.stereotype.Component
 
 @Component
-class PlaywrightLinkDocumentFetcher {
-    fun fetch(url: String): Document {
+class PlaywrightLinkDocumentFetcher : LinkDocumentFetcher {
+    override fun fetch(url: String): Document {
         val playwright = Playwright.create()
         try {
             val browser =

--- a/src/main/kotlin/com/techtaurant/mainserver/link/application/PlaywrightLinkDocumentFetcher.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/link/application/PlaywrightLinkDocumentFetcher.kt
@@ -1,0 +1,74 @@
+package com.techtaurant.mainserver.link.application
+
+import com.microsoft.playwright.Browser
+import com.microsoft.playwright.BrowserType
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.Playwright
+import com.microsoft.playwright.TimeoutError
+import com.microsoft.playwright.options.LoadState
+import com.microsoft.playwright.options.WaitUntilState
+import org.jsoup.HttpStatusException
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.springframework.stereotype.Component
+
+@Component
+class PlaywrightLinkDocumentFetcher {
+    fun fetch(url: String): Document {
+        val playwright = Playwright.create()
+        try {
+            val browser =
+                playwright.chromium()
+                    .launch(BrowserType.LaunchOptions().setHeadless(true))
+            try {
+                return fetchWithBrowser(browser, url)
+            } finally {
+                browser.close()
+            }
+        } finally {
+            playwright.close()
+        }
+    }
+
+    private fun fetchWithBrowser(
+        browser: Browser,
+        url: String,
+    ): Document {
+        val page = browser.newPage()
+        try {
+            val response =
+                page.navigate(
+                    url,
+                    Page.NavigateOptions()
+                        .setWaitUntil(WaitUntilState.LOAD)
+                        .setTimeout(NAVIGATION_TIMEOUT_MILLIS),
+                )
+
+            if (response != null && response.status() >= HTTP_ERROR_STATUS_CODE) {
+                throw HttpStatusException("HTTP error fetching URL", response.status(), url)
+            }
+
+            waitForRenderedContent(page)
+            return Jsoup.parse(page.content(), url)
+        } finally {
+            page.close()
+        }
+    }
+
+    private fun waitForRenderedContent(page: Page) {
+        try {
+            page.waitForLoadState(
+                LoadState.NETWORKIDLE,
+                Page.WaitForLoadStateOptions().setTimeout(RENDER_IDLE_TIMEOUT_MILLIS),
+            )
+        } catch (exception: TimeoutError) {
+            return
+        }
+    }
+
+    private companion object {
+        private const val HTTP_ERROR_STATUS_CODE = 400
+        private const val NAVIGATION_TIMEOUT_MILLIS = 30_000.0
+        private const val RENDER_IDLE_TIMEOUT_MILLIS = 5_000.0
+    }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/link/application/JsoupLinkDocumentFetcherTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/application/JsoupLinkDocumentFetcherTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertFailsWith
 
 @DisplayName("JsoupLinkDocumentFetcher 테스트")
 class JsoupLinkDocumentFetcherTest {
-    private val playwrightLinkDocumentFetcher: PlaywrightLinkDocumentFetcher = mockk()
+    private val playwrightLinkDocumentFetcher: LinkDocumentFetcher = mockk()
     private val fetcher = JsoupLinkDocumentFetcher(playwrightLinkDocumentFetcher)
 
     @Test

--- a/src/test/kotlin/com/techtaurant/mainserver/link/application/JsoupLinkDocumentFetcherTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/link/application/JsoupLinkDocumentFetcherTest.kt
@@ -1,0 +1,65 @@
+package com.techtaurant.mainserver.link.application
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.jsoup.Jsoup
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFailsWith
+
+@DisplayName("JsoupLinkDocumentFetcher 테스트")
+class JsoupLinkDocumentFetcherTest {
+    private val playwrightLinkDocumentFetcher: PlaywrightLinkDocumentFetcher = mockk()
+    private val fetcher = JsoupLinkDocumentFetcher(playwrightLinkDocumentFetcher)
+
+    @Test
+    @DisplayName("Jsoup 요청이 실패하면 Playwright로 렌더링 문서를 가져온다")
+    fun fetchFallsBackToPlaywrightWhenJsoupFails() {
+        // Given
+        val url = "not-a-url"
+        val fallbackDocument =
+            Jsoup.parse(
+                """
+                <html>
+                  <body>
+                    <main>CSR 렌더링</main>
+                  </body>
+                </html>
+                """.trimIndent(),
+                url,
+            )
+        every { playwrightLinkDocumentFetcher.fetch(url) } returns fallbackDocument
+
+        // When
+        val result = fetcher.fetch(url)
+
+        // Then
+        assertThat(result.selectFirst("main")?.text()).isEqualTo("CSR 렌더링")
+        verify(exactly = 1) { playwrightLinkDocumentFetcher.fetch(url) }
+    }
+
+    @Test
+    @DisplayName("Playwright fallback도 실패하면 Jsoup 실패 원인을 suppressed exception으로 보존한다")
+    fun fetchPreservesJsoupFailureWhenPlaywrightFails() {
+        // Given
+        val url = "not-a-url"
+        val playwrightException = IllegalStateException("playwright failure")
+        every { playwrightLinkDocumentFetcher.fetch(url) } throws playwrightException
+
+        // When
+        val result =
+            assertFailsWith<IllegalStateException> {
+                fetcher.fetch(url)
+            }
+
+        // Then
+        assertThat(result).isSameAs(playwrightException)
+        assertThat(result.suppressed)
+            .hasSize(1)
+            .allSatisfy { suppressedException ->
+                assertThat(suppressedException).isInstanceOf(IllegalArgumentException::class.java)
+            }
+    }
+}


### PR DESCRIPTION
## 어떤 작업인가요?
- Jsoup만으로 HTML을 가져오기 어려운 CSR 렌더링 페이지를 Playwright fallback으로 수집하고, Spring bean 주입 시 기본 LinkDocumentFetcher가 명확히 선택되도록 정리합니다.

## 어떻게 해결했나요?
**CSR 문서 수집 fallback 추가**
- Jsoup 요청 실패 시 Playwright headless Chromium으로 페이지를 렌더링하고 HTML을 Jsoup Document로 파싱합니다.
- Playwright fallback도 실패하면 최초 Jsoup 실패 원인을 suppressed exception으로 보존합니다.

**Playwright 실행 환경 구성**
- Playwright Java 의존성을 추가하고 SLF4J simple 바인딩 충돌을 제외합니다.
- 런타임 Docker 이미지를 Playwright browser/system dependency가 포함된 이미지로 변경합니다.

**LinkDocumentFetcher bean wiring 정리**
- Playwright fetcher를 LinkDocumentFetcher 구현체로 등록합니다.
- Jsoup fetcher를 primary bean으로 지정하고 fallback 주입에는 qualifier를 사용해 기본 fetcher 주입 충돌을 방지합니다.

**회귀 테스트 추가**
- Jsoup 실패 시 fallback 호출, fallback 실패 시 원인 보존 동작을 테스트합니다.
- fetcher 생성자 타입을 LinkDocumentFetcher 기준으로 맞춰 bean 계약을 검증합니다.

## 중요한 변경 사항은 무엇인가요?
### 링크 문서 fetcher fallback

**Jsoup 실패 후 Playwright 재시도**
- **변경 이유**: CSR 기반 페이지의 렌더링된 HTML을 수집하기 위해 필요합니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/link/application/JsoupLinkDocumentFetcher.kt`, `src/main/kotlin/com/techtaurant/mainserver/link/application/PlaywrightLinkDocumentFetcher.kt`

**Playwright 런타임 의존성 추가**
- **변경 이유**: headless Chromium 기반 렌더링 fetcher를 빌드와 운영 환경에서 사용할 수 있게 하기 위해 필요합니다.
- **수정 파일**: `build.gradle.kts`, `Dockerfile`

**Spring bean 주입 경로 고정**
- **변경 이유**: LinkDocumentFetcher 구현체가 둘 이상일 때 기본 fetcher와 fallback fetcher가 명확히 분리되어야 합니다.
- **수정 파일**: `src/main/kotlin/com/techtaurant/mainserver/link/application/JsoupLinkDocumentFetcher.kt`, `src/main/kotlin/com/techtaurant/mainserver/link/application/PlaywrightLinkDocumentFetcher.kt`

**fallback 동작 테스트 추가**
- **변경 이유**: Jsoup 실패와 Playwright 실패 경로의 동작을 회귀 테스트로 고정하기 위해 필요합니다.
- **수정 파일**: `src/test/kotlin/com/techtaurant/mainserver/link/application/JsoupLinkDocumentFetcherTest.kt`

Co-Authored-By: Codex <codex@openai.com>