### PR TITLE
fix(attachment): S3 쓰기를 커밋 경계에 맞춰 첨부 유실 경로 제거

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
@@ -253,7 +253,15 @@ class AttachmentService(
         TransactionSynchronizationManager.registerSynchronization(
             object : TransactionSynchronization {
                 override fun afterCommit() {
-                    s3StorageService.deleteObjects(objectKeys)
+                    log.info("Deleting S3 objects after commit: {}", objectKeys)
+                    try {
+                        s3StorageService.deleteObjects(objectKeys)
+                    } catch (e: Exception) {
+                        // afterCommit 예외는 호출자에게 전파되어 이미 커밋된 요청이 실패로 보이고,
+                        // 클라이언트가 반영이 끝난 상태에 재시도하게 된다. 정리 실패의 결과는
+                        // 참조되지 않는 객체가 남는 것뿐이므로 여기서 가두고 로그로만 남긴다.
+                        log.error("Failed to delete S3 objects after commit: {}", objectKeys, e)
+                    }
                 }
             },
         )

--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentService.kt
@@ -14,12 +14,14 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.util.UUID
 
 /**
  * 첨부파일 비즈니스 로직 서비스.
  *
- * Presigned URL 발급, TMP → CONFIRMED 전환(S3 파일 이동 포함),
+ * Presigned URL 발급, TMP → CONFIRMED 전환(S3 파일 복사 포함),
  * 첨부파일 삭제를 담당한다.
  */
 @Service
@@ -108,7 +110,9 @@ class AttachmentService(
 
     /**
      * attachmentId에 해당하는 TMP Attachment를 CONFIRMED 상태로 전환합니다.
-     * S3 파일을 tmp/ 경로에서 referenceType에 맞는 확정 경로로 이동합니다.
+     * S3 파일을 tmp/ 경로에서 referenceType에 맞는 확정 경로로 복사하며, tmp/ 원본은 지우지 않습니다.
+     * 원본을 커밋 전에 지우면 이후 단계나 커밋이 실패했을 때 DB는 tmp/ 키로 롤백되는데 그 객체가 없어
+     * 재시도가 불가능해지므로, 원본 정리는 tmp/ 경로의 S3 lifecycle 만료 정책에 맡긴다.
      *
      * @param referenceId 연관 도메인 PK (게시물 ID 등)
      * @param referenceType 연관 도메인 타입
@@ -179,7 +183,6 @@ class AttachmentService(
                 sourceKey = tmpObjectKey,
                 destinationKey = newObjectKey,
             )
-            s3StorageService.deleteObject(tmpObjectKey)
 
             attachment.objectKey = newObjectKey
             attachment.status = AttachmentStatus.CONFIRMED
@@ -204,8 +207,8 @@ class AttachmentService(
         val attachments = attachmentRepository.findAllByReferenceIdAndReferenceType(referenceId, referenceType)
         if (attachments.isEmpty()) return
 
-        s3StorageService.deleteObjects(attachments.map { it.objectKey })
         attachmentRepository.deleteAllByReferenceIdAndReferenceType(referenceId, referenceType)
+        deleteObjectsAfterCommit(attachments.map { it.objectKey })
     }
 
     /**
@@ -234,8 +237,26 @@ class AttachmentService(
             }
         if (orphaned.isEmpty()) return
 
-        s3StorageService.deleteObjects(orphaned.map { it.objectKey })
         attachmentRepository.deleteAll(orphaned)
+        deleteObjectsAfterCommit(orphaned.map { it.objectKey })
+    }
+
+    /**
+     * S3 객체 삭제를 트랜잭션 커밋 이후로 미룹니다.
+     * 커밋 전에 지우면 롤백됐을 때 DB에는 첨부 행이 남고 S3 객체만 사라져,
+     * 정상으로 보이는 presigned URL이 존재하지 않는 객체를 가리키게 된다.
+     * 커밋 뒤로 미루면 실패해도 참조되지 않는 객체만 남으므로 조회 결과가 깨지지 않는다.
+     *
+     * @param objectKeys 삭제할 S3 오브젝트 키 목록
+     */
+    private fun deleteObjectsAfterCommit(objectKeys: List<String>) {
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCommit() {
+                    s3StorageService.deleteObjects(objectKeys)
+                }
+            },
+        )
     }
 
     /**

--- a/src/main/kotlin/com/techtaurant/mainserver/attachment/application/S3StorageService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/attachment/application/S3StorageService.kt
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest
 import software.amazon.awssdk.services.s3.model.Delete
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
@@ -19,7 +18,7 @@ import java.time.Duration
 /**
  * S3 파일 I/O 작업 서비스.
  *
- * Presigned URL 생성, 파일 복사, 단건/배치 삭제를 담당한다.
+ * Presigned URL 생성, 파일 복사, 배치 삭제를 담당한다.
  * 비즈니스 로직 없이 AWS S3 API 호출만 수행한다.
  */
 @Service
