### PR TITLE
modify(security): CORS origin 패턴 매칭 적용

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,11 +22,11 @@ OAUTH2_SUCCESS_REDIRECT_URL=http://localhost:3000/oauth/callback
 OAUTH2_FAILURE_REDIRECT_URL=http://localhost:3000/oauth/error
 
 # CORS
-# 허용할 Origin을 쉼표로 구분하여 지정
-# 개발 환경: 프론트엔드 로컬 주소
-# 프로덕션: 실제 도메인 (예: https://techtaurant.com)
-# 주의: allowCredentials=true 설정으로 와일드카드(*) 사용 불가
-CORS_ORIGINS=http://localhost:3000,http://localhost:8000
+# 허용할 Origin 패턴을 쉼표로 구분하여 지정
+# 개발 환경: 프론트엔드 로컬 주소 또는 https://*.techtaurant.com:[*] 형식
+# 프로덕션: fallback에 사용할 구체 origin을 먼저 두고, 소유한 도메인 범위의 패턴만 추가
+# 패턴 매칭 시 요청 origin이 응답되므로 allowCredentials=true와 함께 사용할 수 있음
+CORS_ORIGINS=https://local.techtaurant.com:3010,http://localhost:3000
 
 # Cookie Settings
 # COOKIE_SECURE: HTTPS에서만 쿠키 전송 (개발: false, 프로덕션: true)

