### PR TITLE
fix(status): 도메인 간 중복된 커스텀 상태 코드 재배정

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ Authorization: Bearer {accessToken}
 
 ## 에러 코드
 
+### PostStatus / TagStatus
+
+게시물 도메인은 2000번대 커스텀 코드를 사용한다. (기존 3000번대는 `JwtStatus`와 겹쳐 2000번대로 이전)
+
+| HTTP Status | Custom Code | 설명 |
+|-------------|-------------|------|
+| 404 | 2001 | 게시물을 찾을 수 없습니다 |
+| 400 | 2002 | 카테고리 깊이는 최대 5단계까지 가능합니다 |
+| 400 | 2005 | 유효하지 않은 정렬 타입입니다 |
+| 403 | 2006 | 다른 사용자의 게시물을 수정할 수 없습니다 |
+| 400 | 2008 | 제목은 필수입니다 |
+| 400 | 2009 | 본문은 필수입니다 |
+| 400 | 2010 | 태그는 최대 10개까지 설정할 수 있습니다 |
+
+**위치**: `post/enums/PostStatus.kt`, `post/enums/TagStatus.kt`
+
 ### OAuthStatus
 
 | HTTP Status | Custom Code | 설명 |

--- a/src/main/kotlin/com/techtaurant/mainserver/comment/enums/CommentStatus.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/comment/enums/CommentStatus.kt
@@ -11,11 +11,11 @@ enum class CommentStatus(
     private val customStatusCode: Int,
     private val description: String,
 ) : StatusIfs {
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 4001, "댓글을 찾을 수 없습니다"),
-    COMMENT_PARENT_MISMATCH(HttpStatus.BAD_REQUEST.value(), 4002, "부모 댓글이 다른 게시물의 댓글입니다"),
-    COMMENT_MAX_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST.value(), 4003, "대댓글의 답글은 작성할 수 없습니다"),
-    COMMENT_AUTHOR_MISMATCH(HttpStatus.FORBIDDEN.value(), 4004, "댓글 작성자만 수행할 수 있습니다"),
-    COMMENT_ALREADY_DELETED(HttpStatus.GONE.value(), 4005, "이미 삭제된 댓글입니다"),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 7001, "댓글을 찾을 수 없습니다"),
+    COMMENT_PARENT_MISMATCH(HttpStatus.BAD_REQUEST.value(), 7002, "부모 댓글이 다른 게시물의 댓글입니다"),
+    COMMENT_MAX_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST.value(), 7003, "대댓글의 답글은 작성할 수 없습니다"),
+    COMMENT_AUTHOR_MISMATCH(HttpStatus.FORBIDDEN.value(), 7004, "댓글 작성자만 수행할 수 있습니다"),
+    COMMENT_ALREADY_DELETED(HttpStatus.GONE.value(), 7005, "이미 삭제된 댓글입니다"),
     ;
 
     override fun getHttpStatusCode(): Int {

--- a/src/main/kotlin/com/techtaurant/mainserver/common/swagger/ApiErrorCodeOperationCustomizer.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/common/swagger/ApiErrorCodeOperationCustomizer.kt
@@ -130,7 +130,7 @@ class ApiErrorCodeOperationCustomizer : OperationCustomizer {
 
     private fun businessErrorSchema(): Schema<*> =
         ObjectSchema()
-            .addProperty("status", IntegerSchema().description("커스텀 상태 코드").example(3001))
+            .addProperty("status", IntegerSchema().description("커스텀 상태 코드").example(2001))
             .addProperty(
                 "data",
                 Schema<Any>().apply {

--- a/src/main/kotlin/com/techtaurant/mainserver/common/swagger/SwaggerErrorResponseConfig.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/common/swagger/SwaggerErrorResponseConfig.kt
@@ -158,7 +158,7 @@ class SwaggerErrorResponseConfig {
 
     private fun businessErrorSchema(): Schema<*> {
         return ObjectSchema()
-            .addProperty("status", IntegerSchema().description("커스텀 상태 코드").example(3001))
+            .addProperty("status", IntegerSchema().description("커스텀 상태 코드").example(2001))
             .addProperty(
                 "data",
                 Schema<Any>().apply {

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/enums/NotificationStatus.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/enums/NotificationStatus.kt
@@ -8,9 +8,9 @@ enum class NotificationStatus(
     private val customStatusCode: Int,
     private val description: String,
 ) : StatusIfs {
-    NOTIFICATION_PAYLOAD_REQUIRED(HttpStatus.BAD_REQUEST.value(), 6001, "알림 payload는 비어 있을 수 없습니다"),
-    NOTIFICATION_RECIPIENT_REQUIRED(HttpStatus.BAD_REQUEST.value(), 6002, "수신자는 최소 1명 이상이어야 합니다"),
-    NOTIFICATION_ARGUMENT_REQUIRED(HttpStatus.BAD_REQUEST.value(), 6003, "알림 메시지 인자 정보가 필요합니다"),
+    NOTIFICATION_PAYLOAD_REQUIRED(HttpStatus.BAD_REQUEST.value(), 8001, "알림 payload는 비어 있을 수 없습니다"),
+    NOTIFICATION_RECIPIENT_REQUIRED(HttpStatus.BAD_REQUEST.value(), 8002, "수신자는 최소 1명 이상이어야 합니다"),
+    NOTIFICATION_ARGUMENT_REQUIRED(HttpStatus.BAD_REQUEST.value(), 8003, "알림 메시지 인자 정보가 필요합니다"),
     ;
 
     override fun getHttpStatusCode(): Int {

--- a/src/main/kotlin/com/techtaurant/mainserver/post/enums/PostStatus.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/enums/PostStatus.kt
@@ -8,12 +8,12 @@ enum class PostStatus(
     private val customStatusCode: Int,
     private val description: String,
 ) : StatusIfs {
-    POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 3001, "게시물을 찾을 수 없습니다"),
-    CATEGORY_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST.value(), 3002, "카테고리 깊이는 최대 5단계까지 가능합니다"),
-    INVALID_SORT_TYPE(HttpStatus.BAD_REQUEST.value(), 3005, "유효하지 않은 정렬 타입입니다"),
-    CANNOT_MODIFY_OTHERS_POST(HttpStatus.FORBIDDEN.value(), 3006, "다른 사용자의 게시물을 수정할 수 없습니다"),
-    TITLE_REQUIRED(HttpStatus.BAD_REQUEST.value(), 3008, "제목은 필수입니다"),
-    CONTENT_REQUIRED(HttpStatus.BAD_REQUEST.value(), 3009, "본문은 필수입니다"),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND.value(), 2001, "게시물을 찾을 수 없습니다"),
+    CATEGORY_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST.value(), 2002, "카테고리 깊이는 최대 5단계까지 가능합니다"),
+    INVALID_SORT_TYPE(HttpStatus.BAD_REQUEST.value(), 2005, "유효하지 않은 정렬 타입입니다"),
+    CANNOT_MODIFY_OTHERS_POST(HttpStatus.FORBIDDEN.value(), 2006, "다른 사용자의 게시물을 수정할 수 없습니다"),
+    TITLE_REQUIRED(HttpStatus.BAD_REQUEST.value(), 2008, "제목은 필수입니다"),
+    CONTENT_REQUIRED(HttpStatus.BAD_REQUEST.value(), 2009, "본문은 필수입니다"),
     ;
 
     override fun getHttpStatusCode(): Int {

--- a/src/main/kotlin/com/techtaurant/mainserver/post/enums/TagStatus.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/enums/TagStatus.kt
@@ -8,7 +8,7 @@ enum class TagStatus(
     private val customStatusCode: Int,
     private val description: String,
 ) : StatusIfs {
-    TAG_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST.value(), 3010, "태그는 최대 10개까지 설정할 수 있습니다"),
+    TAG_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST.value(), 2010, "태그는 최대 10개까지 설정할 수 있습니다"),
     ;
 
     override fun getHttpStatusCode(): Int = httpStatusCode

--- a/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentDeleteIntegrationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/comment/infrastructure/in/CommentDeleteIntegrationTest.kt
@@ -176,7 +176,7 @@ class CommentDeleteIntegrationTest : IntegrationTest() {
             .delete("/api/comments/${comment.id}")
             .then()
             .statusCode(HttpStatus.FORBIDDEN.value())
-            .body("status", org.hamcrest.Matchers.equalTo(4004))
+            .body("status", org.hamcrest.Matchers.equalTo(7004))
             .body("message", org.hamcrest.Matchers.equalTo("댓글 작성자만 수행할 수 있습니다"))
 
         // then
@@ -205,7 +205,7 @@ class CommentDeleteIntegrationTest : IntegrationTest() {
             .delete("/api/comments/${comment.id}")
             .then()
             .statusCode(HttpStatus.GONE.value())
-            .body("status", org.hamcrest.Matchers.equalTo(4005))
+            .body("status", org.hamcrest.Matchers.equalTo(7005))
             .body("message", org.hamcrest.Matchers.equalTo("이미 삭제된 댓글입니다"))
     }
 
@@ -222,7 +222,7 @@ class CommentDeleteIntegrationTest : IntegrationTest() {
             .delete("/api/comments/$nonExistentCommentId")
             .then()
             .statusCode(HttpStatus.NOT_FOUND.value())
-            .body("status", org.hamcrest.Matchers.equalTo(4001))
+            .body("status", org.hamcrest.Matchers.equalTo(7001))
             .body("message", org.hamcrest.Matchers.equalTo("댓글을 찾을 수 없습니다"))
     }
 

--- a/src/test/kotlin/com/techtaurant/mainserver/common/status/CustomStatusCodeUniquenessTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/common/status/CustomStatusCodeUniquenessTest.kt
@@ -1,0 +1,65 @@
+package com.techtaurant.mainserver.common.status
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.type.filter.AssignableTypeFilter
+
+@DisplayName("커스텀 상태 코드 유일성 테스트")
+class CustomStatusCodeUniquenessTest {
+    @Test
+    @DisplayName("도메인 상태 enum은 서로 겹치지 않는 커스텀 상태 코드를 사용한다")
+    fun customStatusCodes_shouldNotOverlapAcrossDomains() {
+        val statusEnums = scanStatusEnums()
+
+        assertThat(statusEnums)
+            .describedAs("StatusIfs 구현 enum을 스캔하지 못하면 중복 검사가 무의미해진다")
+            .hasSizeGreaterThanOrEqualTo(KNOWN_STATUS_ENUM_COUNT)
+
+        val ownersByCustomStatusCode =
+            statusEnums
+                .flatMap { statusEnum -> statusEnum.enumConstants.toList() }
+                .groupBy({ it.getCustomStatusCode() }, { describe(it) })
+        val duplicatedCodes = ownersByCustomStatusCode.filterValues { owners -> owners.size > 1 }
+
+        assertThat(duplicatedCodes)
+            .describedAs("같은 커스텀 상태 코드를 여러 도메인이 사용하면 클라이언트가 에러를 구분할 수 없다")
+            .isEmpty()
+    }
+
+    private fun scanStatusEnums(): List<Class<out StatusIfs>> {
+        val scanner =
+            object : ClassPathScanningCandidateComponentProvider(false) {
+                override fun isCandidateComponent(beanDefinition: AnnotatedBeanDefinition): Boolean = true
+            }
+        scanner.addIncludeFilter(AssignableTypeFilter(StatusIfs::class.java))
+
+        return scanner
+            .findCandidateComponents(BASE_PACKAGE)
+            .mapNotNull { it.beanClassName }
+            .map { Class.forName(it) }
+            .filter { it.isEnum && isProductionClass(it) }
+            .map {
+                @Suppress("UNCHECKED_CAST")
+                it as Class<out StatusIfs>
+            }
+    }
+
+    private fun isProductionClass(candidate: Class<*>): Boolean {
+        val classLocation = candidate.protectionDomain?.codeSource?.location?.path ?: return false
+        return classLocation.contains(MAIN_CLASSES_PATH)
+    }
+
+    private fun describe(status: StatusIfs): String {
+        val constant = status as Enum<*>
+        return "${constant.declaringJavaClass.simpleName}.${constant.name}"
+    }
+
+    companion object {
+        private const val BASE_PACKAGE = "com.techtaurant.mainserver"
+        private const val MAIN_CLASSES_PATH = "/classes/kotlin/main/"
+        private const val KNOWN_STATUS_ENUM_COUNT = 10
+    }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostLikeControllerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostLikeControllerTest.kt
@@ -158,7 +158,7 @@ class PostLikeControllerTest : IntegrationTest() {
 
         // Then: 에러 응답 확인
         assertNotNull(response)
-        assertEquals(3001, response.status, "POST_NOT_FOUND 에러 코드 (3001)가 반환되어야 함")
+        assertEquals(2001, response.status, "POST_NOT_FOUND 에러 코드 (2001)가 반환되어야 함")
         assertNotNull(response.message)
     }
 

--- a/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadLogControllerTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/infrastructure/in/PostReadLogControllerTest.kt
@@ -186,7 +186,7 @@ class PostReadLogControllerTest : IntegrationTest() {
 
         // Then: 에러 응답 확인
         assertNotNull(response)
-        assertEquals(3001, response.status, "POST_NOT_FOUND 에러 코드 (3001)가 반환되어야 함")
+        assertEquals(2001, response.status, "POST_NOT_FOUND 에러 코드 (2001)가 반환되어야 함")
         assertNotNull(response.message)
     }
 


### PR DESCRIPTION
## 관련 자료
- 이슈 : #167

Closes #167

## 어떤 작업인가요?
- 도메인별 커스텀 상태 코드 대역이 서로 겹쳐 클라이언트가 `status` 값만으로 에러를 구분할 수 없던 문제를 해결합니다.

## 어떻게 해결했나요?
**중복 커스텀 상태 코드 재배정**
- 작업 목적: 각 도메인이 고유한 커스텀 상태 코드 대역을 갖도록 정리
- 작업 내용 요약: `PostStatus`/`TagStatus`를 2000번대, `CommentStatus`를 7000번대, `NotificationStatus`를 8000번대로 이전하고, Swagger 예시 값과 영향받는 통합 테스트 기대값을 함께 갱신

**중복 방지 테스트 추가**
- 작업 목적: 코드 대역 재배정이 이후 작업에서 다시 무너지는 것을 방지
- 작업 내용 요약: `StatusIfs` 구현 enum을 클래스패스에서 스캔해 도메인 간 커스텀 상태 코드 중복 여부를 검증하는 테스트 추가

**에러 코드 문서화**
- 작업 목적: 재배정된 게시물 도메인 코드를 리뷰어/클라이언트가 참고할 수 있도록 정리
- 작업 내용 요약: README 에러 코드 섹션에 `PostStatus`/`TagStatus` 표와 이전 배경 추가

## 중요한 변경 사항은 무엇인가요?
### 중복 커스텀 상태 코드 재배정

**게시물 도메인 3000번대 → 2000번대**
- **변경 이유**: `JwtStatus`가 3001~3099를 이미 사용 중이어서 `POST_NOT_FOUND(3001)`과 JWT 에러가 같은 코드로 응답됨
- **수정 파일**: `post/enums/PostStatus.kt`, `post/enums/TagStatus.kt`

**댓글 도메인 4000번대 → 7000번대**
- **변경 이유**: `OAuthStatus`가 4001~4004를 사용 중이어서 `COMMENT_NOT_FOUND(4001)`과 충돌
- **수정 파일**: `comment/enums/CommentStatus.kt`

**알림 도메인 6000번대 → 8000번대**
- **변경 이유**: `LinkStatus`가 6001~6008을 사용 중이어서 알림 에러 코드와 충돌
- **수정 파일**: `notification/enums/NotificationStatus.kt`

**Swagger 예시 코드 갱신**
- **변경 이유**: 비즈니스 에러 응답 예시가 재배정 전 값(3001)을 노출하고 있어 실제 응답과 불일치
- **수정 파일**: `common/swagger/ApiErrorCodeOperationCustomizer.kt`, `common/swagger/SwaggerErrorResponseConfig.kt`

**기존 테스트 기대값 갱신**
- **변경 이유**: 재배정된 코드에 맞춰 통합 테스트의 `status` 기대값 수정
- **수정 파일**: `comment/infrastructure/in/CommentDeleteIntegrationTest.kt`, `post/infrastructure/in/PostLikeControllerTest.kt`, `post/infrastructure/in/PostReadLogControllerTest.kt`

### 중복 방지 테스트 추가

**커스텀 상태 코드 유일성 검증**
- **변경 이유**: 수동 관리만으로는 새 도메인 enum 추가 시 코드 대역 충돌이 재발할 수 있음
- **수정 파일**: `common/status/CustomStatusCodeUniquenessTest.kt` (신규)

### 에러 코드 문서화

**README 에러 코드 표 추가**
- **변경 이유**: 재배정된 게시물 도메인 코드와 이전 배경을 문서로 남김
- **수정 파일**: `README.md`

## 변경사항 공유 메시지

FE 공유용 원문입니다. 아래 블록을 그대로 복사해 Discord에 올리면 됩니다. (전체 파일: `discord-notice-status-code-2026-07-28.txt`)

<details>
<summary>펼쳐서 복사하기</summary>

```text
[BE 공지] 커스텀 에러 코드 대역 재배정 (2026-07-28)
PR: https://github.com/Techtaurant/be/pull/166  (base: dev)

────────────────────────────────────────────────────────────
■ 한 줄 요약
────────────────────────────────────────────────────────────
도메인끼리 겹치던 커스텀 에러 코드를 도메인당 1000단위로 갈라놨습니다.
HTTP 상태 코드는 그대로고, 응답 body의 "status" 값만 바뀝니다.

  기존: { "status": 3001, "message": "게시물을 찾을 수 없습니다" }  // HTTP 404
  변경: { "status": 2001, "message": "게시물을 찾을 수 없습니다" }  // HTTP 404

규칙은 단순합니다. 뒤 세 자리는 그대로, 앞자리 하나만 바뀝니다.


────────────────────────────────────────────────────────────
■ 안 바뀌는 것 (먼저 확인해 주세요)
────────────────────────────────────────────────────────────
- HTTP 상태 코드: 전부 그대로입니다. HTTP로만 분기하는 코드는 영향 없음.
- message 문구: 그대로입니다.
- 인증 관련 코드: JWT 3xxx, OAuth 4xxx 는 이동하지 않았습니다.
  → 3003(Access Token 만료), 3008(인증 필요), 4003(OAuth 인증 실패)
    같은 기존 인증 분기는 그대로 동작합니다.


────────────────────────────────────────────────────────────
■ 바뀌는 코드 전체 목록
────────────────────────────────────────────────────────────

[게시물]  3xxx -> 2xxx
  AS-IS  TO-BE  HTTP  설명
  3001   2001   404   게시물을 찾을 수 없습니다
  3002   2002   400   카테고리 깊이는 최대 5단계까지 가능합니다
  3005   2005   400   유효하지 않은 정렬 타입입니다
  3006   2006   403   다른 사용자의 게시물을 수정할 수 없습니다
  3008   2008   400   제목은 필수입니다
  3009   2009   400   본문은 필수입니다
  3010   2010   400   태그는 최대 10개까지 설정할 수 있습니다

[댓글]  4xxx -> 7xxx
  AS-IS  TO-BE  HTTP  설명
  4001   7001   404   댓글을 찾을 수 없습니다
  4002   7002   400   부모 댓글이 다른 게시물의 댓글입니다
  4003   7003   400   대댓글의 답글은 작성할 수 없습니다
  4004   7004   403   댓글 작성자만 수행할 수 있습니다
  4005   7005   410   이미 삭제된 댓글입니다

[알림]  6xxx -> 8xxx
  AS-IS  TO-BE  HTTP  설명
  6001   8001   400   알림 payload는 비어 있을 수 없습니다
  6002   8002   400   수신자는 최소 1명 이상이어야 합니다
  6003   8003   400   알림 메시지 인자 정보가 필요합니다


────────────────────────────────────────────────────────────
■ 왜 바꾸나요
────────────────────────────────────────────────────────────
서로 다른 도메인이 같은 숫자를 쓰고 있어서, status 값만으로는
어떤 에러인지 구분이 안 되는 상태였습니다.

  3001 = 게시물 없음(404)  AND  Refresh Token 무효(401)
  3008 = 제목 필수(400)    AND  인증 필요(401)
  3010 = 태그 초과(400)    AND  Refresh Token 만료(401)
  4001 = 댓글 없음(404)    AND  지원하지 않는 OAuth Provider(400)
  6001 = 알림 payload 없음  AND  링크를 찾을 수 없음

특히 게시물 쪽 3008/3010이 인증 코드 대역과 겹쳐 있어서,
"제목 안 씀"이 "인증 만료"로 오인될 수 있는 구조였습니다.


────────────────────────────────────────────────────────────
■ FE에서 확인 부탁드릴 것
────────────────────────────────────────────────────────────
아래 숫자를 코드에서 검색해 주세요. 쓰고 있다면 수정이 필요합니다.

  3001  3002  3005  3006  3008  3009  3010
  4001  4002  4003  4004  4005
  6001  6002  6003

주의할 점 하나:
배포 후에도 3001/3008/3010 은 "존재하는 코드"입니다. 다만 의미가
게시물 에러에서 JWT 에러로 바뀝니다. 즉 분기가 사라지는 게 아니라
조용히 다른 에러로 오작동합니다. 값 비교로 분기 중이라면 꼭 확인 필요.

  3001 -> 이제 Refresh Token 무효 (401)
  3002 -> 이제 Refresh Token 없음 (401)
  3005 -> 이제 잘못된 형식의 토큰 (401)
  3006 -> 이제 지원하지 않는 토큰 (401)
  3008 -> 이제 인증 필요 (401)
  3009 -> 이제 접근 권한 없음 (403)
  3010 -> 이제 Refresh Token 만료 (401)
  4001~4004 -> 이제 OAuth 에러
  6001, 6002 -> 이제 링크 관련 에러


────────────────────────────────────────────────────────────
■ 영향받는 API
────────────────────────────────────────────────────────────
  PATCH  /api/posts/{postId}
  DELETE /api/posts/{postId}
  GET    /api/posts/drafts
  GET    /api/posts/drafts/{postId}
  POST   /api/posts/{postId}/like
  POST   /api/posts/{postId}/read-logs
  PATCH  /api/comments/{commentId}
  DELETE /api/comments/{commentId}
  POST   /api/comments/{commentId}/like
  GET    /api/users/me/posts/{postId}
  + Open API 접두 엔드포인트 (.../posts/{postId}/view-logs 등)


────────────────────────────────────────────────────────────
■ 배포 관련
────────────────────────────────────────────────────────────
- DB 마이그레이션 없음. 무중단 배포 가능하고 롤백도 코드 되돌리기로 끝납니다.
- 다만 FE와 배포 시점을 맞춰야 합니다. BE만 먼저 나가면 위 분기들이
  그 사이에 오작동합니다. 롤백할 때도 짝을 맞춰 주세요.
- Swagger 예시값도 함께 갱신했습니다 (3001 -> 2001).
- 앞으로 코드 중복을 막는 테스트를 추가했습니다.
  이미 쓰인 커스텀 코드를 재사용하면 CI에서 빌드가 깨집니다.

현재 대역 소유 현황 (새 도메인은 9xxx 이상에서 시작해 주세요):
  999 이하  공통(Default)      1xxx  User        2xxx  Post / Tag
  3xxx      JWT                4xxx  OAuth       5xxx  Lock
  6xxx      Link               7xxx  Comment     8xxx  Notification


────────────────────────────────────────────────────────────
질문 있으시면 스레드로 남겨주세요.
```

</details>

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙인다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.