@@ -126,21 +125,6 @@ class S3StorageService(
                 .build()
 
         s3Client.copyObject(request)
-    }
-
-    /**
-     * S3 오브젝트를 삭제합니다.
-     *
-     * @param objectKey 삭제할 오브젝트 키
-     */
-    fun deleteObject(objectKey: String) {
-        val request =
-            DeleteObjectRequest.builder()
-                .bucket(bucketName)
-                .key(objectKey)
-                .build()
-
-        s3Client.deleteObject(request)
     }
 
     /**

--- a/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/post/application/PostWriteService.kt
@@ -166,15 +166,6 @@ class PostWriteService(
 
         val newStatus = request.status ?: post.status
         if (newStatus != PostStatusEnum.DRAFT) {
-            request.thumbnailAttachmentId?.let { thumbnailAttachmentId ->
-                attachmentService.confirmAttachmentsByIds(
-                    referenceId = postId,
-                    referenceType = AttachmentReferenceType.POST,
-                    attachmentIds = listOf(thumbnailAttachmentId),
-                )
-                post.thumbnailImage = thumbnailAttachmentId
-            }
-
             // 썸네일 교체도 이전 썸네일의 참조를 끊으므로 본문·첨부 목록 변경과 같은 정리 대상으로 본다.
             // 그렇지 않으면 본문에 없던 이전 썸네일이 확정 상태로 남아 상세 조회의 첨부 URL 목록에 계속 노출된다.
             val isAttachmentReferenceChanged =
@@ -183,17 +174,25 @@ class PostWriteService(
             if (isAttachmentReferenceChanged) {
                 val attachmentIdsReferencedInContent = post.referencedAttachmentIds()
 
-                request.attachmentIds?.let { requestedAttachmentIds ->
+                // 확정은 S3 복사를 일으키므로 썸네일과 본문 첨부를 한 번에 넘긴다.
+                // 나눠 호출하면 앞선 호출이 S3를 바꾼 뒤 뒤 호출의 검증이 실패할 수 있고,
+                // 그때 롤백된 DB와 이미 변경된 S3가 어긋난다.
+                if (request.attachmentIds != null || request.thumbnailAttachmentId != null) {
                     attachmentService.confirmAttachmentsByIds(
                         referenceId = postId,
                         referenceType = AttachmentReferenceType.POST,
                         attachmentIds =
-                            filterAttachmentIdsIncludedInContent(
-                                attachmentIdsReferencedInContent,
-                                requestedAttachmentIds,
+                            mergeAttachmentIds(
+                                filterAttachmentIdsIncludedInContent(
+                                    attachmentIdsReferencedInContent,
+                                    request.attachmentIds,
+                                ),
+                                request.thumbnailAttachmentId,
                             ),
                     )
                 }
+
+                request.thumbnailAttachmentId?.let { post.thumbnailImage = it }
 
                 attachmentService.deleteOrphanedAttachmentsByIds(
                     referenceId = postId,

--- a/src/test/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentServiceTest.kt
@@ -15,6 +15,7 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -622,6 +623,31 @@ class AttachmentServiceTest {
             verify { attachmentRepository.deleteAll(listOf(orphanAttachment)) }
 
             triggerAfterCommit()
+            verify { s3StorageService.deleteObjects(listOf(orphanAttachment.objectKey)) }
+        }
+
+        @Test
+        @DisplayName("커밋 후 S3 삭제가 실패해도 예외를 호출자에게 전파하지 않는다")
+        fun deleteOrphanedAttachmentsByIds_s3DeleteFailsAfterCommit_doesNotPropagateException() {
+            // given
+            val orphanAttachment = makeAttachment("posts/$postId/uuid2/orphan.jpg")
+
+            every {
+                attachmentRepository.findAllByReferenceIdAndReferenceType(postId, AttachmentReferenceType.POST)
+            } returns listOf(orphanAttachment)
+            every { attachmentRepository.deleteAll(any<List<Attachment>>()) } just runs
+            every { s3StorageService.deleteObjects(any()) } throws RuntimeException("S3 unavailable")
+
+            // when
+            attachmentService.deleteOrphanedAttachmentsByIds(
+                postId,
+                AttachmentReferenceType.POST,
+                emptyList(),
+            )
+
+            // then
+            // 전파되면 DB 커밋이 끝난 요청이 실패로 보이고 클라이언트가 반영된 상태에 재시도한다.
+            assertThatCode { triggerAfterCommit() }.doesNotThrowAnyException()
             verify { s3StorageService.deleteObjects(listOf(orphanAttachment.objectKey)) }
         }
     }

--- a/src/test/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/attachment/application/AttachmentServiceTest.kt
@@ -16,11 +16,13 @@ import io.mockk.slot
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.util.UUID
 
 class AttachmentServiceTest {
@@ -36,6 +38,22 @@ class AttachmentServiceTest {
         )
 
     private val postId = UUID.randomUUID()
+
+    // 파괴적 S3 삭제는 커밋 이후로 미뤄지므로, 단위 테스트도 트랜잭션 동기화를 활성화해야 콜백이 등록된다.
+    @BeforeEach
+    fun initTransactionSynchronization() {
+        TransactionSynchronizationManager.initSynchronization()
+    }
+
+    @AfterEach
+    fun clearTransactionSynchronization() {
+        TransactionSynchronizationManager.clearSynchronization()
+    }
+
+    /** 등록된 커밋 후 콜백을 실행해 커밋 시점을 재현한다. */
+    private fun triggerAfterCommit() {
+        TransactionSynchronizationManager.getSynchronizations().forEach { it.afterCommit() }
+    }
 
     private fun makeAttachment(
         objectKey: String,
@@ -130,7 +148,6 @@ class AttachmentServiceTest {
             }
             every { s3StorageService.exists(any()) } returns true
             every { s3StorageService.copyObject(any(), any()) } just runs
-            every { s3StorageService.deleteObject(any()) } just runs
             every { attachmentRepository.saveAll(any<List<Attachment>>()) } answers { firstArg() }
         }
 
