### PR TITLE
release: 첨부 하드 삭제 수정과 S3·DB 쓰기 순서 정리 배포

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
@@ -253,7 +253,15 @@ class AttachmentService(
         TransactionSynchronizationManager.registerSynchronization(
             object : TransactionSynchronization {
                 override fun afterCommit() {
-                    s3StorageService.deleteObjects(objectKeys)
+                    log.info("Deleting S3 objects after commit: {}", objectKeys)
+                    try {
+                        s3StorageService.deleteObjects(objectKeys)
+                    } catch (e: Exception) {
+                        // afterCommit 예외는 호출자에게 전파되어 이미 커밋된 요청이 실패로 보이고,
+                        // 클라이언트가 반영이 끝난 상태에 재시도하게 된다. 정리 실패의 결과는
+                        // 참조되지 않는 객체가 남는 것뿐이므로 여기서 가두고 로그로만 남긴다.
+                        log.error("Failed to delete S3 objects after commit: {}", objectKeys, e)
+                    }
                 }
             },
         )

--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
@@ -14,12 +14,14 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.util.UUID
 
 /**
  * 첨부파일 비즈니스 로직 서비스.
  *
- * Presigned URL 발급, TMP → CONFIRMED 전환(S3 파일 이동 포함),
+ * Presigned URL 발급, TMP → CONFIRMED 전환(S3 파일 복사 포함),
  * 첨부파일 삭제를 담당한다.
  */
 @Service
@@ -108,7 +110,9 @@ class AttachmentService(
 
     /**
      * attachmentId에 해당하는 TMP Attachment를 CONFIRMED 상태로 전환합니다.
-     * S3 파일을 tmp/ 경로에서 referenceType에 맞는 확정 경로로 이동합니다.
+     * S3 파일을 tmp/ 경로에서 referenceType에 맞는 확정 경로로 복사하며, tmp/ 원본은 지우지 않습니다.
+     * 원본을 커밋 전에 지우면 이후 단계나 커밋이 실패했을 때 DB는 tmp/ 키로 롤백되는데 그 객체가 없어
+     * 재시도가 불가능해지므로, 원본 정리는 tmp/ 경로의 S3 lifecycle 만료 정책에 맡긴다.
      *
      * @param referenceId 연관 도메인 PK (게시물 ID 등)
      * @param referenceType 연관 도메인 타입
@@ -179,7 +183,6 @@ class AttachmentService(
                 sourceKey = tmpObjectKey,
                 destinationKey = newObjectKey,
             )
-            s3StorageService.deleteObject(tmpObjectKey)
 
             attachment.objectKey = newObjectKey
             attachment.status = AttachmentStatus.CONFIRMED
@@ -204,8 +207,8 @@ class AttachmentService(
         val attachments = attachmentRepository.findAllByReferenceIdAndReferenceType(referenceId, referenceType)
         if (attachments.isEmpty()) return
 
-        s3StorageService.deleteObjects(attachments.map { it.objectKey })
         attachmentRepository.deleteAllByReferenceIdAndReferenceType(referenceId, referenceType)
+        deleteObjectsAfterCommit(attachments.map { it.objectKey })
     }
 
     /**
@@ -234,8 +237,26 @@ class AttachmentService(
             }
         if (orphaned.isEmpty()) return
 
-        s3StorageService.deleteObjects(orphaned.map { it.objectKey })
         attachmentRepository.deleteAll(orphaned)
+        deleteObjectsAfterCommit(orphaned.map { it.objectKey })
+    }
+
+    /**
+     * S3 객체 삭제를 트랜잭션 커밋 이후로 미룹니다.
+     * 커밋 전에 지우면 롤백됐을 때 DB에는 첨부 행이 남고 S3 객체만 사라져,
+     * 정상으로 보이는 presigned URL이 존재하지 않는 객체를 가리키게 된다.
+     * 커밋 뒤로 미루면 실패해도 참조되지 않는 객체만 남으므로 조회 결과가 깨지지 않는다.
+     *
+     * @param objectKeys 삭제할 S3 오브젝트 키 목록
+     */
+    private fun deleteObjectsAfterCommit(objectKeys: List<String>) {
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCommit() {
+                    s3StorageService.deleteObjects(objectKeys)
+                }
+            },
+        )
     }
 
     /**

--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/application/S3StorageService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/application/S3StorageService.kt
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest
 import software.amazon.awssdk.services.s3.model.Delete
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
@@ -19,7 +18,7 @@ import java.time.Duration
 /**
  * S3 파일 I/O 작업 서비스.
  *
- * Presigned URL 생성, 파일 복사, 단건/배치 삭제를 담당한다.
+ * Presigned URL 생성, 파일 복사, 배치 삭제를 담당한다.
  * 비즈니스 로직 없이 AWS S3 API 호출만 수행한다.
  */
 @Service
