### PR TITLE
fix(oauth): 와일드카드 origin 리다이렉트 오류 수정

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2RedirectResolver.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2RedirectResolver.kt
@@ -23,6 +23,7 @@ class OAuth2RedirectResolver(
         const val DEFAULT_SUCCESS_REDIRECT_URI = "/oauth/callback"
         const val DEFAULT_FAILURE_REDIRECT_URI = "/oauth/error"
         private const val DEFAULT_ORIGIN = "http://localhost:3000"
+        private const val WILDCARD_HOST_PLACEHOLDER = "wildcard"
     }
 
     fun resolveSuccessRedirectUrl(request: HttpServletRequest): String =
@@ -83,7 +84,7 @@ class OAuth2RedirectResolver(
         origin: String?,
         allowedOrigins: List<String>,
     ): String {
-        if (origin != null && origin in allowedOrigins) {
+        if (origin != null && isOriginAllowed(origin, allowedOrigins)) {
             return origin
         }
 
@@ -92,7 +93,7 @@ class OAuth2RedirectResolver(
             origin,
             allowedOrigins,
         )
-        return allowedOrigins.firstOrNull() ?: DEFAULT_ORIGIN
+        return allowedOrigins.firstOrNull { parseOrigin(it) != null } ?: DEFAULT_ORIGIN
     }
 
     private fun resolveRedirectUrl(
@@ -126,7 +127,7 @@ class OAuth2RedirectResolver(
         return try {
             val uri = URI(redirectUri)
             val origin = uri.toOrigin()
-            if (origin != null && origin in allowedOrigins) {
+            if (origin != null && isOriginAllowed(origin, allowedOrigins)) {
                 redirectUri
             } else {
                 logger.warn(
@@ -142,10 +143,77 @@ class OAuth2RedirectResolver(
         }
     }
 
+    private fun isOriginAllowed(
+        origin: String,
+        allowedOrigins: List<String>,
+    ): Boolean {
+        val actualOrigin = parseOrigin(origin) ?: return false
+        return allowedOrigins.any { allowedOrigin ->
+            matchesAllowedOrigin(actualOrigin, allowedOrigin)
+        }
+    }
+
+    private fun matchesAllowedOrigin(
+        actualOrigin: Origin,
+        allowedOrigin: String,
+    ): Boolean {
+        val isWildcard = allowedOrigin.substringAfter("://", "").startsWith("*.")
+        if (!isWildcard) {
+            return parseOrigin(allowedOrigin) == actualOrigin
+        }
+        if (allowedOrigin.count { it == '*' } != 1) {
+            return false
+        }
+
+        val patternOrigin =
+            parseOrigin(
+                allowedOrigin.replaceFirst("*.", "$WILDCARD_HOST_PLACEHOLDER."),
+            ) ?: return false
+        val baseHost = patternOrigin.host.removePrefix("$WILDCARD_HOST_PLACEHOLDER.")
+
+        return actualOrigin.scheme == patternOrigin.scheme &&
+            actualOrigin.port == patternOrigin.port &&
+            actualOrigin.host.endsWith(".$baseHost")
+    }
+
+    private fun parseOrigin(value: String): Origin? {
+        return try {
+            val uri = URI(value)
+            val scheme = uri.scheme?.lowercase() ?: return null
+            val host = uri.host?.lowercase() ?: return null
+            if (scheme != "http" && scheme != "https") return null
+            if (uri.userInfo != null || uri.query != null || uri.fragment != null) return null
+            if (!uri.path.isNullOrEmpty() && uri.path != "/") return null
+
+            Origin(
+                scheme = scheme,
+                host = host,
+                port = uri.normalizedPort(scheme),
+            )
+        } catch (e: Exception) {
+            null
+        }
+    }
+
     private fun URI.toOrigin(): String? {
         val scheme = this.scheme ?: return null
         val host = this.host ?: return null
         val port = if (this.port != -1) ":${this.port}" else ""
         return "$scheme://$host$port".trimEnd('/')
     }
+
+    private fun URI.normalizedPort(scheme: String): Int {
+        if (port != -1) return port
+        return when (scheme) {
+            "http" -> 80
+            "https" -> 443
+            else -> -1
+        }
+    }
+
+    private data class Origin(
+        val scheme: String,
+        val host: String,
+        val port: Int,
+    )
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2RedirectResolverTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2RedirectResolverTest.kt
@@ -150,4 +150,111 @@ class OAuth2RedirectResolverTest {
         // then
         assertThat(redirectUrl).isEqualTo("https://techtaurant.com/oauth/callback")
     }
+
+    @Test
+    @DisplayName("origin이 wildcard 허용 패턴과 일치하면 실제 origin으로 redirect한다")
+    fun `resolve actual origin matching wildcard pattern`() {
+        // given
+        resolver = resolverWithAllowedOrigins("https://*.techtaurant.com")
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_ORIGIN_COOKIE,
+            )
+        } returns "https://dev.techtaurant.com"
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_SUCCESS_REDIRECT_URI_COOKIE,
+            )
+        } returns null
+
+        // when
+        val redirectUrl = resolver.resolveSuccessRedirectUrl(request)
+
+        // then
+        assertThat(redirectUrl).isEqualTo("https://dev.techtaurant.com/oauth/callback")
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 origin은 wildcard가 아닌 안전한 기본 origin으로 fallback한다")
+    fun `fallback safely without using wildcard as origin`() {
+        // given
+        resolver = resolverWithAllowedOrigins("https://*.techtaurant.com")
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_ORIGIN_COOKIE,
+            )
+        } returns "https://evil.example"
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_SUCCESS_REDIRECT_URI_COOKIE,
+            )
+        } returns null
+
+        // when
+        val redirectUrl = resolver.resolveSuccessRedirectUrl(request)
+
+        // then
+        assertThat(redirectUrl).isEqualTo("http://localhost:3000/oauth/callback")
+    }
+
+    @Test
+    @DisplayName("내부 path는 wildcard와 일치한 실제 origin과 결합한다")
+    fun `resolve internal path with actual origin matching wildcard pattern`() {
+        // given
+        resolver = resolverWithAllowedOrigins("https://*.techtaurant.com")
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_ORIGIN_COOKIE,
+            )
+        } returns "https://dev.techtaurant.com"
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_SUCCESS_REDIRECT_URI_COOKIE,
+            )
+        } returns "/posts"
+
+        // when
+        val redirectUrl = resolver.resolveSuccessRedirectUrl(request)
+
+        // then
+        assertThat(redirectUrl).isEqualTo("https://dev.techtaurant.com/posts")
+    }
+
+    @Test
+    @DisplayName("absolute redirect URL의 origin이 wildcard 패턴과 일치하면 그대로 사용한다")
+    fun `resolve absolute redirect url matching wildcard pattern`() {
+        // given
+        resolver = resolverWithAllowedOrigins("https://*.techtaurant.com")
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_ORIGIN_COOKIE,
+            )
+        } returns "https://dev.techtaurant.com"
+        every {
+            cookieHelper.getCookie(
+                request,
+                HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_FAILURE_REDIRECT_URI_COOKIE,
+            )
+        } returns "https://dev.techtaurant.com/oauth/error"
+
+        // when
+        val redirectUrl = resolver.resolveFailureRedirectUrl(request)
+
+        // then
+        assertThat(redirectUrl).isEqualTo("https://dev.techtaurant.com/oauth/error")
+    }
+
+    private fun resolverWithAllowedOrigins(allowedOrigins: String): OAuth2RedirectResolver {
+        return OAuth2RedirectResolver(
+            cookieHelper = cookieHelper,
+            corsProperties = CorsProperties(allowedOrigins = allowedOrigins),
+        )
+    }
 }