@@ -314,8 +331,8 @@ class AttachmentServiceTest {
         }
 
         @Test
-        @DisplayName("TMP 파일을 posts/{referenceId}/ 경로로 복사하고 원본을 삭제한다")
-        fun confirmAttachmentsByIds_tmpAttachment_copiesAndDeletesS3Object() {
+        @DisplayName("TMP 파일을 posts/{referenceId}/ 경로로 복사하고 tmp/ 원본은 남긴다")
+        fun confirmAttachmentsByIds_tmpAttachment_copiesS3ObjectAndKeepsSource() {
             // given
             every { attachmentRepository.findAllById(listOf(tmpAttachment.id!!)) } returns listOf(tmpAttachment)
 
@@ -332,7 +349,8 @@ class AttachmentServiceTest {
             assertThat(newKey).endsWith("photo.jpg")
 
             verify { s3StorageService.copyObject(tmpKey, newKey) }
-            verify { s3StorageService.deleteObject(tmpKey) }
+            // 커밋 전에 원본을 지우면 롤백 시 DB가 가리키는 tmp/ 객체가 사라져 재시도가 막힌다.
+            verify(exactly = 0) { s3StorageService.deleteObjects(any()) }
         }
 
         @Test
@@ -485,12 +503,15 @@ class AttachmentServiceTest {
             attachmentService.deleteAttachmentsByReference(postId, AttachmentReferenceType.POST)
 
             // then
+            verify { attachmentRepository.deleteAllByReferenceIdAndReferenceType(postId, AttachmentReferenceType.POST) }
+            verify(exactly = 0) { s3StorageService.deleteObjects(any()) }
+
+            triggerAfterCommit()
             verify {
                 s3StorageService.deleteObjects(
                     match { it.containsAll(listOf("posts/$postId/uuid1/a.jpg", "posts/$postId/uuid2/b.jpg")) },
                 )
             }
-            verify { attachmentRepository.deleteAllByReferenceIdAndReferenceType(postId, AttachmentReferenceType.POST) }
         }
 
         @Test
@@ -540,8 +561,11 @@ class AttachmentServiceTest {
             )
 
             // then
-            verify { s3StorageService.deleteObjects(listOf(orphanAttachment.objectKey)) }
             verify { attachmentRepository.deleteAll(listOf(orphanAttachment)) }
+            verify(exactly = 0) { s3StorageService.deleteObjects(any()) }
+
+            triggerAfterCommit()
+            verify { s3StorageService.deleteObjects(listOf(orphanAttachment.objectKey)) }
         }
 
         @Test
@@ -595,8 +619,10 @@ class AttachmentServiceTest {
             verify(exactly = 0) {
                 attachmentRepository.findAllByReferenceIdAndReferenceTypeAndIdNotIn(any(), any(), any())
             }
-            verify { s3StorageService.deleteObjects(listOf(orphanAttachment.objectKey)) }
             verify { attachmentRepository.deleteAll(listOf(orphanAttachment)) }
+
+            triggerAfterCommit()
+            verify { s3StorageService.deleteObjects(listOf(orphanAttachment.objectKey)) }
         }
     }
 