@@ -126,21 +125,6 @@ class S3StorageService(
                 .build()
 
         s3Client.copyObject(request)
-    }
-
-    /**
-     * S3 오브젝트를 삭제합니다.
-     *
-     * @param objectKey 삭제할 오브젝트 키
-     */
-    fun deleteObject(objectKey: String) {
-        val request =
-            DeleteObjectRequest.builder()
-                .bucket(bucketName)
-                .key(objectKey)
-                .build()
-
-        s3Client.deleteObject(request)
     }
 
     /**

--- a/src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationPayloadResourceResolver.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/notification/application/NotificationPayloadResourceResolver.kt
@@ -2,6 +2,7 @@ package com.techtaurant.mainserver.notification.application
 
 import com.techtaurant.mainserver.attachment.application.AttachmentService
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
+import com.techtaurant.mainserver.post.application.PostThumbnailResolver
 import com.techtaurant.mainserver.post.entity.Post
 import com.techtaurant.mainserver.post.infrastructure.out.PostRepository
 import com.techtaurant.mainserver.user.application.UserProfileImageResolver
@@ -17,6 +18,7 @@ class NotificationPayloadResourceResolver(
     private val postRepository: PostRepository,
     private val attachmentService: AttachmentService,
     private val userProfileImageResolver: UserProfileImageResolver,
+    private val postThumbnailResolver: PostThumbnailResolver,
     @param:Value("\${app.default-post-thumbnail-url}")
     private val defaultPostThumbnailUrl: String,
     @param:Value("\${app.default-user-thumbnail-url:/static/images/user-thumbnail.png}")
@@ -68,12 +70,8 @@ class NotificationPayloadResourceResolver(
             postsById.values.associate { post ->
                 val postId = post.id!!
                 val attachments = attachmentsByPostId[postId].orEmpty()
-                val thumbnailAttachment =
-                    post.thumbnailImage?.let { thumbnailAttachmentId ->
-                        attachments.firstOrNull { it.id == thumbnailAttachmentId }
-                    } ?: attachments.minByOrNull { it.createdAt }
 
-                postId to thumbnailAttachment
+                postId to postThumbnailResolver.resolve(post, attachments)
             }
         val presignedThumbnailUrlByAttachmentId =
             thumbnailAttachmentByPostId.values

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostMetadataReadService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostMetadataReadService.kt
@@ -17,6 +17,7 @@ import java.util.UUID
 class PostMetadataReadService(
     private val postRepository: PostRepository,
     private val attachmentService: AttachmentService,
+    private val postThumbnailResolver: PostThumbnailResolver,
     @param:Value("\${app.default-post-thumbnail-url}")
     private val defaultThumbnailUrl: String,
     @param:Value("\${swagger.base-url}")
@@ -83,10 +84,7 @@ class PostMetadataReadService(
         attachments: List<Attachment>,
         presignedUrlByAttachmentId: Map<UUID, String>,
     ): String {
-        val thumbnailAttachment =
-            post.thumbnailImage?.let { thumbnailAttachmentId ->
-                attachments.firstOrNull { it.id == thumbnailAttachmentId }
-            } ?: attachments.minByOrNull { it.createdAt }
+        val thumbnailAttachment = postThumbnailResolver.resolve(post, attachments)
 
         return thumbnailAttachment?.id?.let { presignedUrlByAttachmentId[it] } ?: "$baseUrl$defaultThumbnailUrl"
     }

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostThumbnailResolver.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostThumbnailResolver.kt
@@ -1,0 +1,26 @@
+package com.techtaurant.mainserver.post.application
+
+import com.techtaurant.mainserver.attachment.entity.Attachment
+import com.techtaurant.mainserver.post.entity.Post
+import org.springframework.stereotype.Component
+
+/**
+ * 게시물 목록/알림에 노출할 썸네일 첨부를 결정합니다.
+ *
+ * 작성자가 명시적으로 지정한 썸네일을 우선하고, 지정이 없으면 본문에서 가장 먼저 참조된 첨부를 사용합니다.
+ * 둘 다 없으면 null을 반환하며, 기본 썸네일 URL로 대체하는 책임은 호출부에 있습니다.
+ * 저장 시점에 썸네일을 자동으로 승격시키지 않고 조회 시점에 결정하므로,
+ * 본문이 바뀌면 별도 갱신 없이 노출 썸네일도 함께 따라갑니다.
+ */
+@Component
+class PostThumbnailResolver {
+    fun resolve(
+        post: Post,
+        confirmedAttachments: List<Attachment>,
+    ): Attachment? {
+        val attachmentById = confirmedAttachments.associateBy { it.id }
+        post.thumbnailImage?.let { attachmentById[it] }?.let { return it }
+
+        return post.referencedAttachmentIds().firstNotNullOfOrNull { attachmentById[it] }
+    }
+}

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -166,15 +166,6 @@ class PostWriteService(
 
         val newStatus = request.status ?: post.status
         if (newStatus != PostStatusEnum.DRAFT) {
-            request.thumbnailAttachmentId?.let { thumbnailAttachmentId ->
-                attachmentService.confirmAttachmentsByIds(
-                    referenceId = postId,
-                    referenceType = AttachmentReferenceType.POST,
-                    attachmentIds = listOf(thumbnailAttachmentId),
-                )
-                post.thumbnailImage = thumbnailAttachmentId
-            }
-
             // 썸네일 교체도 이전 썸네일의 참조를 끊으므로 본문·첨부 목록 변경과 같은 정리 대상으로 본다.
             // 그렇지 않으면 본문에 없던 이전 썸네일이 확정 상태로 남아 상세 조회의 첨부 URL 목록에 계속 노출된다.
             val isAttachmentReferenceChanged =
@@ -183,17 +174,25 @@ class PostWriteService(
             if (isAttachmentReferenceChanged) {
                 val attachmentIdsReferencedInContent = post.referencedAttachmentIds()
 
-                request.attachmentIds?.let { requestedAttachmentIds ->
+                // 확정은 S3 복사를 일으키므로 썸네일과 본문 첨부를 한 번에 넘긴다.
+                // 나눠 호출하면 앞선 호출이 S3를 바꾼 뒤 뒤 호출의 검증이 실패할 수 있고,
+                // 그때 롤백된 DB와 이미 변경된 S3가 어긋난다.
+                if (request.attachmentIds != null || request.thumbnailAttachmentId != null) {
                     attachmentService.confirmAttachmentsByIds(
                         referenceId = postId,
                         referenceType = AttachmentReferenceType.POST,
                         attachmentIds =
-                            filterAttachmentIdsIncludedInContent(
-                                attachmentIdsReferencedInContent,
-                                requestedAttachmentIds,
+                            mergeAttachmentIds(
+                                filterAttachmentIdsIncludedInContent(
+                                    attachmentIdsReferencedInContent,
+                                    request.attachmentIds,
+                                ),
+                                request.thumbnailAttachmentId,
                             ),
                     )
                 }
+
+                request.thumbnailAttachmentId?.let { post.thumbnailImage = it }
 
                 attachmentService.deleteOrphanedAttachmentsByIds(
                     referenceId = postId,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -163,35 +163,44 @@ class PostWriteService(
         }
 
         val newStatus = request.status ?: post.status
-        if (newStatus != PostStatusEnum.DRAFT) {
-            val attachmentIdsIncludedInContent =
-                mergeAttachmentIds(
-                    filterAttachmentIdsIncludedInContent(post.content, request.attachmentIds),
-                    request.thumbnailAttachmentId,
+        when {
+            newStatus == PostStatusEnum.DRAFT -> post.thumbnailImage = null
+            request.attachmentIds != null -> {
+                val attachmentIdsIncludedInContent =
+                    mergeAttachmentIds(
+                        filterAttachmentIdsIncludedInContent(post.content, request.attachmentIds),
+                        request.thumbnailAttachmentId,
+                    )
+                val thumbnailAttachmentId =
+                    resolveThumbnailAttachmentId(
+                        requestThumbnailAttachmentId = request.thumbnailAttachmentId,
+                        currentThumbnailAttachmentId = post.thumbnailImage,
+                        attachmentIdsIncludedInContent = attachmentIdsIncludedInContent,
+                    )
+                val keepAttachmentIds = mergeAttachmentIds(attachmentIdsIncludedInContent, thumbnailAttachmentId)
+
+                attachmentService.confirmAttachmentsByIds(
+                    referenceId = postId,
+                    referenceType = AttachmentReferenceType.POST,
+                    attachmentIds = keepAttachmentIds,
                 )
-            val thumbnailAttachmentId =
-                resolveThumbnailAttachmentId(
-                    requestThumbnailAttachmentId = request.thumbnailAttachmentId,
-                    currentThumbnailAttachmentId = post.thumbnailImage,
-                    attachmentIdsIncludedInContent = attachmentIdsIncludedInContent,
+
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    referenceId = postId,
+                    referenceType = AttachmentReferenceType.POST,
+                    keepAttachmentIds = keepAttachmentIds,
                 )
-            val keepAttachmentIds = mergeAttachmentIds(attachmentIdsIncludedInContent, thumbnailAttachmentId)
 
-            attachmentService.confirmAttachmentsByIds(
-                referenceId = postId,
-                referenceType = AttachmentReferenceType.POST,
-                attachmentIds = keepAttachmentIds,
-            )
-
-            attachmentService.deleteOrphanedAttachmentsByIds(
-                referenceId = postId,
-                referenceType = AttachmentReferenceType.POST,
-                keepAttachmentIds = keepAttachmentIds,
-            )
-
-            post.thumbnailImage = thumbnailAttachmentId
-        } else {
-            post.thumbnailImage = null
+                post.thumbnailImage = thumbnailAttachmentId
+            }
+            request.thumbnailAttachmentId != null -> {
+                attachmentService.confirmAttachmentsByIds(
+                    referenceId = postId,
+                    referenceType = AttachmentReferenceType.POST,
+                    attachmentIds = listOf(request.thumbnailAttachmentId),
+                )
+                post.thumbnailImage = request.thumbnailAttachmentId
+            }
         }
 
         val savedPost = postRepository.save(post)

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -162,45 +162,30 @@ class PostWriteService(
             post.status = newStatus
         }
 
-        val newStatus = request.status ?: post.status
-        when {
-            newStatus == PostStatusEnum.DRAFT -> post.thumbnailImage = null
-            request.attachmentIds != null -> {
-                val attachmentIdsIncludedInContent =
-                    mergeAttachmentIds(
-                        filterAttachmentIdsIncludedInContent(post.content, request.attachmentIds),
-                        request.thumbnailAttachmentId,
-                    )
-                val thumbnailAttachmentId =
-                    resolveThumbnailAttachmentId(
-                        requestThumbnailAttachmentId = request.thumbnailAttachmentId,
-                        currentThumbnailAttachmentId = post.thumbnailImage,
-                        attachmentIdsIncludedInContent = attachmentIdsIncludedInContent,
-                    )
-                val keepAttachmentIds = mergeAttachmentIds(attachmentIdsIncludedInContent, thumbnailAttachmentId)
+        request.thumbnailAttachmentId?.let { thumbnailAttachmentId ->
+            attachmentService.confirmAttachmentsByIds(
+                referenceId = postId,
+                referenceType = AttachmentReferenceType.POST,
+                attachmentIds = listOf(thumbnailAttachmentId),
+            )
+            post.thumbnailImage = thumbnailAttachmentId
+        }
 
-                attachmentService.confirmAttachmentsByIds(
-                    referenceId = postId,
-                    referenceType = AttachmentReferenceType.POST,
-                    attachmentIds = keepAttachmentIds,
-                )
+        request.attachmentIds?.let { attachmentIds ->
+            val attachmentIdsIncludedInContent =
+                filterAttachmentIdsIncludedInContent(post.content, attachmentIds)
 
-                attachmentService.deleteOrphanedAttachmentsByIds(
-                    referenceId = postId,
-                    referenceType = AttachmentReferenceType.POST,
-                    keepAttachmentIds = keepAttachmentIds,
-                )
+            attachmentService.confirmAttachmentsByIds(
+                referenceId = postId,
+                referenceType = AttachmentReferenceType.POST,
+                attachmentIds = attachmentIdsIncludedInContent,
+            )
 
-                post.thumbnailImage = thumbnailAttachmentId
-            }
-            request.thumbnailAttachmentId != null -> {
-                attachmentService.confirmAttachmentsByIds(
-                    referenceId = postId,
-                    referenceType = AttachmentReferenceType.POST,
-                    attachmentIds = listOf(request.thumbnailAttachmentId),
-                )
-                post.thumbnailImage = request.thumbnailAttachmentId
-            }
+            attachmentService.deleteOrphanedAttachmentsByIds(
+                referenceId = postId,
+                referenceType = AttachmentReferenceType.POST,
+                keepAttachmentIds = mergeAttachmentIds(attachmentIdsIncludedInContent, post.thumbnailImage),
+            )
         }
 
         val savedPost = postRepository.save(post)
@@ -268,32 +253,6 @@ class PostWriteService(
         attachmentIds: List<UUID>,
         thumbnailAttachmentId: UUID?,
     ): List<UUID> = (attachmentIds + listOfNotNull(thumbnailAttachmentId)).distinct()
-
-    /**
-     * 게시물 수정 후 최종 썸네일 attachmentId를 결정합니다.
-     * 요청 썸네일이 있으면 그 값을 우선 사용하고, 없으면 본문에 여전히 포함된 기존 썸네일을 유지합니다.
-     * 둘 다 없으면 본문에 남아 있는 첫 번째 attachment를 썸네일로 사용합니다.
-     *
-     * @param requestThumbnailAttachmentId 수정 요청에서 명시적으로 전달한 썸네일 attachmentId
-     * @param currentThumbnailAttachmentId 게시물에 현재 저장된 썸네일 attachmentId
-     * @param attachmentIdsIncludedInContent 수정 후 본문에 포함된 attachmentId 목록
-     * @return 최종적으로 게시물에 저장할 썸네일 attachmentId, 없으면 null
-     */
-    private fun resolveThumbnailAttachmentId(
-        requestThumbnailAttachmentId: UUID?,
-        currentThumbnailAttachmentId: UUID?,
-        attachmentIdsIncludedInContent: List<UUID>,
-    ): UUID? {
-        if (requestThumbnailAttachmentId != null) {
-            return requestThumbnailAttachmentId
-        }
-
-        if (currentThumbnailAttachmentId in attachmentIdsIncludedInContent) {
-            return currentThumbnailAttachmentId
-        }
-
-        return attachmentIdsIncludedInContent.firstOrNull()
-    }
 
     /**
      * 카테고리 경로를 파싱하여 해당 카테고리를 반환합니다.

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -171,15 +171,22 @@ class PostWriteService(
             post.thumbnailImage = thumbnailAttachmentId
         }
 
-        request.attachmentIds?.let { attachmentIds ->
+        if (request.content != null || request.attachmentIds != null) {
+            val attachmentIds =
+                request.attachmentIds
+                    ?: attachmentService
+                        .getConfirmedAttachments(postId, AttachmentReferenceType.POST)
+                        .mapNotNull { it.id }
             val attachmentIdsIncludedInContent =
                 filterAttachmentIdsIncludedInContent(post.content, attachmentIds)
 
-            attachmentService.confirmAttachmentsByIds(
-                referenceId = postId,
-                referenceType = AttachmentReferenceType.POST,
-                attachmentIds = attachmentIdsIncludedInContent,
-            )
+            request.attachmentIds?.let {
+                attachmentService.confirmAttachmentsByIds(
+                    referenceId = postId,
+                    referenceType = AttachmentReferenceType.POST,
+                    attachmentIds = attachmentIdsIncludedInContent,
+                )
+            }
 
             attachmentService.deleteOrphanedAttachmentsByIds(
                 referenceId = postId,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -129,6 +129,7 @@ class PostWriteService(
      * 요청에 포함된 필드만 업데이트하며, 작성자 권한을 검증합니다.
      * 상태 전환 시 DRAFT를 제외한 상태는 제목과 본문이 필수입니다.
      * DRAFT 상태에서는 생성 경로와 동일하게 첨부 확정과 orphan 정리를 수행하지 않습니다.
+     * 본문, 첨부 목록, 썸네일 중 하나라도 전달되면 본문 참조와 현재 썸네일을 기준으로 orphan 첨부를 정리합니다.
      *
      * @param postId 게시물 ID
      * @param request 게시물 수정 요청
@@ -174,7 +175,12 @@ class PostWriteService(
                 post.thumbnailImage = thumbnailAttachmentId
             }
 
-            if (request.content != null || request.attachmentIds != null) {
+            // 썸네일 교체도 이전 썸네일의 참조를 끊으므로 본문·첨부 목록 변경과 같은 정리 대상으로 본다.
+            // 그렇지 않으면 본문에 없던 이전 썸네일이 확정 상태로 남아 상세 조회의 첨부 URL 목록에 계속 노출된다.
+            val isAttachmentReferenceChanged =
+                request.content != null || request.attachmentIds != null || request.thumbnailAttachmentId != null
+
+            if (isAttachmentReferenceChanged) {
                 val attachmentIdsReferencedInContent = post.referencedAttachmentIds()
 
                 request.attachmentIds?.let { requestedAttachmentIds ->

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -98,7 +98,7 @@ class PostWriteService(
                 emptyList()
             } else {
                 mergeAttachmentIds(
-                    filterAttachmentIdsIncludedInContent(post.content, request.attachmentIds),
+                    filterAttachmentIdsIncludedInContent(post.referencedAttachmentIds(), request.attachmentIds),
                     request.thumbnailAttachmentId,
                 )
             }
@@ -113,7 +113,7 @@ class PostWriteService(
                 referenceType = AttachmentReferenceType.POST,
                 attachmentIds = attachmentIds,
             )
-            savedPost.thumbnailImage = request.thumbnailAttachmentId ?: attachmentIds.firstOrNull()
+            savedPost.thumbnailImage = request.thumbnailAttachmentId
             savedPost.updatedAt = postRepository.updateThumbnailImage(savedPost.id!!, savedPost.thumbnailImage)
         }
 
@@ -128,6 +128,7 @@ class PostWriteService(
      * 게시물을 수정합니다.
      * 요청에 포함된 필드만 업데이트하며, 작성자 권한을 검증합니다.
      * 상태 전환 시 DRAFT를 제외한 상태는 제목과 본문이 필수입니다.
+     * DRAFT 상태에서는 생성 경로와 동일하게 첨부 확정과 orphan 정리를 수행하지 않습니다.
      *
      * @param postId 게시물 ID
      * @param request 게시물 수정 요청
@@ -162,37 +163,38 @@ class PostWriteService(
             post.status = newStatus
         }
 
-        request.thumbnailAttachmentId?.let { thumbnailAttachmentId ->
-            attachmentService.confirmAttachmentsByIds(
-                referenceId = postId,
-                referenceType = AttachmentReferenceType.POST,
-                attachmentIds = listOf(thumbnailAttachmentId),
-            )
-            post.thumbnailImage = thumbnailAttachmentId
-        }
-
-        if (request.content != null || request.attachmentIds != null) {
-            val attachmentIds =
-                request.attachmentIds
-                    ?: attachmentService
-                        .getConfirmedAttachments(postId, AttachmentReferenceType.POST)
-                        .mapNotNull { it.id }
-            val attachmentIdsIncludedInContent =
-                filterAttachmentIdsIncludedInContent(post.content, attachmentIds)
-
-            request.attachmentIds?.let {
+        val newStatus = request.status ?: post.status
+        if (newStatus != PostStatusEnum.DRAFT) {
+            request.thumbnailAttachmentId?.let { thumbnailAttachmentId ->
                 attachmentService.confirmAttachmentsByIds(
                     referenceId = postId,
                     referenceType = AttachmentReferenceType.POST,
-                    attachmentIds = attachmentIdsIncludedInContent,
+                    attachmentIds = listOf(thumbnailAttachmentId),
                 )
+                post.thumbnailImage = thumbnailAttachmentId
             }
 
-            attachmentService.deleteOrphanedAttachmentsByIds(
-                referenceId = postId,
-                referenceType = AttachmentReferenceType.POST,
-                keepAttachmentIds = mergeAttachmentIds(attachmentIdsIncludedInContent, post.thumbnailImage),
-            )
+            if (request.content != null || request.attachmentIds != null) {
+                val attachmentIdsReferencedInContent = post.referencedAttachmentIds()
+
+                request.attachmentIds?.let { requestedAttachmentIds ->
+                    attachmentService.confirmAttachmentsByIds(
+                        referenceId = postId,
+                        referenceType = AttachmentReferenceType.POST,
+                        attachmentIds =
+                            filterAttachmentIdsIncludedInContent(
+                                attachmentIdsReferencedInContent,
+                                requestedAttachmentIds,
+                            ),
+                    )
+                }
+
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    referenceId = postId,
+                    referenceType = AttachmentReferenceType.POST,
+                    keepAttachmentIds = mergeAttachmentIds(attachmentIdsReferencedInContent, post.thumbnailImage),
+                )
+            }
         }
 
         val savedPost = postRepository.save(post)
@@ -246,14 +248,14 @@ class PostWriteService(
     }
 
     private fun filterAttachmentIdsIncludedInContent(
-        content: String,
+        attachmentIdsReferencedInContent: List<UUID>,
         requestedAttachmentIds: List<UUID>?,
     ): List<UUID> =
         requestedAttachmentIds
             .orEmpty()
             .distinct()
             .filter { attachmentId ->
-                content.contains(attachmentId.toString())
+                attachmentId in attachmentIdsReferencedInContent
             }
 
     private fun mergeAttachmentIds(

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
@@ -17,7 +17,7 @@ import java.util.UUID
  * @property content 게시물 본문 (선택)
  * @property categoryPath 카테고리 경로 (선택)
  * @property tags 태그 목록 (선택)
- * @property attachmentIds 게시물 첨부 ID 목록 (생략 시 유지, 빈 목록이면 전체 제거)
+ * @property attachmentIds 게시물 본문 첨부 ID 목록 (생략 시 유지, 빈 목록이면 본문 첨부 제거)
  * @property thumbnailAttachmentId 대표 썸네일 첨부 ID (생략 시 유지)
  * @property status 게시물 상태 (선택, DRAFT/PUBLISHED/PRIVATE)
  */
@@ -34,7 +34,7 @@ data class UpdatePostRequest(
     @field:ArraySchema(maxItems = TaggedContent.MAX_TAG_COUNT, schema = Schema(description = "태그명", example = "spring"))
     val tags: List<String>? = null,
     @field:Schema(
-        description = "게시물에 연결할 attachment ID 목록 (생략 시 기존 첨부 유지, 빈 목록이면 전체 제거)",
+        description = "게시물 본문에 연결할 attachment ID 목록 (생략 시 기존 본문 첨부 유지, 빈 목록이면 본문 첨부 제거)",
         example = "[\"01234567-89ab-cdef-0123-456789abcdef\"]",
     )
     val attachmentIds: List<UUID>? = null,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
@@ -18,7 +18,7 @@ import java.util.UUID
  * @property categoryPath 카테고리 경로 (선택)
  * @property tags 태그 목록 (선택)
  * @property attachmentIds 새로 확정할 첨부 ID 목록 (유지·삭제 판단은 항상 본문 참조 기준)
- * @property thumbnailAttachmentId 대표 썸네일 첨부 ID (생략 시 유지, 지정된 적 없으면 본문 첫 첨부로 노출)
+ * @property thumbnailAttachmentId 대표 썸네일 첨부 ID (생략 시 유지, 지정된 적 없으면 본문 첫 첨부로 노출, 교체 시 본문에서 참조되지 않는 이전 썸네일은 삭제)
  * @property status 게시물 상태 (선택, DRAFT/PUBLISHED/PRIVATE)
  */
 @Schema(description = "게시물 수정 요청")
@@ -39,7 +39,10 @@ data class UpdatePostRequest(
     )
     val attachmentIds: List<UUID>? = null,
     @field:Schema(
-        description = "대표 썸네일로 사용할 attachment ID (생략 시 기존 썸네일 유지, 지정된 적 없으면 본문 첫 첨부로 노출)",
+        description =
+            "대표 썸네일로 사용할 attachment ID " +
+                "(생략 시 기존 썸네일 유지, 지정된 적 없으면 본문 첫 첨부로 노출, " +
+                "교체 시 본문에서 참조되지 않는 이전 썸네일은 삭제)",
         example = "01234567-89ab-cdef-0123-456789abcdef",
     )
     val thumbnailAttachmentId: UUID? = null,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
@@ -17,8 +17,8 @@ import java.util.UUID
  * @property content 게시물 본문 (선택, 변경 시 본문에서 참조가 사라진 기존 첨부 제거)
  * @property categoryPath 카테고리 경로 (선택)
  * @property tags 태그 목록 (선택)
- * @property attachmentIds 새 게시물 본문 첨부 ID 목록 (생략 시 기존 첨부를 변경된 본문 참조 기준으로 정리)
- * @property thumbnailAttachmentId 대표 썸네일 첨부 ID (생략 시 유지)
+ * @property attachmentIds 새로 확정할 첨부 ID 목록 (유지·삭제 판단은 항상 본문 참조 기준)
+ * @property thumbnailAttachmentId 대표 썸네일 첨부 ID (생략 시 유지, 지정된 적 없으면 본문 첫 첨부로 노출)
  * @property status 게시물 상태 (선택, DRAFT/PUBLISHED/PRIVATE)
  */
 @Schema(description = "게시물 수정 요청")
@@ -34,12 +34,12 @@ data class UpdatePostRequest(
     @field:ArraySchema(maxItems = TaggedContent.MAX_TAG_COUNT, schema = Schema(description = "태그명", example = "spring"))
     val tags: List<String>? = null,
     @field:Schema(
-        description = "새 게시물 본문에 연결할 attachment ID 목록 (생략 시 기존 첨부를 변경된 본문 참조 기준으로 정리, 빈 목록이면 본문 첨부 제거)",
+        description = "새로 확정할 attachment ID 목록 (본문에 참조가 있는 항목만 확정되며, 첨부 유지·삭제는 목록과 무관하게 본문 참조 기준으로 판단)",
         example = "[\"01234567-89ab-cdef-0123-456789abcdef\"]",
     )
     val attachmentIds: List<UUID>? = null,
     @field:Schema(
-        description = "대표 썸네일로 사용할 attachment ID (생략 시 기존 썸네일 유지)",
+        description = "대표 썸네일로 사용할 attachment ID (생략 시 기존 썸네일 유지, 지정된 적 없으면 본문 첫 첨부로 노출)",
         example = "01234567-89ab-cdef-0123-456789abcdef",
     )
     val thumbnailAttachmentId: UUID? = null,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
@@ -17,6 +17,8 @@ import java.util.UUID
  * @property content 게시물 본문 (선택)
  * @property categoryPath 카테고리 경로 (선택)
  * @property tags 태그 목록 (선택)
+ * @property attachmentIds 게시물 첨부 ID 목록 (생략 시 유지, 빈 목록이면 전체 제거)
+ * @property thumbnailAttachmentId 대표 썸네일 첨부 ID (생략 시 유지)
  * @property status 게시물 상태 (선택, DRAFT/PUBLISHED/PRIVATE)
  */
 @Schema(description = "게시물 수정 요청")
@@ -31,9 +33,15 @@ data class UpdatePostRequest(
     @field:Size(max = TaggedContent.MAX_TAG_COUNT, message = "태그는 최대 10개까지 설정할 수 있습니다")
     @field:ArraySchema(maxItems = TaggedContent.MAX_TAG_COUNT, schema = Schema(description = "태그명", example = "spring"))
     val tags: List<String>? = null,
-    @field:Schema(description = "게시물에 연결할 attachment ID 목록", example = "[\"01234567-89ab-cdef-0123-456789abcdef\"]")
+    @field:Schema(
+        description = "게시물에 연결할 attachment ID 목록 (생략 시 기존 첨부 유지, 빈 목록이면 전체 제거)",
+        example = "[\"01234567-89ab-cdef-0123-456789abcdef\"]",
+    )
     val attachmentIds: List<UUID>? = null,
-    @field:Schema(description = "대표 썸네일로 사용할 attachment ID", example = "01234567-89ab-cdef-0123-456789abcdef")
+    @field:Schema(
+        description = "대표 썸네일로 사용할 attachment ID (생략 시 기존 썸네일 유지)",
+        example = "01234567-89ab-cdef-0123-456789abcdef",
+    )
     val thumbnailAttachmentId: UUID? = null,
     @field:Schema(description = "게시물 상태 (DRAFT/PUBLISHED/PRIVATE)", example = "PUBLISHED")
     val status: PostStatusEnum? = null,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/dto/UpdatePostRequest.kt
@@ -14,10 +14,10 @@ import java.util.UUID
  * 상태 전환 시 DRAFT를 제외한 상태는 제목과 본문이 필수입니다.
  *
  * @property title 게시물 제목 (선택, 최대 200자)
- * @property content 게시물 본문 (선택)
+ * @property content 게시물 본문 (선택, 변경 시 본문에서 참조가 사라진 기존 첨부 제거)
  * @property categoryPath 카테고리 경로 (선택)
  * @property tags 태그 목록 (선택)
- * @property attachmentIds 게시물 본문 첨부 ID 목록 (생략 시 유지, 빈 목록이면 본문 첨부 제거)
+ * @property attachmentIds 새 게시물 본문 첨부 ID 목록 (생략 시 기존 첨부를 변경된 본문 참조 기준으로 정리)
  * @property thumbnailAttachmentId 대표 썸네일 첨부 ID (생략 시 유지)
  * @property status 게시물 상태 (선택, DRAFT/PUBLISHED/PRIVATE)
  */
@@ -26,7 +26,7 @@ data class UpdatePostRequest(
     @field:Size(max = 200, message = "제목은 최대 200자까지 가능합니다")
     @field:Schema(description = "게시물 제목", example = "Spring Boot 시작하기", maxLength = 200)
     val title: String? = null,
-    @field:Schema(description = "게시물 본문", example = "Spring Boot를 사용하면...")
+    @field:Schema(description = "게시물 본문 (변경 시 본문에서 참조가 사라진 기존 첨부 제거)", example = "Spring Boot를 사용하면...")
     val content: String? = null,
     @field:Schema(description = "카테고리 경로 (슬래시로 구분, 최대 5단계)", example = "java/spring/deepdive")
     val categoryPath: String? = null,
@@ -34,7 +34,7 @@ data class UpdatePostRequest(
     @field:ArraySchema(maxItems = TaggedContent.MAX_TAG_COUNT, schema = Schema(description = "태그명", example = "spring"))
     val tags: List<String>? = null,
     @field:Schema(
-        description = "게시물 본문에 연결할 attachment ID 목록 (생략 시 기존 본문 첨부 유지, 빈 목록이면 본문 첨부 제거)",
+        description = "새 게시물 본문에 연결할 attachment ID 목록 (생략 시 기존 첨부를 변경된 본문 참조 기준으로 정리, 빈 목록이면 본문 첨부 제거)",
         example = "[\"01234567-89ab-cdef-0123-456789abcdef\"]",
     )
     val attachmentIds: List<UUID>? = null,

--- a/src/main/kotlin/com/techtaurant/mainserver/post/entity/Post.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/entity/Post.kt
@@ -3,6 +3,7 @@ package com.techtaurant.mainserver.post.entity
 import com.techtaurant.mainserver.common.base.EntityBase
 import com.techtaurant.mainserver.post.enums.PostStatusEnum
 import com.techtaurant.mainserver.user.entity.User
+import java.util.UUID
 
 /**
  * 게시물 엔티티
@@ -32,5 +33,22 @@ class Post(
 ) : EntityBase(), TaggedContent {
     init {
         validateTagCount()
+    }
+
+    /**
+     * 본문이 참조하는 첨부 ID를 본문에 등장한 순서대로 반환합니다.
+     * 첨부 유지 판정과 썸네일 fallback이 모두 이 목록을 기준으로 동작하므로,
+     * 본문에서 참조가 사라진 첨부는 요청 목록에 남아 있어도 유지 대상이 아닙니다.
+     */
+    fun referencedAttachmentIds(): List<UUID> =
+        ATTACHMENT_ID_PATTERN
+            .findAll(content)
+            .map { UUID.fromString(it.value) }
+            .distinct()
+            .toList()
+
+    companion object {
+        private val ATTACHMENT_ID_PATTERN =
+            Regex("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentServiceTest.kt
@@ -15,6 +15,7 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -622,6 +623,31 @@ class AttachmentServiceTest {
             verify { attachmentRepository.deleteAll(listOf(orphanAttachment)) }
 
             triggerAfterCommit()
+            verify { s3StorageService.deleteObjects(listOf(orphanAttachment.objectKey)) }
+        }
+
+        @Test
+        @DisplayName("커밋 후 S3 삭제가 실패해도 예외를 호출자에게 전파하지 않는다")
+        fun deleteOrphanedAttachmentsByIds_s3DeleteFailsAfterCommit_doesNotPropagateException() {
+            // given
+            val orphanAttachment = makeAttachment("posts/$postId/uuid2/orphan.jpg")
+
+            every {
+                attachmentRepository.findAllByReferenceIdAndReferenceType(postId, AttachmentReferenceType.POST)
+            } returns listOf(orphanAttachment)
+            every { attachmentRepository.deleteAll(any<List<Attachment>>()) } just runs
+            every { s3StorageService.deleteObjects(any()) } throws RuntimeException("S3 unavailable")
+
+            // when
+            attachmentService.deleteOrphanedAttachmentsByIds(
+                postId,
+                AttachmentReferenceType.POST,
+                emptyList(),
+            )
+
+            // then
+            // 전파되면 DB 커밋이 끝난 요청이 실패로 보이고 클라이언트가 반영된 상태에 재시도한다.
+            assertThatCode { triggerAfterCommit() }.doesNotThrowAnyException()
             verify { s3StorageService.deleteObjects(listOf(orphanAttachment.objectKey)) }
         }
     }

--- a/src/test/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentServiceTest.kt
@@ -16,11 +16,13 @@ import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.util.UUID
 
 class AttachmentServiceTest {
@@ -36,6 +38,22 @@ class AttachmentServiceTest {
         )
 
     private val postId = UUID.randomUUID()
+
+    // 파괴적 S3 삭제는 커밋 이후로 미뤄지므로, 단위 테스트도 트랜잭션 동기화를 활성화해야 콜백이 등록된다.
+    @BeforeEach
+    fun initTransactionSynchronization() {
+        TransactionSynchronizationManager.initSynchronization()
+    }
+
+    @AfterEach
+    fun clearTransactionSynchronization() {
+        TransactionSynchronizationManager.clearSynchronization()
+    }
+
+    /** 등록된 커밋 후 콜백을 실행해 커밋 시점을 재현한다. */
+    private fun triggerAfterCommit() {
+        TransactionSynchronizationManager.getSynchronizations().forEach { it.afterCommit() }
+    }
 
     private fun makeAttachment(
         objectKey: String,
@@ -130,7 +148,6 @@ class AttachmentServiceTest {
             }
             every { s3StorageService.exists(any()) } returns true
             every { s3StorageService.copyObject(any(), any()) } just runs
-            every { s3StorageService.deleteObject(any()) } just runs
             every { attachmentRepository.saveAll(any<List<Attachment>>()) } answers { firstArg() }
         }
 
@@ -314,8 +331,8 @@ class AttachmentServiceTest {
         }
 
         @Test
-        @DisplayName("TMP 파일을 posts/{referenceId}/ 경로로 복사하고 원본을 삭제한다")
-        fun confirmAttachmentsByIds_tmpAttachment_copiesAndDeletesS3Object() {
+        @DisplayName("TMP 파일을 posts/{referenceId}/ 경로로 복사하고 tmp/ 원본은 남긴다")
+        fun confirmAttachmentsByIds_tmpAttachment_copiesS3ObjectAndKeepsSource() {
             // given
             every { attachmentRepository.findAllById(listOf(tmpAttachment.id!!)) } returns listOf(tmpAttachment)
 
@@ -332,7 +349,8 @@ class AttachmentServiceTest {
             assertThat(newKey).endsWith("photo.jpg")
 
             verify { s3StorageService.copyObject(tmpKey, newKey) }
-            verify { s3StorageService.deleteObject(tmpKey) }
+            // 커밋 전에 원본을 지우면 롤백 시 DB가 가리키는 tmp/ 객체가 사라져 재시도가 막힌다.
+            verify(exactly = 0) { s3StorageService.deleteObjects(any()) }
         }
 
         @Test
@@ -485,12 +503,15 @@ class AttachmentServiceTest {
             attachmentService.deleteAttachmentsByReference(postId, AttachmentReferenceType.POST)
 
             // then
+            verify { attachmentRepository.deleteAllByReferenceIdAndReferenceType(postId, AttachmentReferenceType.POST) }
+            verify(exactly = 0) { s3StorageService.deleteObjects(any()) }
+
+            triggerAfterCommit()
             verify {
                 s3StorageService.deleteObjects(
                     match { it.containsAll(listOf("posts/$postId/uuid1/a.jpg", "posts/$postId/uuid2/b.jpg")) },
                 )
             }
-            verify { attachmentRepository.deleteAllByReferenceIdAndReferenceType(postId, AttachmentReferenceType.POST) }
         }
 
         @Test
@@ -540,8 +561,11 @@ class AttachmentServiceTest {
             )
 
             // then
-            verify { s3StorageService.deleteObjects(listOf(orphanAttachment.objectKey)) }
             verify { attachmentRepository.deleteAll(listOf(orphanAttachment)) }
+            verify(exactly = 0) { s3StorageService.deleteObjects(any()) }
+
+            triggerAfterCommit()
+            verify { s3StorageService.deleteObjects(listOf(orphanAttachment.objectKey)) }
         }
 
         @Test
@@ -595,8 +619,10 @@ class AttachmentServiceTest {
             verify(exactly = 0) {
                 attachmentRepository.findAllByReferenceIdAndReferenceTypeAndIdNotIn(any(), any(), any())
             }
-            verify { s3StorageService.deleteObjects(listOf(orphanAttachment.objectKey)) }
             verify { attachmentRepository.deleteAll(listOf(orphanAttachment)) }
+
+            triggerAfterCommit()
+            verify { s3StorageService.deleteObjects(listOf(orphanAttachment.objectKey)) }
         }
     }
 

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostListReadServiceTest.kt
@@ -43,6 +43,7 @@ class PostListReadServiceTest {
         PostMetadataReadService(
             postRepository = postRepository,
             attachmentService = attachmentService,
+            postThumbnailResolver = PostThumbnailResolver(),
             defaultThumbnailUrl = defaultThumbnailUrl,
             baseUrl = baseUrl,
         )
@@ -287,8 +288,8 @@ class PostListReadServiceTest {
         }
 
         @Test
-        @DisplayName("첨부파일 썸네일은 presigned URL로 반환한다")
-        fun getPosts_withThumbnailAttachment_returnsPresignedThumbnailUrl() {
+        @DisplayName("썸네일 지정이 없으면 업로드 순서가 아니라 본문에 먼저 등장한 첨부의 presigned URL을 반환한다")
+        fun getPosts_withoutThumbnailImage_returnsFirstAttachmentReferencedInContent() {
             // given
             val post = createPost(otherUser)
             val firstAttachment =
@@ -303,6 +304,7 @@ class PostListReadServiceTest {
                     objectKey = "posts/${post.id}/uuid-2/later.jpg",
                     createdAt = Instant.ofEpochMilli(2_000L),
                 )
+            post.content = "<img src=\"${laterAttachment.id}\" /><img src=\"${firstAttachment.id}\" />"
             every {
                 postRepository.findPostsWithConditions(
                     cursor = null,
@@ -329,7 +331,7 @@ class PostListReadServiceTest {
             val result = postListReadService.getPosts(cursor = null, size = 20, currentUserId = null)
 
             // then
-            assertThat(result.content.single().thumbnailUrl).isEqualTo("https://cdn.example.com/first.jpg")
+            assertThat(result.content.single().thumbnailUrl).isEqualTo("https://cdn.example.com/later.jpg")
         }
 
         @Test

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostMetadataReadServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostMetadataReadServiceTest.kt
@@ -26,6 +26,7 @@ class PostMetadataReadServiceTest {
         PostMetadataReadService(
             postRepository = postRepository,
             attachmentService = attachmentService,
+            postThumbnailResolver = PostThumbnailResolver(),
             defaultThumbnailUrl = "/static/images/post-thumbnail.png",
             baseUrl = "http://localhost:8080",
         )

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostThumbnailResolverTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostThumbnailResolverTest.kt
@@ -1,0 +1,121 @@
+package com.techtaurant.mainserver.post.application
+
+import com.techtaurant.mainserver.attachment.entity.Attachment
+import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
+import com.techtaurant.mainserver.attachment.enums.AttachmentStatus
+import com.techtaurant.mainserver.post.entity.Post
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class PostThumbnailResolverTest {
+    private val postThumbnailResolver = PostThumbnailResolver()
+
+    private lateinit var author: User
+
+    @BeforeEach
+    fun setUp() {
+        author =
+            User(
+                name = "작성자",
+                email = "writer@example.com",
+                provider = OAuthProvider.GOOGLE,
+                identifier = "writer-id",
+                role = UserRole.USER,
+                profileImageUrl = "https://example.com/profile.jpg",
+            ).apply { id = UUID.randomUUID() }
+    }
+
+    @Test
+    @DisplayName("명시적으로 지정한 썸네일이 본문에 없어도 그 첨부를 사용한다")
+    fun resolve_withExplicitThumbnail_usesThumbnailEvenWhenAbsentFromContent() {
+        // given
+        val thumbnailAttachment = createAttachment(createdAt = Instant.ofEpochMilli(3_000L))
+        val bodyAttachment = createAttachment(createdAt = Instant.ofEpochMilli(1_000L))
+        val post =
+            createPost(content = "<img src=\"${bodyAttachment.id}\" />")
+                .apply { thumbnailImage = thumbnailAttachment.id }
+
+        // when
+        val resolved = postThumbnailResolver.resolve(post, listOf(thumbnailAttachment, bodyAttachment))
+
+        // then
+        assertThat(resolved).isSameAs(thumbnailAttachment)
+    }
+
+    @Test
+    @DisplayName("썸네일 지정이 없으면 업로드 순서가 아니라 본문에 먼저 등장한 첨부를 사용한다")
+    fun resolve_withoutExplicitThumbnail_usesFirstAttachmentReferencedInContent() {
+        // given: 나중에 업로드된 첨부가 본문에서는 먼저 등장한다
+        val earlierUploadedAttachment = createAttachment(createdAt = Instant.ofEpochMilli(1_000L))
+        val laterUploadedAttachment = createAttachment(createdAt = Instant.ofEpochMilli(9_000L))
+        val post =
+            createPost(
+                content = "<img src=\"${laterUploadedAttachment.id}\" /><img src=\"${earlierUploadedAttachment.id}\" />",
+            )
+
+        // when
+        val resolved =
+            postThumbnailResolver.resolve(post, listOf(earlierUploadedAttachment, laterUploadedAttachment))
+
+        // then
+        assertThat(resolved).isSameAs(laterUploadedAttachment)
+    }
+
+    @Test
+    @DisplayName("지정한 썸네일이 확정 첨부에 없으면 본문 첫 첨부로 대체한다")
+    fun resolve_withMissingThumbnailAttachment_fallsBackToContent() {
+        // given
+        val bodyAttachment = createAttachment(createdAt = Instant.ofEpochMilli(1_000L))
+        val post =
+            createPost(content = "<img src=\"${bodyAttachment.id}\" />")
+                .apply { thumbnailImage = UUID.randomUUID() }
+
+        // when
+        val resolved = postThumbnailResolver.resolve(post, listOf(bodyAttachment))
+
+        // then
+        assertThat(resolved).isSameAs(bodyAttachment)
+    }
+
+    @Test
+    @DisplayName("본문이 참조하는 첨부가 없으면 null을 반환해 호출부가 기본 썸네일을 쓰게 한다")
+    fun resolve_withoutReferencedAttachment_returnsNull() {
+        // given
+        val unreferencedAttachment = createAttachment(createdAt = Instant.ofEpochMilli(1_000L))
+        val post = createPost(content = "<p>첨부 참조가 없는 본문</p>")
+
+        // when
+        val resolved = postThumbnailResolver.resolve(post, listOf(unreferencedAttachment))
+
+        // then
+        assertThat(resolved).isNull()
+    }
+
+    private fun createPost(content: String): Post =
+        Post(
+            title = "게시물",
+            content = content,
+            author = author,
+        ).apply { id = UUID.randomUUID() }
+
+    private fun createAttachment(createdAt: Instant): Attachment =
+        Attachment(
+            referenceId = UUID.randomUUID(),
+            referenceType = AttachmentReferenceType.POST,
+            objectKey = "posts/image.jpg",
+            status = AttachmentStatus.CONFIRMED,
+            originalFileName = "image.jpg",
+            contentType = "image/jpeg",
+            fileSize = 1024,
+        ).apply {
+            id = UUID.randomUUID()
+            this.createdAt = createdAt
+        }
+}

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -415,16 +415,18 @@ class PostWriteServiceAttachmentTest {
         }
 
         @Test
-        @DisplayName("attachmentIds 없이 본문만 바꾸면 첨부 확정 없이 orphan 정리도 빈 목록 기준으로 한다")
-        fun updatePost_withoutRequestAttachmentIds_usesEmptyAttachmentIds() {
+        @DisplayName("첨부 필드 없이 본문만 바꾸면 기존 첨부와 썸네일을 유지한다")
+        fun updatePost_withoutAttachmentFields_keepsExistingAttachmentsAndThumbnail() {
             // given
             val postId = UUID.randomUUID()
             val newAttachmentId = UUID.randomUUID()
+            val currentThumbnailAttachmentId = UUID.randomUUID()
             val post =
                 Post(
                     title = "기존 제목",
                     content = "기존 본문",
                     author = author,
+                    thumbnailImage = currentThumbnailAttachmentId,
                     status = PostStatusEnum.PUBLISHED,
                 ).apply { id = postId }
 
@@ -440,13 +442,37 @@ class PostWriteServiceAttachmentTest {
             val response = postWriteService.updatePost(postId, request, author.id!!)
 
             // then
-            verify {
-                attachmentService.confirmAttachmentsByIds(
-                    postId,
-                    AttachmentReferenceType.POST,
-                    emptyList(),
-                )
-            }
+            verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
+            verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
+            assertThat(response.content).contains(newAttachmentId.toString())
+            assertThat(post.thumbnailImage).isEqualTo(currentThumbnailAttachmentId)
+        }
+
+        @Test
+        @DisplayName("attachmentIds를 빈 목록으로 명시하면 기존 첨부와 썸네일을 제거한다")
+        fun updatePost_withEmptyAttachmentIds_removesExistingAttachmentsAndThumbnail() {
+            // given
+            val postId = UUID.randomUUID()
+            val currentThumbnailAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    thumbnailImage = currentThumbnailAttachmentId,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(attachmentIds = emptyList()),
+                author.id!!,
+            )
+
+            // then
             verify {
                 attachmentService.deleteOrphanedAttachmentsByIds(
                     postId,
@@ -454,7 +480,42 @@ class PostWriteServiceAttachmentTest {
                     emptyList(),
                 )
             }
-            assertThat(response.content).contains(newAttachmentId.toString())
+            assertThat(post.thumbnailImage).isNull()
+        }
+
+        @Test
+        @DisplayName("thumbnailAttachmentId만 지정하면 새 썸네일을 확정하고 기존 본문 첨부는 유지한다")
+        fun updatePost_withOnlyThumbnailAttachmentId_updatesThumbnailWithoutDeletingAttachments() {
+            // given
+            val postId = UUID.randomUUID()
+            val newThumbnailAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(thumbnailAttachmentId = newThumbnailAttachmentId),
+                author.id!!,
+            )
+
+            // then
+            verify {
+                attachmentService.confirmAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(newThumbnailAttachmentId),
+                )
+            }
+            verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
+            assertThat(post.thumbnailImage).isEqualTo(newThumbnailAttachmentId)
         }
 
         @Test

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -751,16 +751,19 @@ class PostWriteServiceAttachmentTest {
         }
 
         @Test
-        @DisplayName("thumbnailAttachmentId만 지정하면 새 썸네일을 확정하고 기존 본문 첨부는 유지한다")
-        fun updatePost_withOnlyThumbnailAttachmentId_updatesThumbnailWithoutDeletingAttachments() {
+        @DisplayName("thumbnailAttachmentId만 지정하면 새 썸네일을 확정하고 본문 참조 첨부는 유지한 채 이전 썸네일을 정리한다")
+        fun updatePost_withOnlyThumbnailAttachmentId_replacesThumbnailAndKeepsReferencedAttachments() {
             // given
             val postId = UUID.randomUUID()
+            val currentBodyAttachmentId = UUID.randomUUID()
+            val previousThumbnailAttachmentId = UUID.randomUUID()
             val newThumbnailAttachmentId = UUID.randomUUID()
             val post =
                 Post(
                     title = "기존 제목",
-                    content = "기존 본문",
+                    content = "<img src=\"$currentBodyAttachmentId\" />",
                     author = author,
+                    thumbnailImage = previousThumbnailAttachmentId,
                     status = PostStatusEnum.PUBLISHED,
                 ).apply { id = postId }
 
@@ -781,8 +784,50 @@ class PostWriteServiceAttachmentTest {
                     listOf(newThumbnailAttachmentId),
                 )
             }
-            verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(currentBodyAttachmentId, newThumbnailAttachmentId),
+                )
+            }
             assertThat(post.thumbnailImage).isEqualTo(newThumbnailAttachmentId)
+        }
+
+        @Test
+        @DisplayName("썸네일을 본문에 남아 있는 첨부로 교체하면 이전 썸네일만 정리 대상에서 빠진다")
+        fun updatePost_replaceThumbnailWithReferencedAttachment_keepsOnlyReferencedAttachments() {
+            // given
+            val postId = UUID.randomUUID()
+            val currentBodyAttachmentId = UUID.randomUUID()
+            val previousThumbnailAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "<img src=\"$currentBodyAttachmentId\" />",
+                    author = author,
+                    thumbnailImage = previousThumbnailAttachmentId,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(thumbnailAttachmentId = currentBodyAttachmentId),
+                author.id!!,
+            )
+
+            // then
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(currentBodyAttachmentId),
+                )
+            }
+            assertThat(post.thumbnailImage).isEqualTo(currentBodyAttachmentId)
         }
 
         @Test

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -325,8 +325,8 @@ class PostWriteServiceAttachmentTest {
         }
 
         @Test
-        @DisplayName("본문 첨부와 thumbnailAttachmentId를 각각 전달하면 각각 confirm하고 유지한다")
-        fun updatePost_withAttachmentIdsAndThumbnailAttachmentId_confirmsEachField() {
+        @DisplayName("본문 첨부와 thumbnailAttachmentId를 함께 전달하면 한 번의 confirm으로 처리하고 유지한다")
+        fun updatePost_withAttachmentIdsAndThumbnailAttachmentId_confirmsInSingleCall() {
             // given
             val postId = UUID.randomUUID()
             val contentAttachmentId = UUID.randomUUID()
@@ -353,18 +353,12 @@ class PostWriteServiceAttachmentTest {
             postWriteService.updatePost(postId, request, author.id!!)
 
             // then
-            verify {
+            // 나눠 호출하면 앞선 호출이 S3를 바꾼 뒤 뒤 호출의 검증이 실패할 수 있으므로 한 번에 넘긴다.
+            verify(exactly = 1) {
                 attachmentService.confirmAttachmentsByIds(
                     postId,
                     AttachmentReferenceType.POST,
-                    listOf(thumbnailAttachmentId),
-                )
-            }
-            verify {
-                attachmentService.confirmAttachmentsByIds(
-                    postId,
-                    AttachmentReferenceType.POST,
-                    listOf(contentAttachmentId),
+                    listOf(contentAttachmentId, thumbnailAttachmentId),
                 )
             }
             verify {

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -279,8 +279,8 @@ class PostWriteServiceAttachmentTest {
         }
 
         @Test
-        @DisplayName("thumbnailAttachmentId가 없어도 기존 thumbnailImage가 본문에 없으면 orphan으로 정리한다")
-        fun updatePost_withoutThumbnailAttachmentId_deletesCurrentThumbnailWhenRemovedFromContent() {
+        @DisplayName("thumbnailAttachmentId가 없으면 기존 thumbnailImage가 본문에서 빠져도 유지한다")
+        fun updatePost_withoutThumbnailAttachmentId_keepsCurrentThumbnailWhenRemovedFromContent() {
             // given
             val postId = UUID.randomUUID()
             val currentThumbnailAttachmentId = UUID.randomUUID()
@@ -307,7 +307,7 @@ class PostWriteServiceAttachmentTest {
             postWriteService.updatePost(postId, request, author.id!!)
 
             // then
-            assertThat(post.thumbnailImage).isEqualTo(remainingAttachmentId)
+            assertThat(post.thumbnailImage).isEqualTo(currentThumbnailAttachmentId)
             verify {
                 attachmentService.confirmAttachmentsByIds(
                     postId,
@@ -319,14 +319,14 @@ class PostWriteServiceAttachmentTest {
                 attachmentService.deleteOrphanedAttachmentsByIds(
                     postId,
                     AttachmentReferenceType.POST,
-                    listOf(remainingAttachmentId),
+                    listOf(remainingAttachmentId, currentThumbnailAttachmentId),
                 )
             }
         }
 
         @Test
-        @DisplayName("수정 시 thumbnailAttachmentId를 별도로 전달하면 본문 첨부와 함께 confirm하고 유지한다")
-        fun updatePost_withSeparateThumbnailAttachment_confirmsAndKeepsThumbnail() {
+        @DisplayName("본문 첨부와 thumbnailAttachmentId를 각각 전달하면 각각 confirm하고 유지한다")
+        fun updatePost_withAttachmentIdsAndThumbnailAttachmentId_confirmsEachField() {
             // given
             val postId = UUID.randomUUID()
             val contentAttachmentId = UUID.randomUUID()
@@ -357,7 +357,14 @@ class PostWriteServiceAttachmentTest {
                 attachmentService.confirmAttachmentsByIds(
                     postId,
                     AttachmentReferenceType.POST,
-                    listOf(contentAttachmentId, thumbnailAttachmentId),
+                    listOf(thumbnailAttachmentId),
+                )
+            }
+            verify {
+                attachmentService.confirmAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(contentAttachmentId),
                 )
             }
             verify {
@@ -449,8 +456,8 @@ class PostWriteServiceAttachmentTest {
         }
 
         @Test
-        @DisplayName("attachmentIds를 빈 목록으로 명시하면 기존 첨부와 썸네일을 제거한다")
-        fun updatePost_withEmptyAttachmentIds_removesExistingAttachmentsAndThumbnail() {
+        @DisplayName("attachmentIds를 빈 목록으로 명시해도 생략한 썸네일은 유지한다")
+        fun updatePost_withEmptyAttachmentIds_keepsOmittedThumbnail() {
             // given
             val postId = UUID.randomUUID()
             val currentThumbnailAttachmentId = UUID.randomUUID()
@@ -477,10 +484,41 @@ class PostWriteServiceAttachmentTest {
                 attachmentService.deleteOrphanedAttachmentsByIds(
                     postId,
                     AttachmentReferenceType.POST,
-                    emptyList(),
+                    listOf(currentThumbnailAttachmentId),
                 )
             }
-            assertThat(post.thumbnailImage).isNull()
+            assertThat(post.thumbnailImage).isEqualTo(currentThumbnailAttachmentId)
+        }
+
+        @Test
+        @DisplayName("DRAFT 상태만 지정하면 생략한 첨부와 썸네일은 유지한다")
+        fun updatePost_withDraftStatusOnly_keepsOmittedAttachmentsAndThumbnail() {
+            // given
+            val postId = UUID.randomUUID()
+            val currentThumbnailAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    thumbnailImage = currentThumbnailAttachmentId,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(status = PostStatusEnum.DRAFT),
+                author.id!!,
+            )
+
+            // then
+            assertThat(post.status).isEqualTo(PostStatusEnum.DRAFT)
+            assertThat(post.thumbnailImage).isEqualTo(currentThumbnailAttachmentId)
+            verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
+            verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
         }
 
         @Test

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -1,6 +1,7 @@
 package com.techtaurant.mainserver.post.application
 
 import com.techtaurant.mainserver.attachment.application.AttachmentService
+import com.techtaurant.mainserver.attachment.entity.Attachment
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
 import com.techtaurant.mainserver.common.lock.DistributedLock
 import com.techtaurant.mainserver.notification.application.NotificationWriteService
@@ -72,6 +73,7 @@ class PostWriteServiceAttachmentTest {
         every { attachmentService.confirmAttachmentsByIds(any(), any(), any()) } just runs
         every { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) } just runs
         every { attachmentService.deleteAttachmentsByReference(any(), any()) } just runs
+        every { attachmentService.getConfirmedAttachments(any(), any()) } returns emptyList()
         every { postRepository.findPostByIdWithAuthorForUpdate(any()) } answers {
             postRepository.findPostByIdWithAuthor(firstArg())
         }
@@ -422,12 +424,59 @@ class PostWriteServiceAttachmentTest {
         }
 
         @Test
-        @DisplayName("첨부 필드 없이 본문만 바꾸면 기존 첨부와 썸네일을 유지한다")
-        fun updatePost_withoutAttachmentFields_keepsExistingAttachmentsAndThumbnail() {
+        @DisplayName("첨부 필드 없이 본문에서 참조를 제거하면 기존 본문 첨부를 삭제하고 썸네일은 유지한다")
+        fun updatePost_withoutAttachmentFields_removesUnreferencedBodyAttachmentAndKeepsThumbnail() {
             // given
             val postId = UUID.randomUUID()
-            val newAttachmentId = UUID.randomUUID()
+            val currentBodyAttachmentId = UUID.randomUUID()
             val currentThumbnailAttachmentId = UUID.randomUUID()
+            val currentBodyAttachment = mockk<Attachment>()
+            every { currentBodyAttachment.id } returns currentBodyAttachmentId
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "<img src=\"$currentBodyAttachmentId\" />",
+                    author = author,
+                    thumbnailImage = currentThumbnailAttachmentId,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+            every {
+                attachmentService.getConfirmedAttachments(postId, AttachmentReferenceType.POST)
+            } returns listOf(currentBodyAttachment)
+
+            val request =
+                UpdatePostRequest(
+                    content = "<p>첨부 참조를 제거한 본문</p>",
+                    status = PostStatusEnum.PUBLISHED,
+                )
+
+            // when
+            val response = postWriteService.updatePost(postId, request, author.id!!)
+
+            // then
+            verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(currentThumbnailAttachmentId),
+                )
+            }
+            assertThat(response.content).doesNotContain(currentBodyAttachmentId.toString())
+            assertThat(post.thumbnailImage).isEqualTo(currentThumbnailAttachmentId)
+        }
+
+        @Test
+        @DisplayName("첨부 필드 없이 본문 참조를 유지하면 기존 본문 첨부와 썸네일을 유지한다")
+        fun updatePost_withoutAttachmentFields_keepsReferencedBodyAttachmentAndThumbnail() {
+            // given
+            val postId = UUID.randomUUID()
+            val currentBodyAttachmentId = UUID.randomUUID()
+            val currentThumbnailAttachmentId = UUID.randomUUID()
+            val currentBodyAttachment = mockk<Attachment>()
+            every { currentBodyAttachment.id } returns currentBodyAttachmentId
             val post =
                 Post(
                     title = "기존 제목",
@@ -438,20 +487,26 @@ class PostWriteServiceAttachmentTest {
                 ).apply { id = postId }
 
             every { postRepository.findPostByIdWithAuthor(postId) } returns post
-
-            val request =
-                UpdatePostRequest(
-                    content = "<img src=\"$newAttachmentId\" />",
-                    status = PostStatusEnum.PUBLISHED,
-                )
+            every {
+                attachmentService.getConfirmedAttachments(postId, AttachmentReferenceType.POST)
+            } returns listOf(currentBodyAttachment)
 
             // when
-            val response = postWriteService.updatePost(postId, request, author.id!!)
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(content = "<img src=\"$currentBodyAttachmentId\" />"),
+                author.id!!,
+            )
 
             // then
             verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
-            verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
-            assertThat(response.content).contains(newAttachmentId.toString())
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(currentBodyAttachmentId, currentThumbnailAttachmentId),
+                )
+            }
             assertThat(post.thumbnailImage).isEqualTo(currentThumbnailAttachmentId)
         }
 

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -1,7 +1,6 @@
 package com.techtaurant.mainserver.post.application
 
 import com.techtaurant.mainserver.attachment.application.AttachmentService
-import com.techtaurant.mainserver.attachment.entity.Attachment
 import com.techtaurant.mainserver.attachment.enums.AttachmentReferenceType
 import com.techtaurant.mainserver.common.lock.DistributedLock
 import com.techtaurant.mainserver.notification.application.NotificationWriteService
@@ -73,7 +72,6 @@ class PostWriteServiceAttachmentTest {
         every { attachmentService.confirmAttachmentsByIds(any(), any(), any()) } just runs
         every { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) } just runs
         every { attachmentService.deleteAttachmentsByReference(any(), any()) } just runs
-        every { attachmentService.getConfirmedAttachments(any(), any()) } returns emptyList()
         every { postRepository.findPostByIdWithAuthorForUpdate(any()) } answers {
             postRepository.findPostByIdWithAuthor(firstArg())
         }
@@ -424,14 +422,133 @@ class PostWriteServiceAttachmentTest {
         }
 
         @Test
+        @DisplayName("attachmentIds에서 빠져도 본문에 참조가 남아 있으면 기존 첨부를 유지한다")
+        fun updatePost_attachmentIdsOmittingReferencedAttachment_keepsItByContent() {
+            // given
+            val postId = UUID.randomUUID()
+            val existingAttachmentId = UUID.randomUUID()
+            val newAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "<img src=\"$existingAttachmentId\" />",
+                    author = author,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when: 새로 추가한 첨부만 attachmentIds에 담고 기존 첨부는 본문에만 남긴다
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(
+                    content = "<img src=\"$existingAttachmentId\" /><img src=\"$newAttachmentId\" />",
+                    attachmentIds = listOf(newAttachmentId),
+                ),
+                author.id!!,
+            )
+
+            // then
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(existingAttachmentId, newAttachmentId),
+                )
+            }
+            verify {
+                attachmentService.confirmAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(newAttachmentId),
+                )
+            }
+        }
+
+        @Test
+        @DisplayName("attachmentIds로 보내도 본문에 참조가 없으면 확정하지 않고 유지 대상에서 제외한다")
+        fun updatePost_attachmentIdsAbsentFromContent_isNeitherConfirmedNorKept() {
+            // given
+            val postId = UUID.randomUUID()
+            val unreferencedAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(
+                    content = "<p>첨부를 넣지 않은 본문</p>",
+                    attachmentIds = listOf(unreferencedAttachmentId),
+                ),
+                author.id!!,
+            )
+
+            // then
+            verify {
+                attachmentService.confirmAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    emptyList(),
+                )
+            }
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    emptyList(),
+                )
+            }
+        }
+
+        @Test
+        @DisplayName("본문에만 있고 attachmentIds가 없으면 확정하지 않은 채 유지 대상으로만 둔다")
+        fun updatePost_attachmentOnlyInContent_isKeptWithoutConfirm() {
+            // given
+            val postId = UUID.randomUUID()
+            val unconfirmedAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(content = "<img src=\"$unconfirmedAttachmentId\" />"),
+                author.id!!,
+            )
+
+            // then
+            verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
+            verify {
+                attachmentService.deleteOrphanedAttachmentsByIds(
+                    postId,
+                    AttachmentReferenceType.POST,
+                    listOf(unconfirmedAttachmentId),
+                )
+            }
+        }
+
+        @Test
         @DisplayName("첨부 필드 없이 본문에서 참조를 제거하면 기존 본문 첨부를 삭제하고 썸네일은 유지한다")
         fun updatePost_withoutAttachmentFields_removesUnreferencedBodyAttachmentAndKeepsThumbnail() {
             // given
             val postId = UUID.randomUUID()
             val currentBodyAttachmentId = UUID.randomUUID()
             val currentThumbnailAttachmentId = UUID.randomUUID()
-            val currentBodyAttachment = mockk<Attachment>()
-            every { currentBodyAttachment.id } returns currentBodyAttachmentId
             val post =
                 Post(
                     title = "기존 제목",
@@ -442,9 +559,6 @@ class PostWriteServiceAttachmentTest {
                 ).apply { id = postId }
 
             every { postRepository.findPostByIdWithAuthor(postId) } returns post
-            every {
-                attachmentService.getConfirmedAttachments(postId, AttachmentReferenceType.POST)
-            } returns listOf(currentBodyAttachment)
 
             val request =
                 UpdatePostRequest(
@@ -475,8 +589,6 @@ class PostWriteServiceAttachmentTest {
             val postId = UUID.randomUUID()
             val currentBodyAttachmentId = UUID.randomUUID()
             val currentThumbnailAttachmentId = UUID.randomUUID()
-            val currentBodyAttachment = mockk<Attachment>()
-            every { currentBodyAttachment.id } returns currentBodyAttachmentId
             val post =
                 Post(
                     title = "기존 제목",
@@ -487,9 +599,6 @@ class PostWriteServiceAttachmentTest {
                 ).apply { id = postId }
 
             every { postRepository.findPostByIdWithAuthor(postId) } returns post
-            every {
-                attachmentService.getConfirmedAttachments(postId, AttachmentReferenceType.POST)
-            } returns listOf(currentBodyAttachment)
 
             // when
             postWriteService.updatePost(
@@ -572,6 +681,71 @@ class PostWriteServiceAttachmentTest {
             // then
             assertThat(post.status).isEqualTo(PostStatusEnum.DRAFT)
             assertThat(post.thumbnailImage).isEqualTo(currentThumbnailAttachmentId)
+            verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
+            verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
+        }
+
+        @Test
+        @DisplayName("DRAFT로 전환하면서 본문과 첨부를 전달해도 첨부를 확정하거나 정리하지 않는다")
+        fun updatePost_toDraftWithAttachmentFields_skipsAttachmentConfirmAndCleanup() {
+            // given
+            val postId = UUID.randomUUID()
+            val newAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    status = PostStatusEnum.PUBLISHED,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(
+                    content = "<img src=\"$newAttachmentId\" />",
+                    attachmentIds = listOf(newAttachmentId),
+                    thumbnailAttachmentId = newAttachmentId,
+                    status = PostStatusEnum.DRAFT,
+                ),
+                author.id!!,
+            )
+
+            // then
+            assertThat(post.thumbnailImage).isNull()
+            verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
+            verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
+        }
+
+        @Test
+        @DisplayName("이미 DRAFT인 게시물은 첨부를 전달해도 확정하거나 정리하지 않는다")
+        fun updatePost_draftPostWithAttachmentFields_skipsAttachmentConfirmAndCleanup() {
+            // given
+            val postId = UUID.randomUUID()
+            val newAttachmentId = UUID.randomUUID()
+            val post =
+                Post(
+                    title = "기존 제목",
+                    content = "기존 본문",
+                    author = author,
+                    status = PostStatusEnum.DRAFT,
+                ).apply { id = postId }
+
+            every { postRepository.findPostByIdWithAuthor(postId) } returns post
+
+            // when
+            postWriteService.updatePost(
+                postId,
+                UpdatePostRequest(
+                    content = "<img src=\"$newAttachmentId\" />",
+                    attachmentIds = listOf(newAttachmentId),
+                ),
+                author.id!!,
+            )
+
+            // then
             verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
             verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
         }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceValidationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceValidationTest.kt
@@ -83,6 +83,7 @@ class PostWriteServiceValidationTest {
         every { tagWriteService.resolveTags(any()) } returns emptySet()
         every { attachmentService.confirmAttachmentsByIds(any(), any(), any()) } just runs
         every { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) } just runs
+        every { attachmentService.getConfirmedAttachments(any(), any()) } returns emptyList()
         every { postRepository.findPostByIdWithAuthorForUpdate(any()) } answers {
             postRepository.findPostByIdWithAuthor(firstArg())
         }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceValidationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceValidationTest.kt
@@ -292,10 +292,11 @@ class PostWriteServiceValidationTest {
         }
 
         @Test
-        @DisplayName("DRAFT로 되돌리면 썸네일을 비우고 첨부 정리를 하지 않는다")
-        fun updatePost_toDraft_clearsThumbnailWithoutAttachmentCleanup() {
+        @DisplayName("DRAFT 상태만 변경하면 생략한 썸네일과 첨부를 유지한다")
+        fun updatePost_toDraft_keepsOmittedThumbnailAndAttachments() {
             // given
-            val post = publishedPost().apply { thumbnailImage = UUID.randomUUID() }
+            val thumbnailAttachmentId = UUID.randomUUID()
+            val post = publishedPost().apply { thumbnailImage = thumbnailAttachmentId }
             every { postRepository.findPostByIdWithAuthor(post.id!!) } returns post
 
             // when
@@ -306,7 +307,9 @@ class PostWriteServiceValidationTest {
             )
 
             // then
-            assertThat(post.thumbnailImage).isNull()
+            assertThat(post.status).isEqualTo(PostStatusEnum.DRAFT)
+            assertThat(post.thumbnailImage).isEqualTo(thumbnailAttachmentId)
+            verify(exactly = 0) { attachmentService.confirmAttachmentsByIds(any(), any(), any()) }
             verify(exactly = 0) { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) }
         }
 

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceValidationTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceValidationTest.kt
@@ -83,7 +83,6 @@ class PostWriteServiceValidationTest {
         every { tagWriteService.resolveTags(any()) } returns emptySet()
         every { attachmentService.confirmAttachmentsByIds(any(), any(), any()) } just runs
         every { attachmentService.deleteOrphanedAttachmentsByIds(any(), any(), any()) } just runs
-        every { attachmentService.getConfirmedAttachments(any(), any()) } returns emptyList()
         every { postRepository.findPostByIdWithAuthorForUpdate(any()) } answers {
             postRepository.findPostByIdWithAuthor(firstArg())
         }

--- a/src/test/kotlin/com/techtaurant/mainserver/post/entity/PostReferencedAttachmentIdsTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/entity/PostReferencedAttachmentIdsTest.kt
@@ -1,0 +1,78 @@
+package com.techtaurant.mainserver.post.entity
+
+import com.techtaurant.mainserver.security.enums.OAuthProvider
+import com.techtaurant.mainserver.user.entity.User
+import com.techtaurant.mainserver.user.enums.UserRole
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class PostReferencedAttachmentIdsTest {
+    private lateinit var author: User
+
+    @BeforeEach
+    fun setUp() {
+        author =
+            User(
+                name = "작성자",
+                email = "writer@example.com",
+                provider = OAuthProvider.GOOGLE,
+                identifier = "writer-id",
+                role = UserRole.USER,
+                profileImageUrl = "https://example.com/profile.jpg",
+            ).apply { id = UUID.randomUUID() }
+    }
+
+    @Test
+    @DisplayName("본문에 등장한 순서대로 첨부 ID를 반환한다")
+    fun referencedAttachmentIds_returnsIdsInContentOrder() {
+        // given
+        val firstAttachmentId = UUID.randomUUID()
+        val secondAttachmentId = UUID.randomUUID()
+        val post = createPost("<img src=\"$firstAttachmentId\" /><p>본문</p><img src=\"$secondAttachmentId\" />")
+
+        // when & then
+        assertThat(post.referencedAttachmentIds()).containsExactly(firstAttachmentId, secondAttachmentId)
+    }
+
+    @Test
+    @DisplayName("같은 첨부가 여러 번 등장해도 한 번만 반환한다")
+    fun referencedAttachmentIds_deduplicatesRepeatedReference() {
+        // given
+        val attachmentId = UUID.randomUUID()
+        val post = createPost("<img src=\"$attachmentId\" /><img src=\"$attachmentId\" />")
+
+        // when & then
+        assertThat(post.referencedAttachmentIds()).containsExactly(attachmentId)
+    }
+
+    @Test
+    @DisplayName("본문에 첨부 참조가 없으면 빈 목록을 반환한다")
+    fun referencedAttachmentIds_withoutReference_returnsEmpty() {
+        // given
+        val post = createPost("<p>첨부가 없는 본문</p>")
+
+        // when & then
+        assertThat(post.referencedAttachmentIds()).isEmpty()
+    }
+
+    @Test
+    @DisplayName("대문자 UUID 표기도 첨부 참조로 인식한다")
+    fun referencedAttachmentIds_recognizesUppercaseUuid() {
+        // given
+        val attachmentId = UUID.randomUUID()
+        val post = createPost("<img src=\"${attachmentId.toString().uppercase()}\" />")
+
+        // when & then
+        assertThat(post.referencedAttachmentIds()).containsExactly(attachmentId)
+    }
+
+    private fun createPost(content: String): Post =
+        Post(
+            title = "게시물",
+            content = content,
+            author = author,
+        ).apply { id = UUID.randomUUID() }
+}


### PR DESCRIPTION
## 어떤 작업인가요?

`dev`에 누적된 8개 커밋(PR #174, #177)을 `main`으로 배포합니다.

`PATCH /api/posts/{postId}`에서 첨부 관련 필드를 생략했을 때 게시물의 **첨부파일과 썸네일이 S3·DB에서 하드 삭제**되던 프로덕션 사고(#173)를 수정하고, 첨부 유지·삭제 판정 기준을 **본문 참조 하나로 단일화**했습니다.

이어서 그 사고를 만든 구조적 원인인 **S3와 DB의 이중 쓰기**를 정리했습니다(#176). 트랜잭션은 롤백되지만 S3는 되돌아가지 않아, DB가 가리키는 객체가 S3에 없는 상태가 만들어질 수 있었고 이 상태는 재업로드 없이 복구되지 않았습니다.

> 스키마 변경(Flyway migration)과 환경변수 변경은 없습니다. 애플리케이션 코드만 배포됩니다.

**FE 계약 변경이 포함된 배포입니다.** `attachmentIds`의 의미가 바뀌었습니다. 아래 [클라이언트(FE) 영향](#클라이언트fe-영향) 참고.

---

## 어떻게 해결했나요?

### 1. 첨부 필드 생략이 전량 삭제로 이어지던 경로 차단 (#173)

기존 `PostWriteService.updatePost()`는 다른 필드와 달리 첨부 요청을 `orEmpty()`로 바꿔 **항상** 첨부 정리를 실행했습니다.

```
filterAttachmentIdsIncludedInContent(content, null) → []
resolveThumbnailAttachmentId(null, currentThumbnailId, []) → null   ← 기존 썸네일 유실
deleteOrphanedAttachmentsByIds(keepAttachmentIds = [])              ← 게시물 첨부 전량 조회
  → S3 deleteObjects + DB deleteAll
```

`AttachmentService.deleteOrphanedAttachmentsByIds()`는 keep 목록이 비면 해당 게시물의 첨부를 전부 삭제 대상으로 봅니다. "지킬 게 없다"와 "클라이언트가 첨부에 대해 아무 말도 안 했다"가 구분되지 않았습니다.

- `thumbnailAttachmentId`가 전달된 경우에만 썸네일을 확정·변경합니다.
- `attachmentIds`가 전달된 경우에만 본문 첨부를 확정(confirm)합니다.
- `content`·`attachmentIds`·`thumbnailAttachmentId` 중 하나라도 전달됐을 때만 orphan 정리를 수행합니다.

### 2. 첨부 유지 판정을 본문 참조로 단일화

1차 수정만으로는 `attachmentIds`가 **유지 대상의 상한**으로 남아 있었습니다. 본문에 참조가 그대로 있는 확정 첨부라도 요청 목록에서 빠지면 삭제되어, 본문에 깨진 이미지만 남는 경로가 있었습니다.

| 요청 | 본문에 있는 기존 첨부 A |
| --- | --- |
| `attachmentIds=[B]` (A 누락), 본문에 A 유지 | 이전: **삭제** → 현재: **유지** |
| `attachmentIds` 생략, `content`만 수정 | 유지 |

판정 기준을 본문 하나로 옮겼습니다. `attachmentIds`는 이제 **새로 확정할 첨부를 지정하는 용도**로만 쓰입니다.

| 상황 | 처리 |
| --- | --- |
| `attachmentIds`에 있으나 본문에 참조 없음 | 확정하지 않고 유지 대상에서도 제외 |
| `attachmentIds`에 없으나 본문에 참조 있고 확정됨 | **유지** |
| 본문에만 있고 확정되지 않음 | 확정하지 않음 (게시물에 바인딩되지 않아 삭제 대상도 아님) |
| `content`·`attachmentIds`·`thumbnailAttachmentId` 모두 생략 | 첨부를 조회하지도 정리하지도 않음 |
| `attachmentIds=[]` | 본문에 참조가 남아 있으면 **유지** |
| `status`가 DRAFT | 확정과 정리를 모두 건너뜀 (생성 경로와 동일) |

- 본문 참조 추출은 신규 `Post.referencedAttachmentIds()`가 담당합니다. 본문을 UUID 정규식으로 스캔해 **등장 순서대로** distinct 목록을 반환하며, 쓰기(유지 판정)와 읽기(썸네일 노출)가 같은 함수를 공유합니다.
- orphan 정리가 이미 게시물에 바인딩된 첨부만 조회하므로, keep 목록에 미확정 첨부가 섞여도 부작용이 없습니다. 그 결과 수정 경로에서 `getConfirmedAttachments` 조회가 제거됐습니다.

### 3. 썸네일 저장과 노출 분리

- **저장**: `thumbnailAttachmentId`가 명시된 경우에만 `thumbnail_image`에 기록합니다. 생성 시 본문 첫 첨부를 자동 승격시키던 동작(`?: attachmentIds.firstOrNull()`)을 제거했습니다.
- **노출**: 신규 `PostThumbnailResolver`가 **명시 지정 → 본문 첫 첨부 → 기본 이미지** 순으로 결정합니다.

노출 체인은 원래도 3단계였지만, 중간 단계가 `attachments.minByOrNull { it.createdAt }` 즉 **업로드 시각** 기준이라 본문 등장 순서와 어긋났습니다. 같은 로직이 목록(`PostMetadataReadService`)과 알림(`NotificationPayloadResourceResolver`) 두 곳에 복제돼 있었고, 하나로 합치면서 본문 기준으로 바로잡았습니다.

저장 시점에 승격하지 않고 조회 시점에 결정하므로, 본문이 바뀌면 별도 갱신 없이 노출 썸네일도 따라갑니다.

### 4. 썸네일 교체 시 이전 썸네일 정리

썸네일 교체도 이전 썸네일의 참조를 끊으므로 본문·첨부 목록 변경과 같은 정리 대상으로 처리합니다. 그렇지 않으면 본문에 없던 이전 썸네일이 확정 상태로 남아 상세 조회의 `attachmentPresignedUrls`에 계속 노출됩니다.

### 5. DRAFT 가드 복원

`newStatus != DRAFT` 가드는 첨부가 `tmp/` 경로의 `TMP` 상태로 머무는 구간을 보호합니다. 확정은 S3 객체를 `posts/{postId}/`로 복사하고 `referenceId`를 바인딩하는 소유권 확정 행위라, 편집 중인 DRAFT에는 적용하지 않습니다.

이 가드는 부분 수정 계약을 고치는 과정에서 한때 사라졌습니다. 생성 경로에는 같은 가드가 남아 있어 DRAFT 게시물에 `attachmentIds`를 보내면 임시 첨부가 확정되는 비대칭이 생겼고, 원래 형태로 되돌렸습니다.

### 6. S3·DB 이중 쓰기 정리 (#176, PR #177)

위 다섯 항목은 계약 결함을 고쳤지만, 그 결함을 만든 구조는 그대로였습니다. `AttachmentService`가 S3 변경과 DB 쓰기를 한 트랜잭션 안에서 섞어 수행해, 롤백돼도 S3는 되돌아가지 않았습니다.

지켜야 할 불변식을 낮추고 규칙 한 줄로 지키도록 정리했습니다.

> **DB가 진실이고, S3는 그 상위집합이다.** DB가 모르는 객체가 S3에 있는 건 허용하고, DB가 가리키는 객체가 S3에 없는 건 금지한다.
>
> **비파괴적 쓰기(copy)는 커밋 전에, 파괴적 삭제(delete)는 커밋 후에.**

| 실패 지점 | 변경 후 결과 |
| --- | --- |
| copy 실패 | 예외 → 롤백. S3·DB 모두 무변경 |
| copy 후 커밋 실패 | 확정 경로에 참조 없는 객체. 원본과 DB는 온전 → **재시도 가능** |
| 커밋 후 delete 실패 | 참조 없는 객체만 남음. DB 정합성 온전 |
| delete 전 커밋 실패 | delete가 실행되지 않음 |

**확정에서 tmp 원본 삭제 제거**
- `confirmAttachmentsByIds`의 `copyObject` 직후 `deleteObject`를 없앴습니다. 커밋 전에 원본을 지우면 롤백 시 DB는 `tmp/` 키로 되돌아가는데 그 객체가 없어 재시도가 막혔습니다.
- 원본 정리는 `tmp/` prefix에 이미 설정된 S3 lifecycle 만료 정책(14일)에 맡깁니다. **인프라 변경이 필요 없습니다.**
- 마지막 호출부가 사라진 `S3StorageService.deleteObject`를 함께 제거했습니다.

**파괴적 삭제를 커밋 이후로**
- `deleteAttachmentsByReference`와 `deleteOrphanedAttachmentsByIds`가 DB를 먼저 지우고, S3 삭제는 `TransactionSynchronization.afterCommit`에서 실행합니다.
- 이전 순서에서는 커밋이 실패하면 DB에 첨부 행이 **살아남는데** S3 객체만 사라져, 상세 조회가 정상으로 보이는 presigned URL을 발급하고 이미지만 깨졌습니다.
- `afterCommit` 예외는 커밋 호출자에게 전파되므로([Spring javadoc](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/transaction/support/TransactionSynchronization.html)), 정리 실패를 잡아 error 로그로만 남깁니다. 그렇지 않으면 커밋이 끝난 요청이 500으로 보이고 클라이언트가 이미 반영된 상태에 재시도합니다.

**게시물 수정의 확정 호출 배칭**
- 썸네일과 본문 첨부를 나눠 확정하던 것을 한 번에 넘깁니다. 검증이 모든 ID에 대해 앞에서 끝나므로 앞선 호출만 S3를 바꾸는 부분 부작용이 사라집니다. 생성 경로는 원래 한 번에 호출하고 있어 수정 경로만 예외였습니다.

---

## 배포 주의사항

### 선행 작업

없습니다. Flyway migration, 환경변수, 인프라 변경이 모두 없습니다. `tmp/` lifecycle rule은 이미 설정돼 있어 이번 배포로 새로 필요한 인프라 작업이 없습니다.

### 운영 영향 (스토리지)

이번 배포로 S3 사용량이 늘어납니다. 데이터 손실은 없고 비용만 증가합니다.

- **확정된 이미지가 최대 14일간 두 벌 존재합니다.** 확정이 `tmp/` 원본을 더 이상 지우지 않고 lifecycle 만료를 기다리기 때문입니다.
- **`posts/` 경로에 참조 없는 객체가 쌓일 수 있습니다.** 확정 후 커밋이 실패하거나, 커밋 후 S3 삭제가 실패하는 경우입니다. 정상 파일과 같은 경로라 lifecycle rule로 지울 수 없어, 청소는 이슈 #176의 후속 작업으로 남습니다.
- 쌓이는 속도는 커밋 실패율에 비례해 선형이고 청구서에 드러나므로, 배포 후 S3 사용량 추이를 한 번 확인해 두면 충분합니다.

### 클라이언트(FE) 영향

**`attachmentIds` 의미 변경 (breaking)**

- 이전: 유지할 첨부 목록. 목록에서 빠진 첨부는 삭제됨.
- 현재: **새로 확정할 첨부 목록**. 유지·삭제는 목록과 무관하게 본문 참조로 판단.
- `attachmentIds=[]`가 더 이상 "본문 첨부 제거"를 뜻하지 않습니다. 빈 배열을 보내도 본문에 참조가 남아 있으면 첨부는 유지됩니다.
- **첨부를 삭제하려면 본문에서 참조를 먼저 제거해야 합니다.** 이것이 유일한 삭제 트리거입니다.
- 기존 첨부를 유지하려고 `attachmentIds`에 다시 담을 필요가 없어졌습니다. 신규 업로드 ID만 담으면 됩니다.

**썸네일**

- `thumbnailAttachmentId` 생략 시 기존 썸네일이 유지됩니다.
- 새로 생성하는 게시물은 `thumbnailAttachmentId`를 보내지 않으면 `thumbnail_image`가 저장되지 않습니다. 목록·알림 노출은 본문 첫 첨부로 fallback되므로 화면상 결과는 이전과 동일하거나 더 정확합니다.
- **목록·알림 썸네일이 배포 직후 달라질 수 있습니다.** 명시 썸네일이 없고 본문에 이미지가 여러 개인 게시물의 경우, fallback 기준이 업로드 시각에서 본문 등장 순서로 바뀌기 때문입니다. 데이터 손실은 없고 노출 이미지만 바뀝니다.

**신규/제거된 엔드포인트**

없습니다. 요청·응답 스키마 변경도 없으며 Swagger 설명 문구만 갱신됐습니다.

### 롤백

스키마 변경이 없어 애플리케이션 롤백만으로 완전히 되돌아갑니다. 다만 롤백하면 #173의 하드 삭제 경로가 다시 열립니다.

---

## 검증

- `PostWriteServiceAttachmentTest` — 첨부 필드 생략 시 유지, 본문 참조 제거 시 정리, 요청 목록에 없어도 본문에 있으면 유지, 본문에만 있고 미확정이면 확정하지 않음, DRAFT 상태에서 확정·정리 건너뜀, 썸네일 교체 시 이전 썸네일 정리를 고정합니다.
- `PostReferencedAttachmentIdsTest`(신규) — 본문 등장 순서, 중복 제거, 대문자 UUID 매칭을 검증합니다.
- `PostThumbnailResolverTest`(신규) — 명시 지정 → 본문 첫 첨부 → null(호출부 기본 이미지) 우선순위 4종을 검증합니다.
- `AttachmentServiceTest` — 확정이 `copyObject`만 호출하고 `deleteObjects`는 호출하지 않는 것, 삭제 경로가 **커밋 전에는 S3를 건드리지 않고 커밋 후에 지우는 것**, 커밋 후 S3 삭제가 실패해도 예외가 전파되지 않는 것을 검증합니다.
- PR #177 최종 커밋(`0f694be`)에서 `./gradlew test spotlessCheck` 전체 통과(**496 tests / 0 failures / 0 errors / 0 skipped**, JaCoCo 커버리지 검증 통과)를 확인했습니다. PR #174 시점은 495 tests였습니다.

> 참고: 작업 중 `PersistenceRowLockIntegrationTest > 첨부 잠금 조회는 다른 트랜잭션의 같은 첨부 잠금 조회를 대기시킨다`가 전체 스위트에서 1회 실패했으나, 격리 실행과 전체 재실행에서 모두 통과해 재현되지 않았습니다. latch와 `lock_timeout`으로 경합을 검증하는 타이밍 의존 테스트라 부하에서 흔들린 것으로 보입니다. CI에서 같은 테스트가 실패하면 이 관측을 참고해 주세요.

## 알려진 후속 작업

- **`posts/` 경로의 참조 없는 객체를 청소하는 배치가 필요합니다**(이슈 #176 작업 항목 4). 정상 파일과 같은 경로라 lifecycle rule로는 지울 수 없습니다. 만들 때는 "생성 직후 객체는 건드리지 않는다"는 유예 기간이 필수입니다 — 커밋 직전의 정상 객체를 쓸어버리지 않으려면 그렇습니다.
- 생성 시 자동 승격이 제거됐지만, 과거에 그렇게 저장된 `thumbnail_image` 값은 DB에 남아 계속 우선 적용됩니다. 되돌리려면 별도 마이그레이션이 필요합니다.
- `Post.referencedAttachmentIds()`는 호출마다 본문을 정규식으로 스캔합니다(목록 조회 시 게시물당 1회, 캐싱 없음).
- 본문 이미지 참조의 공식 계약이 `attachmentId`인지 `objectKey`인지 문서화가 필요합니다(#173에서 제기). 현재 구현은 `attachmentId` UUID만 매칭합니다.
- `GET` 응답에 현재 `thumbnailAttachmentId`를 포함할지 결정이 필요합니다. 없으면 클라이언트가 수정 시 썸네일 유지 여부를 판단할 수 없습니다.

---

## 관련 자료

- 이슈: #173, #176
- PR: #174, #177

---

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙입니다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
