### PR TITLE
fix(post): 첨부를 생략한 부분 수정에서 기존 파일 유지

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationPayloadResourceResolver.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationPayloadResourceResolver.kt
@@ -2,6 +2,7 @@ package com.techtaurant.mainserver.notification.application
 
 import com.techtaurant.mainserver.attachment.application.AttachmentService
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
+import com.techtaurant.mainserver.post.application.PostThumbnailResolver
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.user.application.UserProfileImageResolver
@@ -17,6 +18,7 @@ class NotificationPayloadResourceResolver(
     private val postRepository: PostRepository,
     private val attachmentService: AttachmentService,
     private val userProfileImageResolver: UserProfileImageResolver,
+    private val postThumbnailResolver: PostThumbnailResolver,
     @param:Value("\${app.default-post-thumbnail-url}")
     private val defaultPostThumbnailUrl: String,
     @param:Value("\${app.default-user-thumbnail-url:/static/images/user-thumbnail.png}")
@@ -68,12 +70,8 @@ class NotificationPayloadResourceResolver(
             postsById.values.associate { post ->
                 val postId = post.id!!
                 val attachments = attachmentsByPostId[postId].orEmpty()
-                val thumbnailAttachment =
-                    post.thumbnailImage?.let { thumbnailAttachmentId ->
-                        attachments.firstOrNull { it.id == thumbnailAttachmentId }
-                    } ?: attachments.minByOrNull { it.createdAt }
 
-                postId to thumbnailAttachment
+                postId to postThumbnailResolver.resolve(post, attachments)
             }
         val presignedThumbnailUrlByAttachmentId =
             thumbnailAttachmentByPostId.values

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostMetadataReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostMetadataReadService.kt
@@ -17,6 +17,7 @@ import java.util.UUID
 class PostMetadataReadService(
     private val postRepository: PostRepository,
     private val attachmentService: AttachmentService,
+    private val postThumbnailResolver: PostThumbnailResolver,
     @param:Value("\${app.default-post-thumbnail-url}")
     private val defaultThumbnailUrl: String,
     @param:Value("\${swagger.base-url}")
@@ -83,10 +84,7 @@ class PostMetadataReadService(
         attachments: List<Attachment>,
         presignedUrlByAttachmentId: Map<UUID, String>,
     ): String {
-        val thumbnailAttachment =
-            post.thumbnailImage?.let { thumbnailAttachmentId ->
-                attachments.firstOrNull { it.id == thumbnailAttachmentId }
-            } ?: attachments.minByOrNull { it.createdAt }
+        val thumbnailAttachment = postThumbnailResolver.resolve(post, attachments)
 
         return thumbnailAttachment?.id?.let { presignedUrlByAttachmentId[it] } ?: "$baseUrl$defaultThumbnailUrl"
     }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostThumbnailResolver.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostThumbnailResolver.kt
@@ -1,0 +1,26 @@
+package com.techtaurant.mainserver.post.application
+
+import com.techtaurant.mainserver.attachment.entity.Attachment
+import com.techtaurant.mainserver.post.entity.Post
+import org.springframework.stereotype.Component
+
+/**
+ * 게시물 목록/알림에 노출할 썸네일 첨부를 결정합니다.
+ *
+ * 작성자가 명시적으로 지정한 썸네일을 우선하고, 지정이 없으면 본문에서 가장 먼저 참조된 첨부를 사용합니다.
+ * 둘 다 없으면 null을 반환하며, 기본 썸네일 URL로 대체하는 책임은 호출부에 있습니다.
+ * 저장 시점에 썸네일을 자동으로 승격시키지 않고 조회 시점에 결정하므로,
+ * 본문이 바뀌면 별도 갱신 없이 노출 썸네일도 함께 따라갑니다.
+ */
+@Component
+class PostThumbnailResolver {
+    fun resolve(
+        post: Post,
+        confirmedAttachments: List<Attachment>,
+    ): Attachment? {
+        val attachmentById = confirmedAttachments.associateBy { it.id }
+        post.thumbnailImage?.let { attachmentById[it] }?.let { return it }
+
+        return post.referencedAttachmentIds().firstNotNullOfOrNull { attachmentById[it] }
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -163,35 +163,44 @@ class PostWriteService(
         }
 
         val newStatus = request.status ?: post.status
-        if (newStatus != PostStatusEnum.DRAFT) {
-            val attachmentIdsIncludedInContent =
-                mergeAttachmentIds(
-                    filterAttachmentIdsIncludedInContent(post.content, request.attachmentIds),
-                    request.thumbnailAttachmentId,
+        when {
+            newStatus == PostStatusEnum.DRAFT -> post.thumbnailImage = null
+            request.attachmentIds != null -> {
+                val attachmentIdsIncludedInContent =
+                    mergeAttachmentIds(
+                        filterAttachmentIdsIncludedInContent(post.content, request.attachmentIds),
+                        request.thumbnailAttachmentId,
+                    )
+                val thumbnailAttachmentId =
+                    resolveThumbnailAttachmentId(
+                        requestThumbnailAttachmentId = request.thumbnailAttachmentId,
+                        currentThumbnailAttachmentId = post.thumbnailImage,
+                        attachmentIdsIncludedInContent = attachmentIdsIncludedInContent,
+                    )
+                val keepAttachmentIds = mergeAttachmentIds(attachmentIdsIncludedInContent, thumbnailAttachmentId)
+
+                attachmentService.confirmAttachmentsByIds(
+                    referenceId = postId,
+                    referenceType = AttachmentReferenceType.POST,
+                    attachmentIds = keepAttachmentIds,
                 )
-            val thumbnailAttachmentId =
-                resolveThumbnailAttachmentId(
-                    requestThumbnailAttachmentId = request.thumbnailAttachmentId,
-                    currentThumbnailAttachmentId = post.thumbnailImage,
-                    attachmentIdsIncludedInContent = attachmentIdsIncludedInContent,
+
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    referenceId = postId,
+                    referenceType = AttachmentReferenceType.POST,
+                    keepAttachmentIds = keepAttachmentIds,
                 )
-            val keepAttachmentIds = mergeAttachmentIds(attachmentIdsIncludedInContent, thumbnailAttachmentId)
 
-            attachmentService.confirmAttachmentsByIds(
-                referenceId = postId,
-                referenceType = AttachmentReferenceType.POST,
-                attachmentIds = keepAttachmentIds,
-            )
-
-            attachmentService.deleteOrphanedAttachmentsByIds(
-                referenceId = postId,
-                referenceType = AttachmentReferenceType.POST,
-                keepAttachmentIds = keepAttachmentIds,
-            )
-
-            post.thumbnailImage = thumbnailAttachmentId
-        } else {
-            post.thumbnailImage = null
+                post.thumbnailImage = thumbnailAttachmentId
+            }
+            request.thumbnailAttachmentId != null -> {
+                attachmentService.confirmAttachmentsByIds(
+                    referenceId = postId,
+                    referenceType = AttachmentReferenceType.POST,
+                    attachmentIds = listOf(request.thumbnailAttachmentId),
+                )
+                post.thumbnailImage = request.thumbnailAttachmentId
+            }
         }
 
         val savedPost = postRepository.save(post)

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -162,45 +162,30 @@ class PostWriteService(
             post.status = newStatus
         }
 
-        val newStatus = request.status ?: post.status
-        when {
-            newStatus == PostStatusEnum.DRAFT -> post.thumbnailImage = null
-            request.attachmentIds != null -> {
-                val attachmentIdsIncludedInContent =
-                    mergeAttachmentIds(
-                        filterAttachmentIdsIncludedInContent(post.content, request.attachmentIds),
-                        request.thumbnailAttachmentId,
-                    )
-                val thumbnailAttachmentId =
-                    resolveThumbnailAttachmentId(
-                        requestThumbnailAttachmentId = request.thumbnailAttachmentId,
-                        currentThumbnailAttachmentId = post.thumbnailImage,
-                        attachmentIdsIncludedInContent = attachmentIdsIncludedInContent,
-                    )
-                val keepAttachmentIds = mergeAttachmentIds(attachmentIdsIncludedInContent, thumbnailAttachmentId)
+        request.thumbnailAttachmentId?.let { thumbnailAttachmentId ->
+            attachmentService.confirmAttachmentsByIds(
+                referenceId = postId,
+                referenceType = AttachmentReferenceType.POST,
+                attachmentIds = listOf(thumbnailAttachmentId),
+            )
+            post.thumbnailImage = thumbnailAttachmentId
+        }
 
-                attachmentService.confirmAttachmentsByIds(
-                    referenceId = postId,
-                    referenceType = AttachmentReferenceType.POST,
-                    attachmentIds = keepAttachmentIds,
-                )
+        request.attachmentIds?.let { attachmentIds ->
+            val attachmentIdsIncludedInContent =
+                filterAttachmentIdsIncludedInContent(post.content, attachmentIds)
 
-                attachmentService.deleteOrphanedAttachmentsByIds(
-                    referenceId = postId,
-                    referenceType = AttachmentReferenceType.POST,
-                    keepAttachmentIds = keepAttachmentIds,
-                )
+            attachmentService.confirmAttachmentsByIds(
+                referenceId = postId,
+                referenceType = AttachmentReferenceType.POST,
+                attachmentIds = attachmentIdsIncludedInContent,
+            )
 
-                post.thumbnailImage = thumbnailAttachmentId
-            }
-            request.thumbnailAttachmentId != null -> {
-                attachmentService.confirmAttachmentsByIds(
-                    referenceId = postId,
-                    referenceType = AttachmentReferenceType.POST,
-                    attachmentIds = listOf(request.thumbnailAttachmentId),
-                )
-                post.thumbnailImage = request.thumbnailAttachmentId
-            }
+            attachmentService.deleteOrphanedAttachmentsByIds(
+                referenceId = postId,
+                referenceType = AttachmentReferenceType.POST,
+                keepAttachmentIds = mergeAttachmentIds(attachmentIdsIncludedInContent, post.thumbnailImage),
+            )
         }
 
         val savedPost = postRepository.save(post)
@@ -268,32 +253,6 @@ class PostWriteService(
         attachmentIds: List<UUID>,
         thumbnailAttachmentId: UUID?,
     ): List<UUID> = (attachmentIds + listOfNotNull(thumbnailAttachmentId)).distinct()
-
-    /**
-     * 게시물 수정 후 최종 썸네일 attachmentId를 결정합니다.
-     * 요청 썸네일이 있으면 그 값을 우선 사용하고, 없으면 본문에 여전히 포함된 기존 썸네일을 유지합니다.
-     * 둘 다 없으면 본문에 남아 있는 첫 번째 attachment를 썸네일로 사용합니다.
-     *
-     * @param requestThumbnailAttachmentId 수정 요청에서 명시적으로 전달한 썸네일 attachmentId
-     * @param currentThumbnailAttachmentId 게시물에 현재 저장된 썸네일 attachmentId
-     * @param attachmentIdsIncludedInContent 수정 후 본문에 포함된 attachmentId 목록
-     * @return 최종적으로 게시물에 저장할 썸네일 attachmentId, 없으면 null
-     */
-    private fun resolveThumbnailAttachmentId(
-        requestThumbnailAttachmentId: UUID?,
-        currentThumbnailAttachmentId: UUID?,
-        attachmentIdsIncludedInContent: List<UUID>,
-    ): UUID? {
-        if (requestThumbnailAttachmentId != null) {
-            return requestThumbnailAttachmentId
-        }
-
-        if (currentThumbnailAttachmentId in attachmentIdsIncludedInContent) {
-            return currentThumbnailAttachmentId
-        }
-
-        return attachmentIdsIncludedInContent.firstOrNull()
-    }
 
     /**
      * 카테고리 경로를 파싱하여 해당 카테고리를 반환합니다.

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -171,15 +171,22 @@ class PostWriteService(
             post.thumbnailImage = thumbnailAttachmentId
         }
 
-        request.attachmentIds?.let { attachmentIds ->
+        if (request.content != null || request.attachmentIds != null) {
+            val attachmentIds =
+                request.attachmentIds
+                    ?: attachmentService
+                        .getConfirmedAttachments(postId, AttachmentReferenceType.POST)
+                        .mapNotNull { it.id }
             val attachmentIdsIncludedInContent =
                 filterAttachmentIdsIncludedInContent(post.content, attachmentIds)
 
-            attachmentService.confirmAttachmentsByIds(
-                referenceId = postId,
-                referenceType = AttachmentReferenceType.POST,
-                attachmentIds = attachmentIdsIncludedInContent,
-            )
+            request.attachmentIds?.let {
+                attachmentService.confirmAttachmentsByIds(
+                    referenceId = postId,
+                    referenceType = AttachmentReferenceType.POST,
+                    attachmentIds = attachmentIdsIncludedInContent,
+                )
+            }
 
             attachmentService.deleteOrphanedAttachmentsByIds(
                 referenceId = postId,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -129,6 +129,7 @@ class PostWriteService(
      * 요청에 포함된 필드만 업데이트하며, 작성자 권한을 검증합니다.
      * 상태 전환 시 DRAFT를 제외한 상태는 제목과 본문이 필수입니다.
      * DRAFT 상태에서는 생성 경로와 동일하게 첨부 확정과 orphan 정리를 수행하지 않습니다.
+     * 본문, 첨부 목록, 썸네일 중 하나라도 전달되면 본문 참조와 현재 썸네일을 기준으로 orphan 첨부를 정리합니다.
      *
      * @param postId 게시물 ID
      * @param request 게시물 수정 요청
@@ -174,7 +175,12 @@ class PostWriteService(
                 post.thumbnailImage = thumbnailAttachmentId
             }
 
-            if (request.content != null || request.attachmentIds != null) {
+            // 썸네일 교체도 이전 썸네일의 참조를 끊으므로 본문·첨부 목록 변경과 같은 정리 대상으로 본다.
+            // 그렇지 않으면 본문에 없던 이전 썸네일이 확정 상태로 남아 상세 조회의 첨부 URL 목록에 계속 노출된다.
+            val isAttachmentReferenceChanged =
+                request.content != null || request.attachmentIds != null || request.thumbnailAttachmentId != null
+
+            if (isAttachmentReferenceChanged) {
                 val attachmentIdsReferencedInContent = post.referencedAttachmentIds()
 
                 request.attachmentIds?.let { requestedAttachmentIds ->

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -98,7 +98,7 @@ class PostWriteService(
                 emptyList()
             } else {
                 mergeAttachmentIds(
-                    filterAttachmentIdsIncludedInContent(post.content, request.attachmentIds),
+                    filterAttachmentIdsIncludedInContent(post.referencedAttachmentIds(), request.attachmentIds),
                     request.thumbnailAttachmentId,
                 )
             }
@@ -113,7 +113,7 @@ class PostWriteService(
                 referenceType = AttachmentReferenceType.POST,
                 attachmentIds = attachmentIds,
             )
-            savedPost.thumbnailImage = request.thumbnailAttachmentId ?: attachmentIds.firstOrNull()
+            savedPost.thumbnailImage = request.thumbnailAttachmentId
             savedPost.updatedAt = postRepository.updateThumbnailImage(savedPost.id!!, savedPost.thumbnailImage)
         }
 
@@ -128,6 +128,7 @@ class PostWriteService(
      * 게시물을 수정합니다.
      * 요청에 포함된 필드만 업데이트하며, 작성자 권한을 검증합니다.
      * 상태 전환 시 DRAFT를 제외한 상태는 제목과 본문이 필수입니다.
+     * DRAFT 상태에서는 생성 경로와 동일하게 첨부 확정과 orphan 정리를 수행하지 않습니다.
      *
      * @param postId 게시물 ID
      * @param request 게시물 수정 요청
@@ -162,37 +163,38 @@ class PostWriteService(
             post.status = newStatus
         }
 
-        request.thumbnailAttachmentId?.let { thumbnailAttachmentId ->
-            attachmentService.confirmAttachmentsByIds(
-                referenceId = postId,
-                referenceType = AttachmentReferenceType.POST,
-                attachmentIds = listOf(thumbnailAttachmentId),
-            )
-            post.thumbnailImage = thumbnailAttachmentId
-        }
-
-        if (request.content != null || request.attachmentIds != null) {
-            val attachmentIds =
-                request.attachmentIds
-                    ?: attachmentService
-                        .getConfirmedAttachments(postId, AttachmentReferenceType.POST)
-                        .mapNotNull { it.id }
-            val attachmentIdsIncludedInContent =
-                filterAttachmentIdsIncludedInContent(post.content, attachmentIds)
-
-            request.attachmentIds?.let {
+        val newStatus = request.status ?: post.status
+        if (newStatus != PostStatusEnum.DRAFT) {
+            request.thumbnailAttachmentId?.let { thumbnailAttachmentId ->
                 attachmentService.confirmAttachmentsByIds(
                     referenceId = postId,
                     referenceType = AttachmentReferenceType.POST,
-                    attachmentIds = attachmentIdsIncludedInContent,
+                    attachmentIds = listOf(thumbnailAttachmentId),
                 )
+                post.thumbnailImage = thumbnailAttachmentId
             }
 
-            attachmentService.deleteOrphanedAttachmentsByIds(
-                referenceId = postId,
-                referenceType = AttachmentReferenceType.POST,
-                keepAttachmentIds = mergeAttachmentIds(attachmentIdsIncludedInContent, post.thumbnailImage),
-            )
+            if (request.content != null || request.attachmentIds != null) {
+                val attachmentIdsReferencedInContent = post.referencedAttachmentIds()
+
+                request.attachmentIds?.let { requestedAttachmentIds ->
+                    attachmentService.confirmAttachmentsByIds(
+                        referenceId = postId,
+                        referenceType = AttachmentReferenceType.POST,
+                        attachmentIds =
+                            filterAttachmentIdsIncludedInContent(
+                                attachmentIdsReferencedInContent,
+                                requestedAttachmentIds,
+                            ),
+                    )
+                }
+
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    referenceId = postId,
+                    referenceType = AttachmentReferenceType.POST,
+                    keepAttachmentIds = mergeAttachmentIds(attachmentIdsReferencedInContent, post.thumbnailImage),
+                )
+            }
         }
 
         val savedPost = postRepository.save(post)
@@ -246,14 +248,14 @@ class PostWriteService(
     }
 
     private fun filterAttachmentIdsIncludedInContent(
-        content: String,
+        attachmentIdsReferencedInContent: List<UUID>,
         requestedAttachmentIds: List<UUID>?,
     ): List<UUID> =
         requestedAttachmentIds
             .orEmpty()
             .distinct()
             .filter { attachmentId ->
-                content.contains(attachmentId.toString())
+                attachmentId in attachmentIdsReferencedInContent
             }
 
     private fun mergeAttachmentIds(

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
@@ -17,7 +17,7 @@ import java.util.UUID
  * @property content 게시물 본문 (선택)
  * @property categoryPath 카테고리 경로 (선택)
  * @property tags 태그 목록 (선택)
- * @property attachmentIds 게시물 첨부 ID 목록 (생략 시 유지, 빈 목록이면 전체 제거)
+ * @property attachmentIds 게시물 본문 첨부 ID 목록 (생략 시 유지, 빈 목록이면 본문 첨부 제거)
  * @property thumbnailAttachmentId 대표 썸네일 첨부 ID (생략 시 유지)
  * @property status 게시물 상태 (선택, DRAFT/PUBLISHED/PRIVATE)
  */
@@ -34,7 +34,7 @@ data class UpdatePostRequest(
     @field:ArraySchema(maxItems = TaggedContent.MAX_TAG_COUNT, schema = Schema(description = "태그명", example = "spring"))
     val tags: List<String>? = null,
     @field:Schema(
-        description = "게시물에 연결할 attachment ID 목록 (생략 시 기존 첨부 유지, 빈 목록이면 전체 제거)",
+        description = "게시물 본문에 연결할 attachment ID 목록 (생략 시 기존 본문 첨부 유지, 빈 목록이면 본문 첨부 제거)",
         example = "[\"01234567-89ab-cdef-0123-456789abcdef\"]",
     )
     val attachmentIds: List<UUID>? = null,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
@@ -18,7 +18,7 @@ import java.util.UUID
  * @property categoryPath 카테고리 경로 (선택)
  * @property tags 태그 목록 (선택)
  * @property attachmentIds 새로 확정할 첨부 ID 목록 (유지·삭제 판단은 항상 본문 참조 기준)
- * @property thumbnailAttachmentId 대표 썸네일 첨부 ID (생략 시 유지, 지정된 적 없으면 본문 첫 첨부로 노출)
+ * @property thumbnailAttachmentId 대표 썸네일 첨부 ID (생략 시 유지, 지정된 적 없으면 본문 첫 첨부로 노출, 교체 시 본문에서 참조되지 않는 이전 썸네일은 삭제)
  * @property status 게시물 상태 (선택, DRAFT/PUBLISHED/PRIVATE)
  */
 @Schema(description = "게시물 수정 요청")
@@ -39,7 +39,10 @@ data class UpdatePostRequest(
     )
     val attachmentIds: List<UUID>? = null,
     @field:Schema(
-        description = "대표 썸네일로 사용할 attachment ID (생략 시 기존 썸네일 유지, 지정된 적 없으면 본문 첫 첨부로 노출)",
+        description =
+            "대표 썸네일로 사용할 attachment ID " +
+                "(생략 시 기존 썸네일 유지, 지정된 적 없으면 본문 첫 첨부로 노출, " +
+                "교체 시 본문에서 참조되지 않는 이전 썸네일은 삭제)",
         example = "01234567-89ab-cdef-0123-456789abcdef",
     )
     val thumbnailAttachmentId: UUID? = null,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
@@ -17,8 +17,8 @@ import java.util.UUID
  * @property content 게시물 본문 (선택, 변경 시 본문에서 참조가 사라진 기존 첨부 제거)
  * @property categoryPath 카테고리 경로 (선택)
  * @property tags 태그 목록 (선택)
- * @property attachmentIds 새 게시물 본문 첨부 ID 목록 (생략 시 기존 첨부를 변경된 본문 참조 기준으로 정리)
- * @property thumbnailAttachmentId 대표 썸네일 첨부 ID (생략 시 유지)
+ * @property attachmentIds 새로 확정할 첨부 ID 목록 (유지·삭제 판단은 항상 본문 참조 기준)
+ * @property thumbnailAttachmentId 대표 썸네일 첨부 ID (생략 시 유지, 지정된 적 없으면 본문 첫 첨부로 노출)
  * @property status 게시물 상태 (선택, DRAFT/PUBLISHED/PRIVATE)
  */
 @Schema(description = "게시물 수정 요청")
@@ -34,12 +34,12 @@ data class UpdatePostRequest(
     @field:ArraySchema(maxItems = TaggedContent.MAX_TAG_COUNT, schema = Schema(description = "태그명", example = "spring"))
     val tags: List<String>? = null,
     @field:Schema(
-        description = "새 게시물 본문에 연결할 attachment ID 목록 (생략 시 기존 첨부를 변경된 본문 참조 기준으로 정리, 빈 목록이면 본문 첨부 제거)",
+        description = "새로 확정할 attachment ID 목록 (본문에 참조가 있는 항목만 확정되며, 첨부 유지·삭제는 목록과 무관하게 본문 참조 기준으로 판단)",
         example = "[\"01234567-89ab-cdef-0123-456789abcdef\"]",
     )
     val attachmentIds: List<UUID>? = null,
     @field:Schema(
-        description = "대표 썸네일로 사용할 attachment ID (생략 시 기존 썸네일 유지)",
+        description = "대표 썸네일로 사용할 attachment ID (생략 시 기존 썸네일 유지, 지정된 적 없으면 본문 첫 첨부로 노출)",
         example = "01234567-89ab-cdef-0123-456789abcdef",
     )
     val thumbnailAttachmentId: UUID? = null,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
@@ -17,6 +17,8 @@ import java.util.UUID
  * @property content 게시물 본문 (선택)
  * @property categoryPath 카테고리 경로 (선택)
  * @property tags 태그 목록 (선택)
+ * @property attachmentIds 게시물 첨부 ID 목록 (생략 시 유지, 빈 목록이면 전체 제거)
+ * @property thumbnailAttachmentId 대표 썸네일 첨부 ID (생략 시 유지)
  * @property status 게시물 상태 (선택, DRAFT/PUBLISHED/PRIVATE)
  */
 @Schema(description = "게시물 수정 요청")
@@ -31,9 +33,15 @@ data class UpdatePostRequest(
     @field:Size(max = TaggedContent.MAX_TAG_COUNT, message = "태그는 최대 10개까지 설정할 수 있습니다")
     @field:ArraySchema(maxItems = TaggedContent.MAX_TAG_COUNT, schema = Schema(description = "태그명", example = "spring"))
     val tags: List<String>? = null,
-    @field:Schema(description = "게시물에 연결할 attachment ID 목록", example = "[\"01234567-89ab-cdef-0123-456789abcdef\"]")
+    @field:Schema(
+        description = "게시물에 연결할 attachment ID 목록 (생략 시 기존 첨부 유지, 빈 목록이면 전체 제거)",
+        example = "[\"01234567-89ab-cdef-0123-456789abcdef\"]",
+    )
     val attachmentIds: List<UUID>? = null,
-    @field:Schema(description = "대표 썸네일로 사용할 attachment ID", example = "01234567-89ab-cdef-0123-456789abcdef")
+    @field:Schema(
+        description = "대표 썸네일로 사용할 attachment ID (생략 시 기존 썸네일 유지)",
+        example = "01234567-89ab-cdef-0123-456789abcdef",
+    )
     val thumbnailAttachmentId: UUID? = null,
     @field:Schema(description = "게시물 상태 (DRAFT/PUBLISHED/PRIVATE)", example = "PUBLISHED")
     val status: PostStatusEnum? = null,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
@@ -14,10 +14,10 @@ import java.util.UUID
  * 상태 전환 시 DRAFT를 제외한 상태는 제목과 본문이 필수입니다.
  *
  * @property title 게시물 제목 (선택, 최대 200자)
- * @property content 게시물 본문 (선택)
+ * @property content 게시물 본문 (선택, 변경 시 본문에서 참조가 사라진 기존 첨부 제거)
  * @property categoryPath 카테고리 경로 (선택)
  * @property tags 태그 목록 (선택)
- * @property attachmentIds 게시물 본문 첨부 ID 목록 (생략 시 유지, 빈 목록이면 본문 첨부 제거)
+ * @property attachmentIds 새 게시물 본문 첨부 ID 목록 (생략 시 기존 첨부를 변경된 본문 참조 기준으로 정리)
  * @property thumbnailAttachmentId 대표 썸네일 첨부 ID (생략 시 유지)
  * @property status 게시물 상태 (선택, DRAFT/PUBLISHED/PRIVATE)
  */
@@ -26,7 +26,7 @@ data class UpdatePostRequest(
     @field:Size(max = 200, message = "제목은 최대 200자까지 가능합니다")
     @field:Schema(description = "게시물 제목", example = "Spring Boot 시작하기", maxLength = 200)
     val title: String? = null,
-    @field:Schema(description = "게시물 본문", example = "Spring Boot를 사용하면...")
+    @field:Schema(description = "게시물 본문 (변경 시 본문에서 참조가 사라진 기존 첨부 제거)", example = "Spring Boot를 사용하면...")
     val content: String? = null,
     @field:Schema(description = "카테고리 경로 (슬래시로 구분, 최대 5단계)", example = "java/spring/deepdive")
     val categoryPath: String? = null,
@@ -34,7 +34,7 @@ data class UpdatePostRequest(
     @field:ArraySchema(maxItems = TaggedContent.MAX_TAG_COUNT, schema = Schema(description = "태그명", example = "spring"))
     val tags: List<String>? = null,
     @field:Schema(
-        description = "게시물 본문에 연결할 attachment ID 목록 (생략 시 기존 본문 첨부 유지, 빈 목록이면 본문 첨부 제거)",
+        description = "새 게시물 본문에 연결할 attachment ID 목록 (생략 시 기존 첨부를 변경된 본문 참조 기준으로 정리, 빈 목록이면 본문 첨부 제거)",
         example = "[\"01234567-89ab-cdef-0123-456789abcdef\"]",
     )
     val attachmentIds: List<UUID>? = null,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/entity/Post.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/entity/Post.kt
@@ -3,6 +3,7 @@ package com.techtaurant.mainserver.post.entity
 import com.techtaurant.mainserver.common.base.EntityBase
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.user.entity.User
+import java.util.UUID
 
 /**
  * 게시물 엔티티
@@ -32,5 +33,22 @@ class Post(
 ) : EntityBase(), TaggedContent {
     init {
         validateTagCount()
+    }
+
+    /**
+     * 본문이 참조하는 첨부 ID를 본문에 등장한 순서대로 반환합니다.
+     * 첨부 유지 판정과 썸네일 fallback이 모두 이 목록을 기준으로 동작하므로,
+     * 본문에서 참조가 사라진 첨부는 요청 목록에 남아 있어도 유지 대상이 아닙니다.
+     */
+    fun referencedAttachmentIds(): List<UUID> =
+        ATTACHMENT_ID_PATTERN
+            .findAll(content)
+            .map { UUID.fromString(it.value) }
+            .distinct()
+            .toList()
+
+    companion object {
+        private val ATTACHMENT_ID_PATTERN =
+            Regex("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -43,6 +43,7 @@ class PostListReadServiceTest {
         PostMetadataReadService(
             postRepository = postRepository,
             attachmentService = attachmentService,
+            postThumbnailResolver = PostThumbnailResolver(),
             defaultThumbnailUrl = defaultThumbnailUrl,
             baseUrl = baseUrl,
         )
@@ -287,8 +288,8 @@ class PostListReadServiceTest {
         }
 
         @Test
-        @DisplayName("첨부파일 썸네일은 presigned URL로 반환한다")
-        fun getPosts_withThumbnailAttachment_returnsPresignedThumbnailUrl() {
+        @DisplayName("썸네일 지정이 없으면 업로드 순서가 아니라 본문에 먼저 등장한 첨부의 presigned URL을 반환한다")
+        fun getPosts_withoutThumbnailImage_returnsFirstAttachmentReferencedInContent() {
             // given
             val post = createPost(otherUser)
             val firstAttachment =
@@ -303,6 +304,7 @@ class PostListReadServiceTest {
                     objectKey = "posts/${post.id}/uuid-2/later.jpg",
                     createdAt = Instant.ofEpochMilli(2_000L),
                 )
+            post.content = "<img src=\"${laterAttachment.id}\" /><img src=\"${firstAttachment.id}\" />"
             every {
                 postRepository.findPostsWithConditions(
                     cursor = null,
@@ -329,7 +331,7 @@ class PostListReadServiceTest {
             val result = postListReadService.getPosts(cursor = null, size = 20, currentUserId = null)
 
             // then
-            assertThat(result.content.single().thumbnailUrl).isEqualTo("https://cdn.example.com/first.jpg")
+            assertThat(result.content.single().thumbnailUrl).isEqualTo("https://cdn.example.com/later.jpg")
         }
 
         @Test

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostMetadataReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostMetadataReadServiceTest.kt
@@ -26,6 +26,7 @@ class PostMetadataReadServiceTest {
         PostMetadataReadService(
             postRepository = postRepository,
             attachmentService = attachmentService,
+            postThumbnailResolver = PostThumbnailResolver(),
             defaultThumbnailUrl = "/static/images/post-thumbnail.png",
             baseUrl = "http://localhost:8080",
         )

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostThumbnailResolverTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostThumbnailResolverTest.kt
@@ -1,0 +1,121 @@
+package com.techtaurant.mainserver.post.application
+
+import com.techtaurant.mainserver.attachment.entity.Attachment
+import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
+import com.techtaurant.mainserver.attachment.enums.AttachmentStatus
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class PostThumbnailResolverTest {
+    private val postThumbnailResolver = PostThumbnailResolver()
+
+    private lateinit var author: User
+
+    @BeforeEach
+    fun setUp() {
+        author =
+            User(
+                name = "작성자",
+                email = "writer@example.com",
+                provider = OAuthProvider.GOOGLE,
+                identifier = "writer-id",
+                role = UserRole.USER,
+                profileImageUrl = "https://example.com/profile.jpg",
+            ).apply { id = UUID.randomUUID() }
+    }
+
+    @Test
+    @DisplayName("명시적으로 지정한 썸네일이 본문에 없어도 그 첨부를 사용한다")
+    fun resolve_withExplicitThumbnail_usesThumbnailEvenWhenAbsentFromContent() {
+        // given
+        val thumbnailAttachment = createAttachment(createdAt = Instant.ofEpochMilli(3_000L))
+        val bodyAttachment = createAttachment(createdAt = Instant.ofEpochMilli(1_000L))
+        val post =
+            createPost(content = "<img src=\"${bodyAttachment.id}\" />")
+                .apply { thumbnailImage = thumbnailAttachment.id }
+
+        // when
+        val resolved = postThumbnailResolver.resolve(post, listOf(thumbnailAttachment, bodyAttachment))
+
+        // then
+        assertThat(resolved).isSameAs(thumbnailAttachment)
+    }
+
+    @Test
+    @DisplayName("썸네일 지정이 없으면 업로드 순서가 아니라 본문에 먼저 등장한 첨부를 사용한다")
+    fun resolve_withoutExplicitThumbnail_usesFirstAttachmentReferencedInContent() {
+        // given: 나중에 업로드된 첨부가 본문에서는 먼저 등장한다
+        val earlierUploadedAttachment = createAttachment(createdAt = Instant.ofEpochMilli(1_000L))
+        val laterUploadedAttachment = createAttachment(createdAt = Instant.ofEpochMilli(9_000L))
+        val post =
+            createPost(
+                content = "<img src=\"${laterUploadedAttachment.id}\" /><img src=\"${earlierUploadedAttachment.id}\" />",
+            )
+
+        // when
+        val resolved =
+            postThumbnailResolver.resolve(post, listOf(earlierUploadedAttachment, laterUploadedAttachment))
+
+        // then
+        assertThat(resolved).isSameAs(laterUploadedAttachment)
+    }
+
+    @Test
+    @DisplayName("지정한 썸네일이 확정 첨부에 없으면 본문 첫 첨부로 대체한다")
+    fun resolve_withMissingThumbnailAttachment_fallsBackToContent() {
+        // given
+        val bodyAttachment = createAttachment(createdAt = Instant.ofEpochMilli(1_000L))
+        val post =
+            createPost(content = "<img src=\"${bodyAttachment.id}\" />")
+                .apply { thumbnailImage = UUID.randomUUID() }
+
+        // when
+        val resolved = postThumbnailResolver.resolve(post, listOf(bodyAttachment))
+
+        // then
+        assertThat(resolved).isSameAs(bodyAttachment)
+    }
+
+    @Test
+    @DisplayName("본문이 참조하는 첨부가 없으면 null을 반환해 호출부가 기본 썸네일을 쓰게 한다")
+    fun resolve_withoutReferencedAttachment_returnsNull() {
+        // given
+        val unreferencedAttachment = createAttachment(createdAt = Instant.ofEpochMilli(1_000L))
+        val post = createPost(content = "<p>첨부 참조가 없는 본문</p>")
+
+        // when
+        val resolved = postThumbnailResolver.resolve(post, listOf(unreferencedAttachment))
+
+        // then
+        assertThat(resolved).isNull()
+    }
+
+    private fun createPost(content: String): Post =
+        Post(
+            title = "게시물",
+            content = content,
+            author = author,
+        ).apply { id = UUID.randomUUID() }
+
+    private fun createAttachment(createdAt: Instant): Attachment =
+        Attachment(
+            referenceId = UUID.randomUUID(),
+            referenceType = AttachmentReferenceType.POST,
+            objectKey = "posts/image.jpg",
+            status = AttachmentStatus.CONFIRMED,
+            originalFileName = "image.jpg",
+            contentType = "image/jpeg",
+            fileSize = 1024,
+        ).apply {
+            id = UUID.randomUUID()
+            this.createdAt = createdAt
+        }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -415,16 +415,18 @@ class PostWriteServiceAttachmentTest {
         }
 
         @Test
-        @DisplayName("attachmentIds 없이 본문만 바꾸면 첨부 확정 없이 orphan 정리도 빈 목록 기준으로 한다")
-        fun updatePost_withoutRequestAttachmentIds_usesEmptyAttachmentIds() {
+        @DisplayName("첨부 필드 없이 본문만 바꾸면 기존 첨부와 썸네일을 유지한다")
+        fun updatePost_withoutAttachmentFields_keepsExistingAttachmentsAndThumbnail() {
             // given
             val postId = UUID.randomUUID()
             val newAttachmentId = UUID.randomUUID()
+            val currentThumbnailAttachmentId = UUID.randomUUID()
             val post =
                 Post(
                     title = "기존 제목",
                     content = "기존 본문",
                     author = author,
+                    thumbnailImage = currentThumbnailAttachmentId,
                     status = PostStatusEnum.PUBLISHED,
                 ).apply { id = postId }
 
@@ -440,13 +442,37 @@ class PostWriteServiceAttachmentTest {
             val response = postWriteService.updatePost(postId, request, author.id!!)
 
             // then
-            verify {
-                attachmentService.confirmAttachmentsByIds(
-                    postId,
-                    AttachmentReferenceType.POST,
-                    emptyList(),
-                )
-            }
+            verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
+            verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
+            assertThat(response.content).contains(newAttachmentId.toString())
+            assertThat(post.thumbnailImage).isEqualTo(currentThumbnailAttachmentId)
+        }
+
+        @Test
+        @DisplayName("attachmentIds를 빈 목록으로 명시하면 기존 첨부와 썸네일을 제거한다")
+        fun updatePost_withEmptyAttachmentIds_removesExistingAttachmentsAndThumbnail() {
+            // given
+            val postId = UUID.randomUUID()
+            val currentThumbnailAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    thumbnailImage = currentThumbnailAttachmentId,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(attachmentIds = emptyList()),
+                author.id!!,
+            )
+
+            // then
             verify {
                 attachmentService.deleteOrphanedAttachmentsByIds(
                     postId,
@@ -454,7 +480,42 @@ class PostWriteServiceAttachmentTest {
                     emptyList(),
                 )
             }
-            assertThat(response.content).contains(newAttachmentId.toString())
+            assertThat(post.thumbnailImage).isNull()
+        }
+
+        @Test
+        @DisplayName("thumbnailAttachmentId만 지정하면 새 썸네일을 확정하고 기존 본문 첨부는 유지한다")
+        fun updatePost_withOnlyThumbnailAttachmentId_updatesThumbnailWithoutDeletingAttachments() {
+            // given
+            val postId = UUID.randomUUID()
+            val newThumbnailAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(thumbnailAttachmentId = newThumbnailAttachmentId),
+                author.id!!,
+            )
+
+            // then
+            verify {
+                attachmentService.confirmAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(newThumbnailAttachmentId),
+                )
+            }
+            verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
+            assertThat(post.thumbnailImage).isEqualTo(newThumbnailAttachmentId)
         }
 
         @Test

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -751,16 +751,19 @@ class PostWriteServiceAttachmentTest {
         }
 
         @Test
-        @DisplayName("thumbnailAttachmentId만 지정하면 새 썸네일을 확정하고 기존 본문 첨부는 유지한다")
-        fun updatePost_withOnlyThumbnailAttachmentId_updatesThumbnailWithoutDeletingAttachments() {
+        @DisplayName("thumbnailAttachmentId만 지정하면 새 썸네일을 확정하고 본문 참조 첨부는 유지한 채 이전 썸네일을 정리한다")
+        fun updatePost_withOnlyThumbnailAttachmentId_replacesThumbnailAndKeepsReferencedAttachments() {
             // given
             val postId = UUID.randomUUID()
+            val currentBodyAttachmentId = UUID.randomUUID()
+            val previousThumbnailAttachmentId = UUID.randomUUID()
             val newThumbnailAttachmentId = UUID.randomUUID()
             val post =
                 Post(
                     title = "기존 제목",
-                    content = "기존 본문",
+                    content = "<img src=\"$currentBodyAttachmentId\" />",
                     author = author,
+                    thumbnailImage = previousThumbnailAttachmentId,
                     status = PostStatusEnum.PUBLISHED,
                 ).apply { id = postId }
 
@@ -781,8 +784,50 @@ class PostWriteServiceAttachmentTest {
                     listOf(newThumbnailAttachmentId),
                 )
             }
-            verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(currentBodyAttachmentId, newThumbnailAttachmentId),
+                )
+            }
             assertThat(post.thumbnailImage).isEqualTo(newThumbnailAttachmentId)
+        }
+
+        @Test
+        @DisplayName("썸네일을 본문에 남아 있는 첨부로 교체하면 이전 썸네일만 정리 대상에서 빠진다")
+        fun updatePost_replaceThumbnailWithReferencedAttachment_keepsOnlyReferencedAttachments() {
+            // given
+            val postId = UUID.randomUUID()
+            val currentBodyAttachmentId = UUID.randomUUID()
+            val previousThumbnailAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "<img src=\"$currentBodyAttachmentId\" />",
+                    author = author,
+                    thumbnailImage = previousThumbnailAttachmentId,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(thumbnailAttachmentId = currentBodyAttachmentId),
+                author.id!!,
+            )
+
+            // then
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(currentBodyAttachmentId),
+                )
+            }
+            assertThat(post.thumbnailImage).isEqualTo(currentBodyAttachmentId)
         }
 
         @Test

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -279,8 +279,8 @@ class PostWriteServiceAttachmentTest {
         }
 
         @Test
-        @DisplayName("thumbnailAttachmentId가 없어도 기존 thumbnailImage가 본문에 없으면 orphan으로 정리한다")
-        fun updatePost_withoutThumbnailAttachmentId_deletesCurrentThumbnailWhenRemovedFromContent() {
+        @DisplayName("thumbnailAttachmentId가 없으면 기존 thumbnailImage가 본문에서 빠져도 유지한다")
+        fun updatePost_withoutThumbnailAttachmentId_keepsCurrentThumbnailWhenRemovedFromContent() {
             // given
             val postId = UUID.randomUUID()
             val currentThumbnailAttachmentId = UUID.randomUUID()
@@ -307,7 +307,7 @@ class PostWriteServiceAttachmentTest {
             postWriteService.updatePost(postId, request, author.id!!)
 
             // then
-            assertThat(post.thumbnailImage).isEqualTo(remainingAttachmentId)
+            assertThat(post.thumbnailImage).isEqualTo(currentThumbnailAttachmentId)
             verify {
                 attachmentService.confirmAttachmentsByIds(
                     postId,
@@ -319,14 +319,14 @@ class PostWriteServiceAttachmentTest {
                 attachmentService.deleteOrphanedAttachmentsByIds(
                     postId,
                     AttachmentReferenceType.POST,
-                    listOf(remainingAttachmentId),
+                    listOf(remainingAttachmentId, currentThumbnailAttachmentId),
                 )
             }
         }
 
         @Test
-        @DisplayName("수정 시 thumbnailAttachmentId를 별도로 전달하면 본문 첨부와 함께 confirm하고 유지한다")
-        fun updatePost_withSeparateThumbnailAttachment_confirmsAndKeepsThumbnail() {
+        @DisplayName("본문 첨부와 thumbnailAttachmentId를 각각 전달하면 각각 confirm하고 유지한다")
+        fun updatePost_withAttachmentIdsAndThumbnailAttachmentId_confirmsEachField() {
             // given
             val postId = UUID.randomUUID()
             val contentAttachmentId = UUID.randomUUID()
@@ -357,7 +357,14 @@ class PostWriteServiceAttachmentTest {
                 attachmentService.confirmAttachmentsByIds(
                     postId,
                     AttachmentReferenceType.POST,
-                    listOf(contentAttachmentId, thumbnailAttachmentId),
+                    listOf(thumbnailAttachmentId),
+                )
+            }
+            verify {
+                attachmentService.confirmAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(contentAttachmentId),
                 )
             }
             verify {
@@ -449,8 +456,8 @@ class PostWriteServiceAttachmentTest {
         }
 
         @Test
-        @DisplayName("attachmentIds를 빈 목록으로 명시하면 기존 첨부와 썸네일을 제거한다")
-        fun updatePost_withEmptyAttachmentIds_removesExistingAttachmentsAndThumbnail() {
+        @DisplayName("attachmentIds를 빈 목록으로 명시해도 생략한 썸네일은 유지한다")
+        fun updatePost_withEmptyAttachmentIds_keepsOmittedThumbnail() {
             // given
             val postId = UUID.randomUUID()
             val currentThumbnailAttachmentId = UUID.randomUUID()
@@ -477,10 +484,41 @@ class PostWriteServiceAttachmentTest {
                 attachmentService.deleteOrphanedAttachmentsByIds(
                     postId,
                     AttachmentReferenceType.POST,
-                    emptyList(),
+                    listOf(currentThumbnailAttachmentId),
                 )
             }
-            assertThat(post.thumbnailImage).isNull()
+            assertThat(post.thumbnailImage).isEqualTo(currentThumbnailAttachmentId)
+        }
+
+        @Test
+        @DisplayName("DRAFT 상태만 지정하면 생략한 첨부와 썸네일은 유지한다")
+        fun updatePost_withDraftStatusOnly_keepsOmittedAttachmentsAndThumbnail() {
+            // given
+            val postId = UUID.randomUUID()
+            val currentThumbnailAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    thumbnailImage = currentThumbnailAttachmentId,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(status = PostStatusEnum.DRAFT),
+                author.id!!,
+            )
+
+            // then
+            assertThat(post.status).isEqualTo(PostStatusEnum.DRAFT)
+            assertThat(post.thumbnailImage).isEqualTo(currentThumbnailAttachmentId)
+            verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
+            verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
         }
 
         @Test

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -1,6 +1,7 @@
 package com.techtaurant.mainserver.post.application
 
 import com.techtaurant.mainserver.attachment.application.AttachmentService
+import com.techtaurant.mainserver.attachment.entity.Attachment
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
 import com.techtaurant.mainserver.common.lock.DistributedLock
 import com.techtaurant.mainserver.notification.application.NotificationWriteService
@@ -72,6 +73,7 @@ class PostWriteServiceAttachmentTest {
         every { attachmentService.confirmAttachmentsByIds(any(), any(), any()) } just runs
         every { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) } just runs
         every { attachmentService.deleteAttachmentsByReference(any(), any()) } just runs
+        every { attachmentService.getConfirmedAttachments(any(), any()) } returns emptyList()
         every { postRepository.findPostByIdWithAuthorForUpdate(any()) } answers {
             postRepository.findPostByIdWithAuthor(firstArg())
         }
@@ -422,12 +424,59 @@ class PostWriteServiceAttachmentTest {
         }
 
         @Test
-        @DisplayName("첨부 필드 없이 본문만 바꾸면 기존 첨부와 썸네일을 유지한다")
-        fun updatePost_withoutAttachmentFields_keepsExistingAttachmentsAndThumbnail() {
+        @DisplayName("첨부 필드 없이 본문에서 참조를 제거하면 기존 본문 첨부를 삭제하고 썸네일은 유지한다")
+        fun updatePost_withoutAttachmentFields_removesUnreferencedBodyAttachmentAndKeepsThumbnail() {
             // given
             val postId = UUID.randomUUID()
-            val newAttachmentId = UUID.randomUUID()
+            val currentBodyAttachmentId = UUID.randomUUID()
             val currentThumbnailAttachmentId = UUID.randomUUID()
+            val currentBodyAttachment = mockk<Attachment>()
+            every { currentBodyAttachment.id } returns currentBodyAttachmentId
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "<img src=\"$currentBodyAttachmentId\" />",
+                    author = author,
+                    thumbnailImage = currentThumbnailAttachmentId,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+            every {
+                attachmentService.getConfirmedAttachments(postId, AttachmentReferenceType.POST)
+            } returns listOf(currentBodyAttachment)
+
+            val request =
+                UpdatePostRequest(
+                    content = "<p>첨부 참조를 제거한 본문</p>",
+                    status = PostStatusEnum.PUBLISHED,
+                )
+
+            // when
+            val response = postWriteService.updatePost(postId, request, author.id!!)
+
+            // then
+            verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(currentThumbnailAttachmentId),
+                )
+            }
+            assertThat(response.content).doesNotContain(currentBodyAttachmentId.toString())
+            assertThat(post.thumbnailImage).isEqualTo(currentThumbnailAttachmentId)
+        }
+
+        @Test
+        @DisplayName("첨부 필드 없이 본문 참조를 유지하면 기존 본문 첨부와 썸네일을 유지한다")
+        fun updatePost_withoutAttachmentFields_keepsReferencedBodyAttachmentAndThumbnail() {
+            // given
+            val postId = UUID.randomUUID()
+            val currentBodyAttachmentId = UUID.randomUUID()
+            val currentThumbnailAttachmentId = UUID.randomUUID()
+            val currentBodyAttachment = mockk<Attachment>()
+            every { currentBodyAttachment.id } returns currentBodyAttachmentId
             val post =
                 Post(
                     title = "기존 제목",
@@ -438,20 +487,26 @@ class PostWriteServiceAttachmentTest {
                 ).apply { id = postId }
 
             every { postRepository.findPostByIdWithAuthor(postId) } returns post
-
-            val request =
-                UpdatePostRequest(
-                    content = "<img src=\"$newAttachmentId\" />",
-                    status = PostStatusEnum.PUBLISHED,
-                )
+            every {
+                attachmentService.getConfirmedAttachments(postId, AttachmentReferenceType.POST)
+            } returns listOf(currentBodyAttachment)
 
             // when
-            val response = postWriteService.updatePost(postId, request, author.id!!)
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(content = "<img src=\"$currentBodyAttachmentId\" />"),
+                author.id!!,
+            )
 
             // then
             verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
-            verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
-            assertThat(response.content).contains(newAttachmentId.toString())
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(currentBodyAttachmentId, currentThumbnailAttachmentId),
+                )
+            }
             assertThat(post.thumbnailImage).isEqualTo(currentThumbnailAttachmentId)
         }
 

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -1,7 +1,6 @@
 package com.techtaurant.mainserver.post.application
 
 import com.techtaurant.mainserver.attachment.application.AttachmentService
-import com.techtaurant.mainserver.attachment.entity.Attachment
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
 import com.techtaurant.mainserver.common.lock.DistributedLock
 import com.techtaurant.mainserver.notification.application.NotificationWriteService
@@ -73,7 +72,6 @@ class PostWriteServiceAttachmentTest {
         every { attachmentService.confirmAttachmentsByIds(any(), any(), any()) } just runs
         every { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) } just runs
         every { attachmentService.deleteAttachmentsByReference(any(), any()) } just runs
-        every { attachmentService.getConfirmedAttachments(any(), any()) } returns emptyList()
         every { postRepository.findPostByIdWithAuthorForUpdate(any()) } answers {
             postRepository.findPostByIdWithAuthor(firstArg())
         }
@@ -424,14 +422,133 @@ class PostWriteServiceAttachmentTest {
         }
 
         @Test
+        @DisplayName("attachmentIds에서 빠져도 본문에 참조가 남아 있으면 기존 첨부를 유지한다")
+        fun updatePost_attachmentIdsOmittingReferencedAttachment_keepsItByContent() {
+            // given
+            val postId = UUID.randomUUID()
+            val existingAttachmentId = UUID.randomUUID()
+            val newAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "<img src=\"$existingAttachmentId\" />",
+                    author = author,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when: 새로 추가한 첨부만 attachmentIds에 담고 기존 첨부는 본문에만 남긴다
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(
+                    content = "<img src=\"$existingAttachmentId\" /><img src=\"$newAttachmentId\" />",
+                    attachmentIds = listOf(newAttachmentId),
+                ),
+                author.id!!,
+            )
+
+            // then
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(existingAttachmentId, newAttachmentId),
+                )
+            }
+            verify {
+                attachmentService.confirmAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(newAttachmentId),
+                )
+            }
+        }
+
+        @Test
+        @DisplayName("attachmentIds로 보내도 본문에 참조가 없으면 확정하지 않고 유지 대상에서 제외한다")
+        fun updatePost_attachmentIdsAbsentFromContent_isNeitherConfirmedNorKept() {
+            // given
+            val postId = UUID.randomUUID()
+            val unreferencedAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(
+                    content = "<p>첨부를 넣지 않은 본문</p>",
+                    attachmentIds = listOf(unreferencedAttachmentId),
+                ),
+                author.id!!,
+            )
+
+            // then
+            verify {
+                attachmentService.confirmAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    emptyList(),
+                )
+            }
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    emptyList(),
+                )
+            }
+        }
+
+        @Test
+        @DisplayName("본문에만 있고 attachmentIds가 없으면 확정하지 않은 채 유지 대상으로만 둔다")
+        fun updatePost_attachmentOnlyInContent_isKeptWithoutConfirm() {
+            // given
+            val postId = UUID.randomUUID()
+            val unconfirmedAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(content = "<img src=\"$unconfirmedAttachmentId\" />"),
+                author.id!!,
+            )
+
+            // then
+            verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(unconfirmedAttachmentId),
+                )
+            }
+        }
+
+        @Test
         @DisplayName("첨부 필드 없이 본문에서 참조를 제거하면 기존 본문 첨부를 삭제하고 썸네일은 유지한다")
         fun updatePost_withoutAttachmentFields_removesUnreferencedBodyAttachmentAndKeepsThumbnail() {
             // given
             val postId = UUID.randomUUID()
             val currentBodyAttachmentId = UUID.randomUUID()
             val currentThumbnailAttachmentId = UUID.randomUUID()
-            val currentBodyAttachment = mockk<Attachment>()
-            every { currentBodyAttachment.id } returns currentBodyAttachmentId
             val post =
                 Post(
                     title = "기존 제목",
@@ -442,9 +559,6 @@ class PostWriteServiceAttachmentTest {
                 ).apply { id = postId }
 
             every { postRepository.findPostByIdWithAuthor(postId) } returns post
-            every {
-                attachmentService.getConfirmedAttachments(postId, AttachmentReferenceType.POST)
-            } returns listOf(currentBodyAttachment)
 
             val request =
                 UpdatePostRequest(
@@ -475,8 +589,6 @@ class PostWriteServiceAttachmentTest {
             val postId = UUID.randomUUID()
             val currentBodyAttachmentId = UUID.randomUUID()
             val currentThumbnailAttachmentId = UUID.randomUUID()
-            val currentBodyAttachment = mockk<Attachment>()
-            every { currentBodyAttachment.id } returns currentBodyAttachmentId
             val post =
                 Post(
                     title = "기존 제목",
@@ -487,9 +599,6 @@ class PostWriteServiceAttachmentTest {
                 ).apply { id = postId }
 
             every { postRepository.findPostByIdWithAuthor(postId) } returns post
-            every {
-                attachmentService.getConfirmedAttachments(postId, AttachmentReferenceType.POST)
-            } returns listOf(currentBodyAttachment)
 
             // when
             postWriteService.updatePost(
@@ -572,6 +681,71 @@ class PostWriteServiceAttachmentTest {
             // then
             assertThat(post.status).isEqualTo(PostStatusEnum.DRAFT)
             assertThat(post.thumbnailImage).isEqualTo(currentThumbnailAttachmentId)
+            verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
+            verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
+        }
+
+        @Test
+        @DisplayName("DRAFT로 전환하면서 본문과 첨부를 전달해도 첨부를 확정하거나 정리하지 않는다")
+        fun updatePost_toDraftWithAttachmentFields_skipsAttachmentConfirmAndCleanup() {
+            // given
+            val postId = UUID.randomUUID()
+            val newAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(
+                    content = "<img src=\"$newAttachmentId\" />",
+                    attachmentIds = listOf(newAttachmentId),
+                    thumbnailAttachmentId = newAttachmentId,
+                    status = PostStatusEnum.DRAFT,
+                ),
+                author.id!!,
+            )
+
+            // then
+            assertThat(post.thumbnailImage).isNull()
+            verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
+            verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
+        }
+
+        @Test
+        @DisplayName("이미 DRAFT인 게시물은 첨부를 전달해도 확정하거나 정리하지 않는다")
+        fun updatePost_draftPostWithAttachmentFields_skipsAttachmentConfirmAndCleanup() {
+            // given
+            val postId = UUID.randomUUID()
+            val newAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    status = PostStatusEnum.DRAFT,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(
+                    content = "<img src=\"$newAttachmentId\" />",
+                    attachmentIds = listOf(newAttachmentId),
+                ),
+                author.id!!,
+            )
+
+            // then
             verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
             verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
         }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceValidationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceValidationTest.kt
@@ -83,6 +83,7 @@ class PostWriteServiceValidationTest {
         every { tagWriteService.resolveTags(any()) } returns emptySet()
         every { attachmentService.confirmAttachmentsByIds(any(), any(), any()) } just runs
         every { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) } just runs
+        every { attachmentService.getConfirmedAttachments(any(), any()) } returns emptyList()
         every { postRepository.findPostByIdWithAuthorForUpdate(any()) } answers {
             postRepository.findPostByIdWithAuthor(firstArg())
         }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceValidationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceValidationTest.kt
@@ -292,10 +292,11 @@ class PostWriteServiceValidationTest {
         }
 
         @Test
-        @DisplayName("DRAFT로 되돌리면 썸네일을 비우고 첨부 정리를 하지 않는다")
-        fun updatePost_toDraft_clearsThumbnailWithoutAttachmentCleanup() {
+        @DisplayName("DRAFT 상태만 변경하면 생략한 썸네일과 첨부를 유지한다")
+        fun updatePost_toDraft_keepsOmittedThumbnailAndAttachments() {
             // given
-            val post = publishedPost().apply { thumbnailImage = UUID.randomUUID() }
+            val thumbnailAttachmentId = UUID.randomUUID()
+            val post = publishedPost().apply { thumbnailImage = thumbnailAttachmentId }
             every { postRepository.findPostByIdWithAuthor(post.id!!) } returns post
 
             // when
@@ -306,7 +307,9 @@ class PostWriteServiceValidationTest {
             )
 
             // then
-            assertThat(post.thumbnailImage).isNull()
+            assertThat(post.status).isEqualTo(PostStatusEnum.DRAFT)
+            assertThat(post.thumbnailImage).isEqualTo(thumbnailAttachmentId)
+            verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
             verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
         }
 

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceValidationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceValidationTest.kt
@@ -83,7 +83,6 @@ class PostWriteServiceValidationTest {
         every { tagWriteService.resolveTags(any()) } returns emptySet()
         every { attachmentService.confirmAttachmentsByIds(any(), any(), any()) } just runs
         every { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) } just runs
-        every { attachmentService.getConfirmedAttachments(any(), any()) } returns emptyList()
         every { postRepository.findPostByIdWithAuthorForUpdate(any()) } answers {
             postRepository.findPostByIdWithAuthor(firstArg())
         }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/entity/PostReferencedAttachmentIdsTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/entity/PostReferencedAttachmentIdsTest.kt
@@ -1,0 +1,78 @@
+package com.techtaurant.mainserver.post.entity
+
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class PostReferencedAttachmentIdsTest {
+    private lateinit var author: User
+
+    @BeforeEach
+    fun setUp() {
+        author =
+            User(
+                name = "작성자",
+                email = "writer@example.com",
+                provider = OAuthProvider.GOOGLE,
+                identifier = "writer-id",
+                role = UserRole.USER,
+                profileImageUrl = "https://example.com/profile.jpg",
+            ).apply { id = UUID.randomUUID() }
+    }
+
+    @Test
+    @DisplayName("본문에 등장한 순서대로 첨부 ID를 반환한다")
+    fun referencedAttachmentIds_returnsIdsInContentOrder() {
+        // given
+        val firstAttachmentId = UUID.randomUUID()
+        val secondAttachmentId = UUID.randomUUID()
+        val post = createPost("<img src=\"$firstAttachmentId\" /><p>본문</p><img src=\"$secondAttachmentId\" />")
+
+        // when & then
+        assertThat(post.referencedAttachmentIds()).containsExactly(firstAttachmentId, secondAttachmentId)
+    }
+
+    @Test
+    @DisplayName("같은 첨부가 여러 번 등장해도 한 번만 반환한다")
+    fun referencedAttachmentIds_deduplicatesRepeatedReference() {
+        // given
+        val attachmentId = UUID.randomUUID()
+        val post = createPost("<img src=\"$attachmentId\" /><img src=\"$attachmentId\" />")
+
+        // when & then
+        assertThat(post.referencedAttachmentIds()).containsExactly(attachmentId)
+    }
+
+    @Test
+    @DisplayName("본문에 첨부 참조가 없으면 빈 목록을 반환한다")
+    fun referencedAttachmentIds_withoutReference_returnsEmpty() {
+        // given
+        val post = createPost("<p>첨부가 없는 본문</p>")
+
+        // when & then
+        assertThat(post.referencedAttachmentIds()).isEmpty()
+    }
+
+    @Test
+    @DisplayName("대문자 UUID 표기도 첨부 참조로 인식한다")
+    fun referencedAttachmentIds_recognizesUppercaseUuid() {
+        // given
+        val attachmentId = UUID.randomUUID()
+        val post = createPost("<img src=\"${attachmentId.toString().uppercase()}\" />")
+
+        // when & then
+        assertThat(post.referencedAttachmentIds()).containsExactly(attachmentId)
+    }
+
+    private fun createPost(content: String): Post =
+        Post(
+            title = "게시물",
+            content = content,
+            author = author,
+        ).apply { id = UUID.randomUUID() }
+}


### PR DESCRIPTION
## 관련 자료
- 이슈: #173

## 어떤 작업인가요?
- 게시물 부분 수정 요청에서 첨부 관련 nullable 필드를 생략했을 때 기존 값이 변경되거나 하드 삭제되는 문제를 해결합니다.
- 반대로 본문만 수정해 첨부 참조가 사라진 경우 기존 첨부가 고아로 남던 문제도 함께 해결합니다.

## 어떻게 해결했나요?
**nullable 첨부 필드 독립 처리**
- `thumbnailAttachmentId`가 전달된 경우에만 썸네일을 확정하고 변경합니다.
- `attachmentIds`가 전달된 경우에만 본문 첨부를 확정(confirm)합니다.
- 두 필드를 함께 전달하면 새 썸네일을 먼저 반영해 orphan 정리 대상에서 보호합니다.

**본문 변경 기준 첨부 정리**
- `content` 또는 `attachmentIds` 중 하나라도 전달되면 orphan 정리를 수행합니다.
- `attachmentIds`가 생략된 경우에는 기존 확정 첨부 목록을 조회해 변경된 본문의 참조 기준으로 정리 대상을 계산합니다.
- 본문에서 참조가 유지되는 첨부와 썸네일은 그대로 보존됩니다.

**API 계약과 회귀 테스트 보강**
- `attachmentIds` 생략은 "기존 첨부를 변경된 본문 참조 기준으로 정리", 빈 배열은 "본문 첨부 제거"로 문서화합니다.
- 본문 참조 제거/유지 두 시나리오와, 빈 배열이나 DRAFT 상태 변경만 요청했을 때 생략한 썸네일이 유지되는 시나리오를 테스트로 고정합니다.

## 중요한 변경 사항은 무엇인가요?
### 게시물 첨부 PATCH 정리 규칙

**null 필드의 부수효과 제거**
- **변경 이유**: 부분 수정에서 전달되지 않은 필드는 현재 값을 유지해야 하기 때문입니다.
- **수정 파일**: `PostWriteService.kt`

**본문 첨부와 썸네일 계약 분리**
- **변경 이유**: 본문 첨부 목록 변경이 생략된 썸네일을 교체하거나 삭제하지 않도록 하기 위함입니다.
- **수정 파일**: `UpdatePostRequest.kt`, `PostWriteServiceAttachmentTest.kt`, `PostWriteServiceValidationTest.kt`

**본문만 수정한 경우의 orphan 정리**
- **변경 이유**: `attachmentIds`를 생략한 채 본문에서 이미지를 삭제하면 해당 첨부가 스토리지에 영구히 남기 때문입니다.
- **수정 파일**: `PostWriteService.kt`, `UpdatePostRequest.kt`, `PostWriteServiceAttachmentTest.kt`, `PostWriteServiceValidationTest.kt`

---

## 추가 작업 (657d975)

### 첨부 유지 판정을 본문 참조로 단일화
기존 구현은 `attachmentIds`를 유지 대상의 **상한**으로 삼았습니다. 그래서 본문에 참조가 그대로 남은 확정 첨부라도 요청 목록에서 빠지면 S3와 DB에서 삭제되고, 본문에는 깨진 이미지만 남았습니다.

판정 기준을 본문 하나로 옮겼습니다.

| 상황 | 처리 |
| --- | --- |
| `attachmentIds`에 있으나 본문에 참조 없음 | 확정하지 않고 유지 대상에서도 제외 |
| `attachmentIds`에 없으나 본문에 참조 있고 확정됨 | **유지** |
| 본문에만 있고 확정되지 않음 | 확정하지 않음 (게시물에 바인딩되지 않아 삭제 대상도 아님) |

- `attachmentIds`는 이제 **새로 확정할 첨부를 지정하는 용도**로만 쓰입니다.
- orphan 정리가 이미 게시물에 바인딩된 첨부만 조회하므로, 유지 목록에 미확정 첨부가 있어도 부작용이 없습니다. 그 결과 `getConfirmedAttachments` 조회가 수정 경로에서 제거됐습니다.
- 위 문서화 항목 중 **"빈 배열은 본문 첨부 제거"는 더 이상 유효하지 않습니다.** 빈 배열을 보내도 본문에 참조가 남아 있으면 첨부는 유지되며, 삭제하려면 본문에서 참조를 먼저 제거해야 합니다.

### 썸네일 저장과 노출 분리
- 저장은 명시 지정(`thumbnailAttachmentId`)만 보관합니다. 생성 시 본문 첫 첨부를 자동 승격시키던 동작을 제거했습니다.
- 노출은 `PostThumbnailResolver`가 **명시 지정 → 본문 첫 첨부 → 기본 이미지** 순으로 결정합니다.
- 목록(`PostMetadataReadService`)과 알림(`NotificationPayloadResourceResolver`)에 같은 체인이 복제돼 있었고, 중간 단계가 업로드 시각(`createdAt`) 기준이라 본문 등장 순서와 어긋났습니다. 하나로 합치면서 본문 기준으로 바로잡았습니다.

### DRAFT 가드 복원
부분 수정 계약을 고치는 과정에서 `newStatus != DRAFT` 가드가 사라졌는데, 생성 경로에는 같은 가드가 남아 있어 DRAFT 게시물에 `attachmentIds`를 보내면 임시 첨부가 확정되는 비대칭이 생겼습니다. 원래 형태로 되돌렸습니다.

### 수정 파일
`Post.kt`, `PostThumbnailResolver.kt`(신규), `PostWriteService.kt`, `PostMetadataReadService.kt`, `NotificationPayloadResourceResolver.kt`, `UpdatePostRequest.kt` + 테스트 6종(신규 2종)

### 검증
`./gradlew test spotlessCheck` — BUILD SUCCESSFUL, 494 tests / 0 failures / 0 errors, jacoco 커버리지 검증 통과

### 리뷰 시 확인이 필요한 부분
- 생성 시 자동 승격이 사라져도, 과거에 그렇게 저장된 `thumbnail_image` 값은 DB에 남아 계속 우선 적용됩니다. 되돌리려면 별도 마이그레이션이 필요합니다.
- `Post.referencedAttachmentIds()`는 호출마다 본문을 정규식으로 스캔합니다(목록 조회 시 게시물당 1회, 캐싱 없음).

Co-Authored-By: OpenAI Codex <codex@openai.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