--- a/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/post/application/PostWriteServiceAttachmentTest.kt
@@ -325,8 +325,8 @@ class PostWriteServiceAttachmentTest {
         }
 
         @Test
-        @DisplayName("본문 첨부와 thumbnailAttachmentId를 각각 전달하면 각각 confirm하고 유지한다")
-        fun updatePost_withAttachmentIdsAndThumbnailAttachmentId_confirmsEachField() {
+        @DisplayName("본문 첨부와 thumbnailAttachmentId를 함께 전달하면 한 번의 confirm으로 처리하고 유지한다")
+        fun updatePost_withAttachmentIdsAndThumbnailAttachmentId_confirmsInSingleCall() {
             // given
             val postId = UUID.randomUUID()
             val contentAttachmentId = UUID.randomUUID()
@@ -353,18 +353,12 @@ class PostWriteServiceAttachmentTest {
             postWriteService.updatePost(postId, request, author.id!!)
 
             // then
-            verify {
+            // 나눠 호출하면 앞선 호출이 S3를 바꾼 뒤 뒤 호출의 검증이 실패할 수 있으므로 한 번에 넘긴다.
+            verify(exactly = 1) {
                 attachmentService.confirmAttachmentsByIds(
                     postId,
                     AttachmentReferenceType.POST,
-                    listOf(thumbnailAttachmentId),
-                )
-            }
-            verify {
-                attachmentService.confirmAttachmentsByIds(
-                    postId,
-                    AttachmentReferenceType.POST,
-                    listOf(contentAttachmentId),
+                    listOf(contentAttachmentId, thumbnailAttachmentId),
                 )
             }
             verify {


### PR DESCRIPTION
## 관련 자료
- 이슈: #176

## 어떤 작업인가요?
- `AttachmentService`가 S3 변경과 DB 쓰기를 한 트랜잭션 안에서 섞어 수행해, 트랜잭션이 롤백돼도 S3는 되돌아가지 않는 문제를 해결합니다.
- 그 결과 만들어지던 **DB가 가리키는 객체가 S3에 없는 상태**(재업로드 없이는 복구 불가)를 제거합니다.
- 이슈 #176의 작업 항목 1·2·3을 반영합니다. 항목 4(`posts/` 고아 청소 배치)는 범위에 없습니다.

## 어떻게 해결했나요?

지켜야 할 불변식을 낮추고, 그 불변식을 규칙 한 줄로 지킵니다.

> **DB가 진실이고, S3는 그 상위집합이다.**
> DB가 모르는 객체가 S3에 있는 건 허용하고, DB가 가리키는 객체가 S3에 없는 건 금지한다.

> **비파괴적 쓰기(copy)는 커밋 전에, 파괴적 삭제(delete)는 커밋 후에.**

| 실패 지점 | 변경 후 결과 |
| --- | --- |
| copy 실패 | 예외 → 롤백. S3·DB 모두 무변경 |
| copy 후 커밋 실패 | 확정 경로에 참조 없는 객체. 원본과 DB는 온전 → **재시도 가능** |
| 커밋 후 delete 실패 | 참조 없는 객체만 남음. DB 정합성 온전 |
| delete 전 커밋 실패 | delete가 실행되지 않음 |

어느 칸에도 "DB가 가리키는데 객체가 없다"가 없습니다.

**확정에서 tmp 원본 삭제 제거**
- `confirmAttachmentsByIds`의 `copyObject` 직후 `deleteObject`를 없앴습니다. 커밋 전에 원본을 지우면 롤백 시 DB는 `tmp/` 키로 되돌아가는데 그 객체가 없어, 재시도가 업로드 확인 검증(`AttachmentService.kt:165`)에 걸려 실패했습니다.
- 원본 정리는 `techtaurant-infra/common/s3.tf`의 `delete-tmp-files` lifecycle rule(`tmp/` prefix, 14일 만료)에 맡깁니다. 이미 이 용도로 설정돼 있어 **인프라 변경이 필요 없습니다.**
- 마지막 호출부가 사라진 `S3StorageService.deleteObject`를 함께 제거했습니다.

**파괴적 삭제를 커밋 이후로**
- `deleteAttachmentsByReference`와 `deleteOrphanedAttachmentsByIds`가 DB를 먼저 지우고, S3 삭제는 `TransactionSynchronization.afterCommit`에서 실행합니다.
- 이전 순서에서는 커밋이 실패하면 DB에 첨부 행이 **살아남는데** S3 객체만 사라져, 상세 조회가 정상으로 보이는 presigned URL을 발급하고 이미지만 깨졌습니다.
- 두 경로가 공유하는 `deleteObjectsAfterCommit` private 헬퍼로 묶어 이유를 한 곳에만 기록했습니다.

**게시물 수정의 확정 호출 배칭**
- `PostWriteService.updatePost`가 썸네일과 본문 첨부를 나눠 확정하던 것을 한 번에 넘깁니다. 검증이 모든 ID에 대해 앞에서 끝나므로 앞선 호출만 S3를 바꾸는 부분 부작용이 사라집니다.
- 생성 경로는 원래 한 번에 호출하고 있어, 수정 경로만 예외였습니다.

## 중요한 변경 사항은 무엇인가요?

### 첨부 확정의 S3 동작

**tmp 원본을 남기고 복사만 수행**
- **변경 이유**: 커밋 전 파괴적 삭제가 롤백을 복구 불가로 만들기 때문입니다.
- **수정 파일**: `AttachmentService.kt`, `S3StorageService.kt`

### 첨부 삭제의 트랜잭션 경계

**DB 삭제 후 커밋 시점에 S3 삭제**
- **변경 이유**: 커밋이 실패하면 DB 행이 남은 채 객체만 사라져 깨진 참조가 되기 때문입니다.
- **수정 파일**: `AttachmentService.kt`

### 게시물 수정의 확정 호출

**썸네일·본문 첨부 확정을 단일 호출로 병합**
- **변경 이유**: 나눠 호출하면 앞선 호출이 S3를 바꾼 뒤 뒤 호출의 검증이 실패해 부분 부작용이 남기 때문입니다.
- **수정 파일**: `PostWriteService.kt`

## 배포 주의사항

### 선행 작업
없습니다. Flyway migration, 환경변수, 인프라 변경이 모두 없습니다.

### 운영 영향
- **확정된 이미지가 최대 14일간 두 벌 존재합니다.** `tmp/` 원본이 lifecycle 만료 전까지 남습니다. 데이터 손실은 없고 스토리지 요금만 늘어납니다.
- **`posts/` 경로에 참조 없는 객체가 쌓일 수 있습니다.** 확정 후 커밋이 실패하거나, 커밋 후 S3 삭제가 실패하는 경우입니다. 정상 파일과 같은 경로라 lifecycle rule로 지울 수 없어, 청소는 이슈 #176의 작업 항목 4(후속)로 남습니다. 증가가 선형이라 급하지 않습니다.

### 클라이언트(FE) 영향
없습니다. 엔드포인트, 요청·응답 스키마, 상태 코드가 모두 그대로입니다.

### 롤백
스키마 변경이 없어 애플리케이션 롤백만으로 되돌아갑니다. 다만 롤백하면 첨부 유실 경로가 다시 열립니다.

## 검증

- `./gradlew test spotlessCheck` — **BUILD SUCCESSFUL, 495 tests / 0 failures / 0 errors / 0 skipped**, JaCoCo 커버리지 검증 통과
- `AttachmentServiceTest` — 확정이 `copyObject`만 호출하고 `deleteObjects`는 호출하지 않는 것, 삭제 경로가 **커밋 전에는 S3를 건드리지 않고 커밋 후에 지우는 것**을 순서까지 검증합니다.
- `PostWriteServiceAttachmentTest` — 썸네일과 본문 첨부를 함께 보낼 때 확정이 `verify(exactly = 1)`로 한 번만 호출되는 것을 고정합니다.

## 리뷰 시 확인이 필요한 부분

- **`TransactionSynchronization` 첫 도입입니다.** 코드베이스에 기존 사용처가 없어 `AttachmentService`의 private 헬퍼로 가두고 공용 추상화는 만들지 않았습니다. 이 범위가 적절한지 봐주세요.
- **단위 테스트가 트랜잭션 동기화를 직접 활성화합니다.** `TransactionSynchronizationManager`는 트랜잭션 밖에서 호출하면 예외를 던져서, 프로덕션 코드에 `isSynchronizationActive()` 분기를 넣는 대신 테스트가 `initSynchronization`/`clearSynchronization`/`triggerAfterCommit`을 쓰도록 했습니다. 프로덕션에 테스트용 우회 경로를 만들지 않는 쪽을 택한 판단입니다.
- **배칭 조건을 `request.attachmentIds != null`로 뒀습니다.** 병합 결과의 비어있음이 아니라 "클라이언트가 확정 대상을 지정했는가"가 기준입니다. `attachmentIds`에 본문에 없는 ID만 담아 보내면 여전히 빈 목록으로 확정이 호출되며, 이 동작을 검증하는 기존 테스트가 3곳 있어 그대로 보존했습니다.

---

### 코드 리뷰 RCA 룰
리뷰 코멘트의 중요도에 따라 접두에 R, C, A 중 하나를 붙입니다.
- **R**(Request changes): 적극적으로 고려하거나 반드시 반영해 주세요.
- **C**(Comment): 가능한 반영해 주세요.
- **A**(Approve): 사소한 의견이므로 반영하지 않고 넘어가도 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