### PR DESCRIPTION
## 어떤 작업인가요?
- OAuth2 완료 후 `https://*.techtaurant.com` 설정값이 실제 리다이렉트 origin으로 사용되어 `%2A.techtaurant.com`으로 이동하는 문제를 수정합니다.

## 어떻게 해결했나요?
**Origin 검증**
- 허용 origin을 scheme, host, port로 구조화해 비교합니다.
- `*.` wildcard가 실제 서브도메인과 일치하면 설정 패턴이 아닌 요청의 실제 origin을 유지합니다.
- 내부 경로와 absolute redirect URL에 동일한 검증을 적용합니다.

**Fallback 방어**
- fallback 후보에서 wildcard 또는 유효하지 않은 origin을 제외합니다.
- concrete origin이 없으면 기존 안전 기본 origin을 사용합니다.

**회귀 방지**
- wildcard 정상 일치, 악성 origin 거부, 내부 경로 결합, absolute redirect URL 동작을 단위 테스트로 검증합니다.

## 중요한 변경 사항은 무엇인가요?
### OAuth 리다이렉트 보안
- **변경 이유**: wildcard 패턴 문자열이 브라우저 redirect 주소로 노출되지 않도록 방어합니다.
- **수정 파일**: `OAuth2RedirectResolver.kt`, `OAuth2RedirectResolverTest.kt`

Co-Authored-By: Codex <codex@openai.com>