--- a/src/main/kotlin/com/techtaurant/mainserver/security/config/CorsProperties.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/config/CorsProperties.kt
@@ -1,8 +1,21 @@
 package com.techtaurant.mainserver.security.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.web.cors.CorsConfiguration
 
 @ConfigurationProperties(prefix = "cors")
 data class CorsProperties(
-    val allowedOrigins: String = "",
-)
+    val allowedOriginPatterns: String = "",
+) {
+    val parsedAllowedOriginPatterns: List<String>
+        get() =
+            allowedOriginPatterns
+                .split(",")
+                .map { it.trim().trimEnd('/') }
+                .filter { it.isNotEmpty() }
+
+    fun createCorsConfiguration(): CorsConfiguration =
+        CorsConfiguration().apply {
+            allowedOriginPatterns = parsedAllowedOriginPatterns
+        }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/security/config/CorsProperties.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/config/CorsProperties.kt
@@ -3,8 +3,6 @@ package com.techtaurant.mainserver.security.config
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.web.cors.CorsConfiguration
 
-private val ORIGIN_PATTERN_SEPARATOR_REGEX = Regex(",(?![^\\[]*\\])")
-
 @ConfigurationProperties(prefix = "cors")
 data class CorsProperties(
     val allowedOriginPatterns: String = "",
@@ -12,7 +10,7 @@ data class CorsProperties(
     val parsedAllowedOriginPatterns: List<String>
         get() =
             allowedOriginPatterns
-                .split(ORIGIN_PATTERN_SEPARATOR_REGEX)
+                .split(",")
                 .map { it.trim().trimEnd('/') }
                 .filter { it.isNotEmpty() }
 

--- a/src/main/kotlin/com/techtaurant/mainserver/security/config/CorsProperties.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/config/CorsProperties.kt
@@ -3,6 +3,8 @@ package com.techtaurant.mainserver.security.config
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.web.cors.CorsConfiguration
 
+private val ORIGIN_PATTERN_SEPARATOR_REGEX = Regex(",(?![^\\[]*\\])")
+
 @ConfigurationProperties(prefix = "cors")
 data class CorsProperties(
     val allowedOriginPatterns: String = "",
@@ -10,7 +12,7 @@ data class CorsProperties(
     val parsedAllowedOriginPatterns: List<String>
         get() =
             allowedOriginPatterns
-                .split(",")
+                .split(ORIGIN_PATTERN_SEPARATOR_REGEX)
                 .map { it.trim().trimEnd('/') }
                 .filter { it.isNotEmpty() }
 

--- a/src/main/kotlin/com/techtaurant/mainserver/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/config/SecurityConfig.kt
@@ -17,7 +17,6 @@ import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter
-import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
@@ -89,12 +88,7 @@ class SecurityConfig(
     @Bean
     fun corsConfigurationSource(): CorsConfigurationSource {
         val configuration =
-            CorsConfiguration().apply {
-                allowedOrigins =
-                    corsProperties.allowedOrigins
-                        .split(",")
-                        .map { it.trim() }
-                        .filter { it.isNotEmpty() }
+            corsProperties.createCorsConfiguration().apply {
                 allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 allowedHeaders = listOf("*")
                 allowCredentials = true

--- a/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2RedirectResolver.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2RedirectResolver.kt
@@ -18,6 +18,8 @@ class OAuth2RedirectResolver(
     private val corsProperties: CorsProperties,
 ) {
     private val logger = LoggerFactory.getLogger(OAuth2RedirectResolver::class.java)
+    private val allowedOriginPatterns = corsProperties.parsedAllowedOriginPatterns
+    private val corsConfiguration = corsProperties.createCorsConfiguration()
 
     companion object {
         const val DEFAULT_SUCCESS_REDIRECT_URI = "/oauth/callback"
@@ -46,26 +48,19 @@ class OAuth2RedirectResolver(
     ): String {
         val origin = getOriginCookie(request)
         val redirectUri = cookieHelper.getCookie(request, redirectUriCookieName)
-        val allowedOrigins =
-            corsProperties.allowedOrigins
-                .split(",")
-                .map { it.trim().trimEnd('/') }
-                .filter { it.isNotEmpty() }
-
         logger.info(
-            "resolve: originCookie={}, allowedOrigins={}, redirectUriCookieName={}, redirectUriPresent={}",
+            "resolve: originCookie={}, allowedOriginPatterns={}, redirectUriCookieName={}, redirectUriPresent={}",
             origin,
-            allowedOrigins,
+            allowedOriginPatterns,
             redirectUriCookieName,
             !redirectUri.isNullOrBlank(),
         )
 
-        val validOrigin = resolveValidOrigin(origin, allowedOrigins)
+        val validOrigin = resolveValidOrigin(origin)
         val redirectUrl =
             resolveRedirectUrl(
                 redirectUri = redirectUri,
                 validOrigin = validOrigin,
-                allowedOrigins = allowedOrigins,
             ) ?: buildRedirectUrl(validOrigin, fallbackRedirectUri)
 
         logger.info("resolve: redirectUrl={}", redirectUrl)
@@ -79,33 +74,37 @@ class OAuth2RedirectResolver(
         )?.trim()?.trimEnd('/')
     }
 
-    private fun resolveValidOrigin(
-        origin: String?,
-        allowedOrigins: List<String>,
-    ): String {
-        if (origin != null && origin in allowedOrigins) {
+    private fun resolveValidOrigin(origin: String?): String {
+        if (origin != null && corsConfiguration.checkOrigin(origin) != null) {
             return origin
         }
 
         logger.warn(
-            "resolve: origin not in allowedOrigins, falling back. origin={}, allowedOrigins={}",
+            "resolve: origin not in allowedOriginPatterns, falling back. origin={}, allowedOriginPatterns={}",
             origin,
-            allowedOrigins,
+            allowedOriginPatterns,
         )
-        return allowedOrigins.firstOrNull() ?: DEFAULT_ORIGIN
+        return resolveFallbackOrigin()
     }
+
+    private fun resolveFallbackOrigin(): String =
+        allowedOriginPatterns.firstNotNullOfOrNull { pattern ->
+            runCatching {
+                val normalizedPattern = pattern.trimEnd('/')
+                URI(normalizedPattern).toOrigin()?.takeIf { it == normalizedPattern }
+            }.getOrNull()
+        } ?: DEFAULT_ORIGIN
 
     private fun resolveRedirectUrl(
         redirectUri: String?,
         validOrigin: String,
-        allowedOrigins: List<String>,
     ): String? {
         val targetUri = redirectUri?.trim()?.takeIf { it.isNotEmpty() } ?: return null
         if (isInternalPath(targetUri)) {
             return buildRedirectUrl(validOrigin, targetUri)
         }
 
-        return resolveAllowedAbsoluteUrl(targetUri, allowedOrigins)
+        return resolveAllowedAbsoluteUrl(targetUri)
     }
 
     private fun isInternalPath(redirectUri: String): Boolean {
@@ -119,20 +118,17 @@ class OAuth2RedirectResolver(
         return "${origin.trimEnd('/')}$path"
     }
 
-    private fun resolveAllowedAbsoluteUrl(
-        redirectUri: String,
-        allowedOrigins: List<String>,
-    ): String? {
+    private fun resolveAllowedAbsoluteUrl(redirectUri: String): String? {
         return try {
             val uri = URI(redirectUri)
             val origin = uri.toOrigin()
-            if (origin != null && origin in allowedOrigins) {
+            if (origin != null && corsConfiguration.checkOrigin(origin) != null) {
                 redirectUri
             } else {
                 logger.warn(
-                    "resolve: redirectUri origin not allowed. redirectOrigin={}, allowedOrigins={}",
+                    "resolve: redirectUri origin not allowed. redirectOrigin={}, allowedOriginPatterns={}",
                     origin,
-                    allowedOrigins,
+                    allowedOriginPatterns,
                 )
                 null
             }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -108,7 +108,7 @@ otel:
 
 # CORS
 cors:
-    allowed-origins: ${CORS_ORIGINS}
+    allowed-origin-patterns: ${CORS_ORIGINS}
 
 # JWT
 jwt:

--- a/src/test/kotlin/com/techtaurant/mainserver/security/config/CorsPropertiesTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/config/CorsPropertiesTest.kt
@@ -35,4 +35,45 @@ class CorsPropertiesTest {
         // then
         assertThat(matchedOrigin).isNull()
     }
+
+    @Test
+    @DisplayName("포트 목록 내부의 쉼표를 origin 구분자로 처리하지 않는다")
+    fun `preserve commas inside origin pattern port list`() {
+        // given
+        val corsProperties =
+            CorsProperties(
+                allowedOriginPatterns =
+                    "https://*.techtaurant.com:[8080,8081], https://techtaurant.com",
+            )
+
+        // when
+        val parsedAllowedOriginPatterns = corsProperties.parsedAllowedOriginPatterns
+
+        // then
+        assertThat(parsedAllowedOriginPatterns).containsExactly(
+            "https://*.techtaurant.com:[8080,8081]",
+            "https://techtaurant.com",
+        )
+    }
+
+    @Test
+    @DisplayName("허용 패턴의 포트 목록에 포함된 모든 origin을 허용한다")
+    fun `allow origins matching ports in origin pattern port list`() {
+        // given
+        val corsConfiguration =
+            CorsProperties(
+                allowedOriginPatterns = "https://*.techtaurant.com:[8080,8081]",
+            ).createCorsConfiguration()
+        val origins =
+            listOf(
+                "https://preview.techtaurant.com:8080",
+                "https://preview.techtaurant.com:8081",
+            )
+
+        // when
+        val matchedOrigins = origins.map(corsConfiguration::checkOrigin)
+
+        // then
+        assertThat(matchedOrigins).containsExactlyElementsOf(origins)
+    }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/security/config/CorsPropertiesTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/config/CorsPropertiesTest.kt
@@ -35,45 +35,4 @@ class CorsPropertiesTest {
         // then
         assertThat(matchedOrigin).isNull()
     }
-
-    @Test
-    @DisplayName("포트 목록 내부의 쉼표를 origin 구분자로 처리하지 않는다")
-    fun `preserve commas inside origin pattern port list`() {
-        // given
-        val corsProperties =
-            CorsProperties(
-                allowedOriginPatterns =
-                    "https://*.techtaurant.com:[8080,8081], https://techtaurant.com",
-            )
-
-        // when
-        val parsedAllowedOriginPatterns = corsProperties.parsedAllowedOriginPatterns
-
-        // then
-        assertThat(parsedAllowedOriginPatterns).containsExactly(
-            "https://*.techtaurant.com:[8080,8081]",
-            "https://techtaurant.com",
-        )
-    }
-
-    @Test
-    @DisplayName("허용 패턴의 포트 목록에 포함된 모든 origin을 허용한다")
-    fun `allow origins matching ports in origin pattern port list`() {
-        // given
-        val corsConfiguration =
-            CorsProperties(
-                allowedOriginPatterns = "https://*.techtaurant.com:[8080,8081]",
-            ).createCorsConfiguration()
-        val origins =
-            listOf(
-                "https://preview.techtaurant.com:8080",
-                "https://preview.techtaurant.com:8081",
-            )
-
-        // when
-        val matchedOrigins = origins.map(corsConfiguration::checkOrigin)
-
-        // then
-        assertThat(matchedOrigins).containsExactlyElementsOf(origins)
-    }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/security/config/CorsPropertiesTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/config/CorsPropertiesTest.kt
@@ -1,0 +1,38 @@
+package com.techtaurant.mainserver.security.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class CorsPropertiesTest {
+    private val corsConfiguration =
+        CorsProperties(
+            allowedOriginPatterns = "https://techtaurant.com, https://*.techtaurant.com",
+        ).createCorsConfiguration()
+
+    @Test
+    @DisplayName("허용 패턴과 일치하는 서브도메인 origin을 반환한다")
+    fun `allow origin matching subdomain pattern`() {
+        // given
+        val origin = "https://preview.techtaurant.com"
+
+        // when
+        val matchedOrigin = corsConfiguration.checkOrigin(origin)
+
+        // then
+        assertThat(matchedOrigin).isEqualTo(origin)
+    }
+
+    @Test
+    @DisplayName("허용 패턴과 일치하지 않는 origin은 거부한다")
+    fun `reject origin not matching allowed pattern`() {
+        // given
+        val origin = "https://evil.example"
+
+        // when
+        val matchedOrigin = corsConfiguration.checkOrigin(origin)
+
+        // then
+        assertThat(matchedOrigin).isNull()
+    }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2RedirectResolverTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2RedirectResolverTest.kt
@@ -23,7 +23,8 @@ class OAuth2RedirectResolverTest {
                 cookieHelper = cookieHelper,
                 corsProperties =
                     CorsProperties(
-                        allowedOrigins = "https://techtaurant.com,http://localhost:3000",
+                        allowedOriginPatterns =
+                            "https://techtaurant.com,https://*.techtaurant.com,http://localhost:3000",
                     ),
             )
         request = MockHttpServletRequest()
@@ -80,6 +81,54 @@ class OAuth2RedirectResolverTest {
     }
 
     @Test
+    @DisplayName("origin 쿠키가 허용된 서브도메인 패턴과 일치하면 내부 path와 결합한다")
+    fun `resolve redirect with origin matching allowed pattern`() {
+        // given
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_ORIGIN_COOKIE,
+            )
+        } returns "https://preview.techtaurant.com"
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_SUCCESS_REDIRECT_URI_COOKIE,
+            )
+        } returns "/ko/oauth/callback"
+
+        // when
+        val redirectUrl = resolver.resolveSuccessRedirectUrl(request)
+
+        // then
+        assertThat(redirectUrl).isEqualTo("https://preview.techtaurant.com/ko/oauth/callback")
+    }
+
+    @Test
+    @DisplayName("redirect-uri absolute URL이 허용된 서브도메인 패턴과 일치하면 그대로 사용한다")
+    fun `resolve absolute redirect matching allowed pattern`() {
+        // given
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_ORIGIN_COOKIE,
+            )
+        } returns "https://techtaurant.com"
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_FAILURE_REDIRECT_URI_COOKIE,
+            )
+        } returns "https://preview.techtaurant.com/ko/oauth/error"
+
+        // when
+        val redirectUrl = resolver.resolveFailureRedirectUrl(request)
+
+        // then
+        assertThat(redirectUrl).isEqualTo("https://preview.techtaurant.com/ko/oauth/error")
+    }
+
+    @Test
     @DisplayName("redirect-uri absolute URL의 origin이 허용되지 않으면 기본 실패 경로로 fallback한다")
     fun `fallback failure redirect when absolute url origin is not allowed`() {
         // given
@@ -107,6 +156,39 @@ class OAuth2RedirectResolverTest {
     @DisplayName("origin 쿠키가 허용되지 않으면 첫 번째 허용 origin으로 내부 path를 결합한다")
     fun `fallback origin when origin cookie is not allowed`() {
         // given
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_ORIGIN_COOKIE,
+            )
+        } returns "https://evil.example"
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_SUCCESS_REDIRECT_URI_COOKIE,
+            )
+        } returns "/en/oauth/callback"
+
+        // when
+        val redirectUrl = resolver.resolveSuccessRedirectUrl(request)
+
+        // then
+        assertThat(redirectUrl).isEqualTo("https://techtaurant.com/en/oauth/callback")
+    }
+
+    @Test
+    @DisplayName("첫 허용 패턴이 wildcard이면 첫 구체 origin으로 fallback한다")
+    fun `fallback to first concrete origin when wildcard pattern is first`() {
+        // given
+        resolver =
+            OAuth2RedirectResolver(
+                cookieHelper = cookieHelper,
+                corsProperties =
+                    CorsProperties(
+                        allowedOriginPatterns =
+                            "https://*.techtaurant.com,https://techtaurant.com",
+                    ),
+            )
         every {
             cookieHelper.getCookie(
                 request,

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -56,7 +56,7 @@ logging:
     org.springframework.test: DEBUG
 
 cors:
-  allowed-origins: http://localhost:3000,http://localhost:8000
+  allowed-origin-patterns: http://localhost:3000,http://localhost:8000
 
 jwt:
   secret: test-jwt-secret-key-minimum-256-bits-for-hs256-algorithm


### PR DESCRIPTION
## 관련 자료
- Infra 이슈: https://github.com/Techtaurant/techtaurant-infra/issues/26

## 어떤 작업인가요?
- 기존 `CORS_ORIGINS` 환경변수 계약을 유지하면서 동적 서브도메인을 Spring origin pattern 방식으로 허용합니다.
- CORS 요청과 OAuth 성공·실패 리다이렉트가 동일한 origin 검증 규칙을 사용하도록 맞춥니다.

## 어떻게 해결했나요?
**Spring origin pattern 적용**
- `CorsProperties`에서 쉼표 구분 값을 정규화하고 `CorsConfiguration.allowedOriginPatterns`에 설정합니다.
- `SecurityConfig`가 공통 CORS 설정을 사용하도록 변경합니다.

**OAuth 리다이렉트 검증 통일**
- origin 쿠키와 absolute redirect URL을 `CorsConfiguration.checkOrigin`으로 검증합니다.
- wildcard pattern 자체가 fallback URL이 되지 않도록 첫 번째 구체 origin만 fallback으로 선택합니다.

**환경변수 호환성 유지**
- 외부 환경변수와 infra SSM key는 기존 `CORS_ORIGINS`를 그대로 사용합니다.
- 애플리케이션 내부 property만 `allowed-origin-patterns`로 변경합니다.

## 중요한 변경 사항은 무엇인가요?
### Credentialed CORS 패턴 지원

**허용 origin 처리 방식 변경**
- **변경 이유**: 프리뷰 등 동적 서브도메인을 origin별로 열거하지 않고 안전한 소유 도메인 패턴으로 허용하기 위함입니다.
- **수정 파일**: `CorsProperties.kt`, `SecurityConfig.kt`, `application.yml`

**OAuth open redirect 방어와 CORS 규칙 정합성 확보**
- **변경 이유**: HTTP CORS만 pattern을 지원할 경우 허용된 서브도메인에서도 OAuth redirect가 fallback되는 불일치를 막기 위함입니다.
- **수정 파일**: `OAuth2RedirectResolver.kt`, 관련 테스트

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.

Co-Authored-By: Codex <codex@openai.com>
