### PR TITLE
feat(security): 인증 쿠키 도메인을 .techtaurant.com으로 지정

### DIFF
--- a/src/main/kotlin/com/techtaurant/mainserver/security/helper/CookieHelper.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/helper/CookieHelper.kt
@@ -14,21 +14,23 @@ class CookieHelper(
     private val cookieProperties: CookieProperties,
 ) {
     fun addCookie(
+        request: HttpServletRequest,
         response: HttpServletResponse,
         name: String,
         value: String,
         maxAge: Int,
     ) {
-        expireLegacyCookies(response, name)
-        addCookieHeader(response, name, value, maxAge, resolveCookiePath(name), AUTH_COOKIE_DOMAIN)
+        val domain = resolveCookieDomain(request, name)
+        expireOtherCookieVariants(response, name, domain)
+        addCookieHeader(response, name, value, maxAge, resolveCookiePath(name), domain)
     }
 
     fun deleteCookie(
         response: HttpServletResponse,
         name: String,
     ) {
-        addCookieHeader(response, name, "", 0, resolveCookiePath(name), AUTH_COOKIE_DOMAIN)
-        expireLegacyCookies(response, name)
+        addCookieHeader(response, name, "", 0, resolveCookiePath(name), domain = null)
+        expireOtherCookieVariants(response, name, currentDomain = null)
     }
 
     fun deleteAllAuthCookies(response: HttpServletResponse) {
@@ -65,26 +67,44 @@ class CookieHelper(
     }
 
     /**
-     * 이전 버전이 Domain 없이 발급한 host-only 쿠키는 도메인 쿠키를 지우는 헤더로는 사라지지 않는다.
-     * 같은 이름의 쿠키가 함께 남으면 먼저 만들어진 옛 쿠키가 요청 헤더 앞에 실려 옛 토큰으로 인증이 처리되므로,
-     * 인증 쿠키를 새로 내려주거나 지울 때마다 예전 Path에 남아 있을 수 있는 host-only 쿠키까지 만료시킨다.
+     * 프론트엔드 서버가 자신의 서브도메인에서 읽어야 하는 accessToken에만 부모 도메인을 부여한다.
+     * refreshToken과 OAuth 쿠키는 API 호스트 밖으로 나갈 이유가 없어 host-only로 둔다.
+     * techtaurant.com 하위가 아닌 호스트에서는 브라우저가 부모 도메인 쿠키를 거부하므로 Domain을 생략한다.
      */
-    private fun expireLegacyCookies(
-        response: HttpServletResponse,
+    private fun resolveCookieDomain(
+        request: HttpServletRequest,
         name: String,
-    ) {
-        expireHostOnlyCookie(response, name, resolveCookiePath(name))
-        if (name == JwtConstants.REFRESH_TOKEN_COOKIE && cookieProperties.path != REFRESH_TOKEN_PATH) {
-            expireHostOnlyCookie(response, name, cookieProperties.path)
+    ): String? {
+        if (name != JwtConstants.ACCESS_TOKEN_COOKIE) {
+            return null
         }
+
+        return ACCESS_TOKEN_COOKIE_DOMAIN.takeIf { isAccessTokenCookieDomainHost(request.serverName) }
     }
 
-    private fun expireHostOnlyCookie(
+    private fun isAccessTokenCookieDomainHost(host: String): Boolean {
+        return host == ACCESS_TOKEN_COOKIE_DOMAIN.removePrefix(".") ||
+            host.endsWith(ACCESS_TOKEN_COOKIE_DOMAIN)
+    }
+
+    /**
+     * 브라우저는 이름이 같아도 Domain·Path 조합이 다르면 서로 다른 쿠키로 취급한다.
+     * 두 조합이 함께 남으면 먼저 만들어진 옛 쿠키가 요청 헤더 앞에 실려 옛 토큰으로 인증이 처리되므로,
+     * 지금 사용하지 않는 조합을 함께 만료시켜 한 이름당 하나만 남게 한다.
+     */
+    private fun expireOtherCookieVariants(
         response: HttpServletResponse,
         name: String,
-        path: String,
+        currentDomain: String?,
     ) {
-        addCookieHeader(response, name, "", 0, path, domain = null)
+        if (name == JwtConstants.ACCESS_TOKEN_COOKIE) {
+            val otherDomain = if (currentDomain == null) ACCESS_TOKEN_COOKIE_DOMAIN else null
+            addCookieHeader(response, name, "", 0, resolveCookiePath(name), otherDomain)
+        }
+
+        if (name == JwtConstants.REFRESH_TOKEN_COOKIE && cookieProperties.path != REFRESH_TOKEN_PATH) {
+            addCookieHeader(response, name, "", 0, cookieProperties.path, domain = null)
+        }
     }
 
     private fun resolveCookiePath(name: String): String {
@@ -97,8 +117,6 @@ class CookieHelper(
 
     private companion object {
         const val REFRESH_TOKEN_PATH = "/open-api/auth/refresh"
-
-        // 프론트엔드 서버가 자신의 서브도메인에서 인증 쿠키를 읽을 수 있도록 techtaurant.com 전체를 쿠키 범위로 둔다.
-        const val AUTH_COOKIE_DOMAIN = ".techtaurant.com"
+        const val ACCESS_TOKEN_COOKIE_DOMAIN = ".techtaurant.com"
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/security/helper/CookieHelper.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/helper/CookieHelper.kt
@@ -13,6 +13,9 @@ import java.time.Duration
 class CookieHelper(
     private val cookieProperties: CookieProperties,
 ) {
+    /**
+     * 쿠키를 발급하면서, 지금 쓰지 않는 옛 Domain·Path 조합의 만료 헤더를 함께 내보낸다.
+     */
     fun addCookie(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -21,16 +24,20 @@ class CookieHelper(
         maxAge: Int,
     ) {
         val domain = resolveCookieDomain(request, name)
-        expireOtherCookieVariants(response, name, domain)
+        val staleAccessTokenDomain = if (domain == null) ACCESS_TOKEN_COOKIE_DOMAIN else null
+        expireStaleCookieVariants(response, name, staleAccessTokenDomain)
         addCookieHeader(response, name, value, maxAge, resolveCookiePath(name), domain)
     }
 
+    /**
+     * 발급 시점의 호스트를 알 수 없으므로 host-only 조합과 도메인 조합의 만료 헤더를 모두 내보낸다.
+     */
     fun deleteCookie(
         response: HttpServletResponse,
         name: String,
     ) {
         addCookieHeader(response, name, "", 0, resolveCookiePath(name), domain = null)
-        expireOtherCookieVariants(response, name, currentDomain = null)
+        expireStaleCookieVariants(response, name, staleAccessTokenDomain = ACCESS_TOKEN_COOKIE_DOMAIN)
     }
 
     fun deleteAllAuthCookies(response: HttpServletResponse) {
@@ -91,15 +98,20 @@ class CookieHelper(
      * 브라우저는 이름이 같아도 Domain·Path 조합이 다르면 서로 다른 쿠키로 취급한다.
      * 두 조합이 함께 남으면 먼저 만들어진 옛 쿠키가 요청 헤더 앞에 실려 옛 토큰으로 인증이 처리되므로,
      * 지금 사용하지 않는 조합을 함께 만료시켜 한 이름당 하나만 남게 한다.
+     *
+     * staleAccessTokenDomain은 호출 경로와 무관하게 언제나 "만료시킬 accessToken 쿠키의 Domain 값"을 뜻한다.
+     *
+     * addCookie 경로에서 host-only 조합을 만료시키는 것은 Domain 부여 이전에 발급된 쿠키를 걷어내기 위한
+     * 마이그레이션 조치이므로, 배포 후 accessToken TTL이 지나 롤백 가능성이 닫히면 제거할 수 있다.
+     * deleteCookie 경로의 두 조합 만료는 발급 호스트를 알 수 없어 남는 영구 동작이다.
      */
-    private fun expireOtherCookieVariants(
+    private fun expireStaleCookieVariants(
         response: HttpServletResponse,
         name: String,
-        currentDomain: String?,
+        staleAccessTokenDomain: String?,
     ) {
         if (name == JwtConstants.ACCESS_TOKEN_COOKIE) {
-            val otherDomain = if (currentDomain == null) ACCESS_TOKEN_COOKIE_DOMAIN else null
-            addCookieHeader(response, name, "", 0, resolveCookiePath(name), otherDomain)
+            addCookieHeader(response, name, "", 0, resolveCookiePath(name), staleAccessTokenDomain)
         }
 
         if (name == JwtConstants.REFRESH_TOKEN_COOKIE && cookieProperties.path != REFRESH_TOKEN_PATH) {

--- a/src/main/kotlin/com/techtaurant/mainserver/security/helper/CookieHelper.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/helper/CookieHelper.kt
@@ -19,16 +19,16 @@ class CookieHelper(
         value: String,
         maxAge: Int,
     ) {
-        deleteLegacyRefreshTokenCookie(response, name)
-        addCookieHeader(response, name, value, maxAge, resolveCookiePath(name))
+        expireLegacyCookies(response, name)
+        addCookieHeader(response, name, value, maxAge, resolveCookiePath(name), AUTH_COOKIE_DOMAIN)
     }
 
     fun deleteCookie(
         response: HttpServletResponse,
         name: String,
     ) {
-        addCookieHeader(response, name, "", 0, resolveCookiePath(name))
-        deleteLegacyRefreshTokenCookie(response, name)
+        addCookieHeader(response, name, "", 0, resolveCookiePath(name), AUTH_COOKIE_DOMAIN)
+        expireLegacyCookies(response, name)
     }
 
     fun deleteAllAuthCookies(response: HttpServletResponse) {
@@ -49,11 +49,13 @@ class CookieHelper(
         value: String,
         maxAge: Int,
         path: String,
+        domain: String?,
     ) {
         val cookie =
             ResponseCookie.from(name, value)
                 .maxAge(Duration.ofSeconds(maxAge.toLong()))
                 .path(path)
+                .domain(domain)
                 .httpOnly(cookieProperties.httpOnly)
                 .secure(cookieProperties.secure)
                 .sameSite(cookieProperties.sameSite)
@@ -62,13 +64,27 @@ class CookieHelper(
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString())
     }
 
-    private fun deleteLegacyRefreshTokenCookie(
+    /**
+     * 이전 버전이 Domain 없이 발급한 host-only 쿠키는 도메인 쿠키를 지우는 헤더로는 사라지지 않는다.
+     * 같은 이름의 쿠키가 함께 남으면 먼저 만들어진 옛 쿠키가 요청 헤더 앞에 실려 옛 토큰으로 인증이 처리되므로,
+     * 인증 쿠키를 새로 내려주거나 지울 때마다 예전 Path에 남아 있을 수 있는 host-only 쿠키까지 만료시킨다.
+     */
+    private fun expireLegacyCookies(
         response: HttpServletResponse,
         name: String,
     ) {
+        expireHostOnlyCookie(response, name, resolveCookiePath(name))
         if (name == JwtConstants.REFRESH_TOKEN_COOKIE && cookieProperties.path != REFRESH_TOKEN_PATH) {
-            addCookieHeader(response, name, "", 0, cookieProperties.path)
+            expireHostOnlyCookie(response, name, cookieProperties.path)
         }
+    }
+
+    private fun expireHostOnlyCookie(
+        response: HttpServletResponse,
+        name: String,
+        path: String,
+    ) {
+        addCookieHeader(response, name, "", 0, path, domain = null)
     }
 
     private fun resolveCookiePath(name: String): String {
@@ -81,5 +97,8 @@ class CookieHelper(
 
     private companion object {
         const val REFRESH_TOKEN_PATH = "/open-api/auth/refresh"
+
+        // 프론트엔드 서버가 자신의 서브도메인에서 인증 쿠키를 읽을 수 있도록 techtaurant.com 전체를 쿠키 범위로 둔다.
+        const val AUTH_COOKIE_DOMAIN = ".techtaurant.com"
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/security/infrastructure/in/DevTestAuthController.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/infrastructure/in/DevTestAuthController.kt
@@ -7,6 +7,7 @@ import com.techtaurant.mainserver.security.SecurityConstants
 import com.techtaurant.mainserver.security.dto.DevTestLoginRequest
 import com.techtaurant.mainserver.security.dto.DevTestLoginResponse
 import com.techtaurant.mainserver.security.service.DevTestAuthService
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
@@ -35,8 +36,9 @@ class DevTestAuthController(
     @PostMapping("/login")
     override fun login(
         @RequestBody @Valid request: DevTestLoginRequest,
+        httpRequest: HttpServletRequest,
         response: HttpServletResponse,
     ): ApiResponse<DevTestLoginResponse> {
-        return ApiResponse.ok(devTestAuthService.execute(request, response))
+        return ApiResponse.ok(devTestAuthService.execute(request, httpRequest, response))
     }
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/security/infrastructure/in/DevTestAuthControllerDocs.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/infrastructure/in/DevTestAuthControllerDocs.kt
@@ -8,6 +8,7 @@ import com.techtaurant.mainserver.security.dto.DevTestLoginRequest
 import com.techtaurant.mainserver.security.dto.DevTestLoginResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponse as SwaggerApiResponse
 
@@ -28,6 +29,7 @@ interface DevTestAuthControllerDocs {
     )
     fun login(
         request: DevTestLoginRequest,
+        httpRequest: HttpServletRequest,
         response: HttpServletResponse,
     ): ApiResponse<DevTestLoginResponse>
 }

--- a/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2SuccessHandler.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/oauth/handler/OAuth2SuccessHandler.kt
@@ -43,12 +43,14 @@ class OAuth2SuccessHandler(
         tokenCacheManager.saveRefreshToken(userId.toString(), refreshToken)
 
         cookieHelper.addCookie(
+            request,
             response,
             JwtConstants.ACCESS_TOKEN_COOKIE,
             accessToken,
             (jwtProperties.accessTokenExpireMs / 1000).toInt(),
         )
         cookieHelper.addCookie(
+            request,
             response,
             JwtConstants.REFRESH_TOKEN_COOKIE,
             refreshToken,

--- a/src/main/kotlin/com/techtaurant/mainserver/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepository.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepository.kt
@@ -61,6 +61,7 @@ class HttpCookieOAuth2AuthorizationRequestRepository(
         }
 
         cookieHelper.addCookie(
+            request,
             response,
             OAUTH2_AUTHORIZATION_REQUEST_COOKIE,
             serialize(authorizationRequest),
@@ -77,6 +78,7 @@ class HttpCookieOAuth2AuthorizationRequestRepository(
         )
         if (origin != null) {
             cookieHelper.addCookie(
+                request,
                 response,
                 OAUTH2_ORIGIN_COOKIE,
                 origin,
@@ -127,6 +129,7 @@ class HttpCookieOAuth2AuthorizationRequestRepository(
         }
 
         cookieHelper.addCookie(
+            request,
             response,
             cookieName,
             redirectUri,

--- a/src/main/kotlin/com/techtaurant/mainserver/security/service/DevTestAuthService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/service/DevTestAuthService.kt
@@ -13,6 +13,7 @@ import com.techtaurant.mainserver.security.jwt.JwtTokenProvider
 import com.techtaurant.mainserver.user.application.UserUniqueNameService
 import com.techtaurant.mainserver.user.entity.User
 import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.context.annotation.Profile
@@ -54,6 +55,7 @@ class DevTestAuthService(
     @Transactional
     fun execute(
         request: DevTestLoginRequest,
+        httpRequest: HttpServletRequest,
         response: HttpServletResponse,
     ): DevTestLoginResponse {
         validatePassword(request.password)
@@ -67,12 +69,14 @@ class DevTestAuthService(
         tokenCacheManager.saveRefreshToken(userId.toString(), refreshToken)
 
         cookieHelper.addCookie(
+            httpRequest,
             response,
             JwtConstants.ACCESS_TOKEN_COOKIE,
             accessToken,
             (jwtProperties.accessTokenExpireMs / 1000).toInt(),
         )
         cookieHelper.addCookie(
+            httpRequest,
             response,
             JwtConstants.REFRESH_TOKEN_COOKIE,
             refreshToken,

--- a/src/main/kotlin/com/techtaurant/mainserver/security/service/TokenRefreshService.kt
+++ b/src/main/kotlin/com/techtaurant/mainserver/security/service/TokenRefreshService.kt
@@ -68,12 +68,14 @@ class TokenRefreshService(
 
         // 8. 쿠키에 새 토큰 설정
         cookieHelper.addCookie(
+            request,
             response,
             JwtConstants.ACCESS_TOKEN_COOKIE,
             newAccessToken,
             (jwtProperties.accessTokenExpireMs / 1000).toInt(),
         )
         cookieHelper.addCookie(
+            request,
             response,
             JwtConstants.REFRESH_TOKEN_COOKIE,
             newRefreshToken,

--- a/src/test/kotlin/com/techtaurant/mainserver/security/helper/CookieHelperTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/helper/CookieHelperTest.kt
@@ -257,8 +257,83 @@ class CookieHelperTest {
             .doesNotContain("legacy-access-token")
     }
 
+    @Test
+    @DisplayName("dev API 로그인이 prod accessToken을 덮어쓴다 - 부모 도메인이 두 환경을 한 슬롯으로 합친 현재 동작")
+    fun devLoginOverwritesProdAccessTokenSlot() {
+        // given
+        val cookieManager = CookieManager(null, CookiePolicy.ACCEPT_ALL)
+        val prodResponse = MockHttpServletResponse()
+        cookieHelper.addCookie(
+            apiHostRequest(),
+            prodResponse,
+            JwtConstants.ACCESS_TOKEN_COOKIE,
+            "prod-access-token",
+            3600,
+        )
+        storeSetCookies(cookieManager, LOGIN_URI, prodResponse)
+
+        val devResponse = MockHttpServletResponse()
+        cookieHelper.addCookie(
+            devApiHostRequest(),
+            devResponse,
+            JwtConstants.ACCESS_TOKEN_COOKIE,
+            "dev-access-token",
+            3600,
+        )
+
+        // when
+        storeSetCookies(cookieManager, DEV_LOGIN_URI, devResponse)
+
+        // then
+        assertThat(devResponse.getHeaders(HttpHeaders.SET_COOKIE).single { it.startsWith("accessToken=dev-access-token") })
+            .contains(DOMAIN_ATTRIBUTE)
+        assertThat(getCookieHeader(cookieManager, GENERAL_API_URI))
+            .contains("accessToken=dev-access-token")
+            .doesNotContain("prod-access-token")
+        assertThat(getCookieHeader(cookieManager, DEV_GENERAL_API_URI))
+            .contains("accessToken=dev-access-token")
+    }
+
+    @Test
+    @DisplayName("도메인 쿠키와 host-only 쿠키가 함께 남으면 한 요청에 accessToken 두 개가 실려 어느 토큰이 쓰일지 정해지지 않는다")
+    fun coexistingAccessTokenVariantsMakeRequestHeaderAmbiguous() {
+        // given
+        val cookieManager = CookieManager(null, CookiePolicy.ACCEPT_ALL)
+        val domainResponse = MockHttpServletResponse()
+        cookieHelper.addCookie(
+            apiHostRequest(),
+            domainResponse,
+            JwtConstants.ACCESS_TOKEN_COOKIE,
+            "domain-access-token",
+            3600,
+        )
+        storeSetCookies(cookieManager, LOGIN_URI, domainResponse)
+
+        val rolledBackResponse = MockHttpServletResponse()
+        addLegacyHostOnlyCookie(
+            rolledBackResponse,
+            JwtConstants.ACCESS_TOKEN_COOKIE,
+            "host-only-access-token",
+            "/",
+        )
+
+        // when
+        storeSetCookies(cookieManager, LOGIN_URI, rolledBackResponse)
+        val cookieHeader = getCookieHeader(cookieManager, GENERAL_API_URI)
+
+        // then
+        assertThat(cookieHeader)
+            .contains("accessToken=domain-access-token")
+            .contains("accessToken=host-only-access-token")
+        assertThat(cookieHeader.split("; ").count { it.startsWith("accessToken=") }).isEqualTo(2)
+    }
+
     private fun apiHostRequest(): MockHttpServletRequest {
         return MockHttpServletRequest().apply { serverName = API_HOST }
+    }
+
+    private fun devApiHostRequest(): MockHttpServletRequest {
+        return MockHttpServletRequest().apply { serverName = DEV_API_HOST }
     }
 
     private fun localhostRequest(): MockHttpServletRequest {
@@ -309,10 +384,14 @@ class CookieHelperTest {
         private const val DOMAIN_ATTRIBUTE = "Domain=.techtaurant.com;"
         private const val OAUTH2_AUTHORIZATION_REQUEST_COOKIE = "oauth2_auth_request"
         private const val API_HOST = "api.techtaurant.com"
+        private const val DEV_API_HOST = "dev-api.techtaurant.com"
+        private const val FRONTEND_HOST = "techtaurant.com"
         private const val LOCAL_HOST = "localhost"
         private val LOGIN_URI = URI("https://$API_HOST/oauth2/callback/google")
-        private val FRONTEND_SERVER_URI = URI("https://www.techtaurant.com/")
-        private val FRONTEND_REFRESH_URI = URI("https://www.techtaurant.com$REFRESH_TOKEN_PATH")
+        private val DEV_LOGIN_URI = URI("https://$DEV_API_HOST/oauth2/callback/google")
+        private val DEV_GENERAL_API_URI = URI("https://$DEV_API_HOST/api/users/me")
+        private val FRONTEND_SERVER_URI = URI("https://$FRONTEND_HOST/")
+        private val FRONTEND_REFRESH_URI = URI("https://$FRONTEND_HOST$REFRESH_TOKEN_PATH")
         private val GENERAL_API_URI = URI("https://$API_HOST/api/users/me")
         private val REFRESH_API_URI = URI("https://$API_HOST$REFRESH_TOKEN_PATH")
         private val LOGOUT_API_URI = URI("https://$API_HOST/api/auth/logout")

--- a/src/test/kotlin/com/techtaurant/mainserver/security/helper/CookieHelperTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/helper/CookieHelperTest.kt
@@ -36,7 +36,7 @@ class CookieHelperTest {
         // given
         val cookieManager = CookieManager(null, CookiePolicy.ACCEPT_ALL)
         val legacyResponse = MockHttpServletResponse()
-        addLegacyRefreshTokenCookie(legacyResponse)
+        addLegacyHostOnlyCookie(legacyResponse, JwtConstants.REFRESH_TOKEN_COOKIE, "legacy-refresh-token", "/")
         storeSetCookies(cookieManager, LOGIN_URI, legacyResponse)
 
         val response = MockHttpServletResponse()
@@ -64,7 +64,7 @@ class CookieHelperTest {
                 .contains("Max-Age=")
                 .contains("Expires=")
         }
-        assertThat(setCookieHeaders.single { it.startsWith("accessToken=") }).contains("Path=/;")
+        assertThat(setCookieHeaders.single { it.startsWith("accessToken=access-token") }).contains("Path=/;")
         assertThat(
             setCookieHeaders.single {
                 it.startsWith("refreshToken=refresh-token")
@@ -130,32 +130,82 @@ class CookieHelperTest {
 
         // then
         val deletionHeaders = logoutResponse.getHeaders(HttpHeaders.SET_COOKIE)
-        assertThat(deletionHeaders.single { it.startsWith("accessToken=") })
-            .contains("Path=/;")
-            .contains("Max-Age=0")
+        assertThat(deletionHeaders).allSatisfy { header ->
+            assertThat(header).contains("Max-Age=0")
+        }
         assertThat(
             deletionHeaders.single {
-                it.startsWith("refreshToken=") &&
-                    it.contains("Path=$REFRESH_TOKEN_PATH;")
+                it.startsWith("accessToken=") && it.contains(DOMAIN_ATTRIBUTE)
             },
-        )
-            .contains("Path=$REFRESH_TOKEN_PATH;")
-            .contains("Max-Age=0")
+        ).contains("Path=/;")
         assertThat(
             deletionHeaders.single {
-                it.startsWith("refreshToken=") &&
-                    it.contains("Path=/;")
+                it.startsWith("refreshToken=") && it.contains(DOMAIN_ATTRIBUTE)
             },
-        ).contains("Max-Age=0")
+        ).contains("Path=$REFRESH_TOKEN_PATH;")
         assertThat(getCookieHeader(cookieManager, GENERAL_API_URI)).isEmpty()
         assertThat(getCookieHeader(cookieManager, REFRESH_API_URI)).isEmpty()
     }
 
-    private fun addLegacyRefreshTokenCookie(response: MockHttpServletResponse) {
+    @Test
+    @DisplayName("인증 쿠키는 techtaurant.com 하위 도메인인 프론트엔드 서버에서도 읽을 수 있다")
+    fun authCookiesAreReadableFromFrontendSubdomain() {
+        // given
+        val response = MockHttpServletResponse()
+        cookieHelper.addCookie(response, JwtConstants.ACCESS_TOKEN_COOKIE, "access-token", 3600)
+        val cookieManager = CookieManager(null, CookiePolicy.ACCEPT_ALL)
+
+        // when
+        storeSetCookies(cookieManager, LOGIN_URI, response)
+        val frontendCookieHeader = getCookieHeader(cookieManager, FRONTEND_SERVER_URI)
+
+        // then
+        assertThat(response.getHeaders(HttpHeaders.SET_COOKIE).single { it.startsWith("accessToken=access-token") })
+            .contains(DOMAIN_ATTRIBUTE)
+        assertThat(frontendCookieHeader).contains("accessToken=access-token")
+    }
+
+    @Test
+    @DisplayName("Domain 없이 발급됐던 이전 인증 쿠키는 새 쿠키를 내려줄 때 함께 만료된다")
+    fun addCookieExpiresLegacyHostOnlyCookies() {
+        // given
+        val cookieManager = CookieManager(null, CookiePolicy.ACCEPT_ALL)
+        val legacyResponse = MockHttpServletResponse()
+        addLegacyHostOnlyCookie(legacyResponse, JwtConstants.ACCESS_TOKEN_COOKIE, "legacy-access-token", "/")
+        addLegacyHostOnlyCookie(
+            legacyResponse,
+            JwtConstants.REFRESH_TOKEN_COOKIE,
+            "legacy-refresh-token",
+            REFRESH_TOKEN_PATH,
+        )
+        storeSetCookies(cookieManager, LOGIN_URI, legacyResponse)
+
+        val response = MockHttpServletResponse()
+        cookieHelper.addCookie(response, JwtConstants.ACCESS_TOKEN_COOKIE, "access-token", 3600)
+        cookieHelper.addCookie(response, JwtConstants.REFRESH_TOKEN_COOKIE, "refresh-token", 604800)
+
+        // when
+        storeSetCookies(cookieManager, LOGIN_URI, response)
+
+        // then
+        assertThat(getCookieHeader(cookieManager, GENERAL_API_URI))
+            .contains("accessToken=access-token")
+            .doesNotContain("legacy-access-token")
+        assertThat(getCookieHeader(cookieManager, REFRESH_API_URI))
+            .contains("refreshToken=refresh-token")
+            .doesNotContain("legacy-refresh-token")
+    }
+
+    private fun addLegacyHostOnlyCookie(
+        response: MockHttpServletResponse,
+        name: String,
+        value: String,
+        path: String,
+    ) {
         val legacyCookie =
-            ResponseCookie.from(JwtConstants.REFRESH_TOKEN_COOKIE, "legacy-refresh-token")
+            ResponseCookie.from(name, value)
                 .maxAge(Duration.ofDays(7))
-                .path("/")
+                .path(path)
                 .httpOnly(true)
                 .secure(true)
                 .sameSite("Lax")
@@ -187,7 +237,9 @@ class CookieHelperTest {
 
     companion object {
         private const val REFRESH_TOKEN_PATH = "/open-api/auth/refresh"
+        private const val DOMAIN_ATTRIBUTE = "Domain=.techtaurant.com;"
         private val LOGIN_URI = URI("https://api.techtaurant.com/oauth2/callback/google")
+        private val FRONTEND_SERVER_URI = URI("https://www.techtaurant.com/")
         private val GENERAL_API_URI = URI("https://api.techtaurant.com/api/users/me")
         private val REFRESH_API_URI = URI("https://api.techtaurant.com$REFRESH_TOKEN_PATH")
         private val LOGOUT_API_URI = URI("https://api.techtaurant.com/api/auth/logout")

--- a/src/test/kotlin/com/techtaurant/mainserver/security/helper/CookieHelperTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/helper/CookieHelperTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseCookie
+import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
 import java.net.CookieManager
 import java.net.CookiePolicy
@@ -40,8 +41,8 @@ class CookieHelperTest {
         storeSetCookies(cookieManager, LOGIN_URI, legacyResponse)
 
         val response = MockHttpServletResponse()
-        cookieHelper.addCookie(response, JwtConstants.ACCESS_TOKEN_COOKIE, "access-token", 3600)
-        cookieHelper.addCookie(response, JwtConstants.REFRESH_TOKEN_COOKIE, "refresh-token", 604800)
+        cookieHelper.addCookie(apiHostRequest(), response, JwtConstants.ACCESS_TOKEN_COOKIE, "access-token", 3600)
+        cookieHelper.addCookie(apiHostRequest(), response, JwtConstants.REFRESH_TOKEN_COOKIE, "refresh-token", 604800)
 
         // when
         storeSetCookies(cookieManager, LOGIN_URI, response)
@@ -83,14 +84,38 @@ class CookieHelperTest {
     fun refreshResponseUpdatesRefreshTokenAtRestrictedPath() {
         // given
         val loginResponse = MockHttpServletResponse()
-        cookieHelper.addCookie(loginResponse, JwtConstants.ACCESS_TOKEN_COOKIE, "old-access-token", 3600)
-        cookieHelper.addCookie(loginResponse, JwtConstants.REFRESH_TOKEN_COOKIE, "old-refresh-token", 604800)
+        cookieHelper.addCookie(
+            apiHostRequest(),
+            loginResponse,
+            JwtConstants.ACCESS_TOKEN_COOKIE,
+            "old-access-token",
+            3600,
+        )
+        cookieHelper.addCookie(
+            apiHostRequest(),
+            loginResponse,
+            JwtConstants.REFRESH_TOKEN_COOKIE,
+            "old-refresh-token",
+            604800,
+        )
         val cookieManager = CookieManager(null, CookiePolicy.ACCEPT_ALL)
         storeSetCookies(cookieManager, LOGIN_URI, loginResponse)
 
         val refreshResponse = MockHttpServletResponse()
-        cookieHelper.addCookie(refreshResponse, JwtConstants.ACCESS_TOKEN_COOKIE, "new-access-token", 3600)
-        cookieHelper.addCookie(refreshResponse, JwtConstants.REFRESH_TOKEN_COOKIE, "new-refresh-token", 604800)
+        cookieHelper.addCookie(
+            apiHostRequest(),
+            refreshResponse,
+            JwtConstants.ACCESS_TOKEN_COOKIE,
+            "new-access-token",
+            3600,
+        )
+        cookieHelper.addCookie(
+            apiHostRequest(),
+            refreshResponse,
+            JwtConstants.REFRESH_TOKEN_COOKIE,
+            "new-refresh-token",
+            604800,
+        )
 
         // when
         storeSetCookies(cookieManager, REFRESH_API_URI, refreshResponse)
@@ -118,8 +143,14 @@ class CookieHelperTest {
     fun deleteAllAuthCookiesUsesOriginalCookiePaths() {
         // given
         val loginResponse = MockHttpServletResponse()
-        cookieHelper.addCookie(loginResponse, JwtConstants.ACCESS_TOKEN_COOKIE, "access-token", 3600)
-        cookieHelper.addCookie(loginResponse, JwtConstants.REFRESH_TOKEN_COOKIE, "refresh-token", 604800)
+        cookieHelper.addCookie(apiHostRequest(), loginResponse, JwtConstants.ACCESS_TOKEN_COOKIE, "access-token", 3600)
+        cookieHelper.addCookie(
+            apiHostRequest(),
+            loginResponse,
+            JwtConstants.REFRESH_TOKEN_COOKIE,
+            "refresh-token",
+            604800,
+        )
         val cookieManager = CookieManager(null, CookiePolicy.ACCEPT_ALL)
         storeSetCookies(cookieManager, LOGIN_URI, loginResponse)
         val logoutResponse = MockHttpServletResponse()
@@ -140,19 +171,19 @@ class CookieHelperTest {
         ).contains("Path=/;")
         assertThat(
             deletionHeaders.single {
-                it.startsWith("refreshToken=") && it.contains(DOMAIN_ATTRIBUTE)
+                it.startsWith("refreshToken=") && it.contains("Path=$REFRESH_TOKEN_PATH;")
             },
-        ).contains("Path=$REFRESH_TOKEN_PATH;")
+        ).doesNotContain(DOMAIN_ATTRIBUTE)
         assertThat(getCookieHeader(cookieManager, GENERAL_API_URI)).isEmpty()
         assertThat(getCookieHeader(cookieManager, REFRESH_API_URI)).isEmpty()
     }
 
     @Test
-    @DisplayName("인증 쿠키는 techtaurant.com 하위 도메인인 프론트엔드 서버에서도 읽을 수 있다")
-    fun authCookiesAreReadableFromFrontendSubdomain() {
+    @DisplayName("accessToken은 techtaurant.com 하위 도메인인 프론트엔드 서버에서도 읽을 수 있다")
+    fun accessTokenIsReadableFromFrontendSubdomain() {
         // given
         val response = MockHttpServletResponse()
-        cookieHelper.addCookie(response, JwtConstants.ACCESS_TOKEN_COOKIE, "access-token", 3600)
+        cookieHelper.addCookie(apiHostRequest(), response, JwtConstants.ACCESS_TOKEN_COOKIE, "access-token", 3600)
         val cookieManager = CookieManager(null, CookiePolicy.ACCEPT_ALL)
 
         // when
@@ -166,23 +197,56 @@ class CookieHelperTest {
     }
 
     @Test
-    @DisplayName("Domain 없이 발급됐던 이전 인증 쿠키는 새 쿠키를 내려줄 때 함께 만료된다")
-    fun addCookieExpiresLegacyHostOnlyCookies() {
+    @DisplayName("refreshToken과 OAuth 쿠키는 API 호스트에만 남아 형제 도메인으로 전송되지 않는다")
+    fun refreshTokenAndOauthCookiesStayHostOnly() {
+        // given
+        val response = MockHttpServletResponse()
+        cookieHelper.addCookie(apiHostRequest(), response, JwtConstants.REFRESH_TOKEN_COOKIE, "refresh-token", 604800)
+        cookieHelper.addCookie(apiHostRequest(), response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE, "oauth-state", 180)
+        val cookieManager = CookieManager(null, CookiePolicy.ACCEPT_ALL)
+
+        // when
+        storeSetCookies(cookieManager, LOGIN_URI, response)
+        val frontendRefreshCookieHeader = getCookieHeader(cookieManager, FRONTEND_REFRESH_URI)
+        val refreshApiCookieHeader = getCookieHeader(cookieManager, REFRESH_API_URI)
+
+        // then
+        assertThat(response.getHeaders(HttpHeaders.SET_COOKIE)).allSatisfy { header ->
+            assertThat(header).doesNotContain("Domain=")
+        }
+        assertThat(frontendRefreshCookieHeader).isEmpty()
+        assertThat(refreshApiCookieHeader).contains("refreshToken=refresh-token")
+    }
+
+    @Test
+    @DisplayName("techtaurant.com 하위가 아닌 호스트에서는 accessToken에 Domain을 붙이지 않는다")
+    fun accessTokenOmitsDomainOnNonTechtaurantHost() {
+        // given
+        val response = MockHttpServletResponse()
+        cookieHelper.addCookie(localhostRequest(), response, JwtConstants.ACCESS_TOKEN_COOKIE, "access-token", 3600)
+        val cookieManager = CookieManager(null, CookiePolicy.ACCEPT_ALL)
+
+        // when
+        storeSetCookies(cookieManager, LOCAL_LOGIN_URI, response)
+        val localApiCookieHeader = getCookieHeader(cookieManager, LOCAL_GENERAL_API_URI)
+
+        // then
+        assertThat(response.getHeaders(HttpHeaders.SET_COOKIE).single { it.startsWith("accessToken=access-token") })
+            .doesNotContain("Domain=")
+        assertThat(localApiCookieHeader).contains("accessToken=access-token")
+    }
+
+    @Test
+    @DisplayName("Domain 없이 발급됐던 이전 accessToken은 새 쿠키를 내려줄 때 함께 만료된다")
+    fun addCookieExpiresLegacyHostOnlyAccessToken() {
         // given
         val cookieManager = CookieManager(null, CookiePolicy.ACCEPT_ALL)
         val legacyResponse = MockHttpServletResponse()
         addLegacyHostOnlyCookie(legacyResponse, JwtConstants.ACCESS_TOKEN_COOKIE, "legacy-access-token", "/")
-        addLegacyHostOnlyCookie(
-            legacyResponse,
-            JwtConstants.REFRESH_TOKEN_COOKIE,
-            "legacy-refresh-token",
-            REFRESH_TOKEN_PATH,
-        )
         storeSetCookies(cookieManager, LOGIN_URI, legacyResponse)
 
         val response = MockHttpServletResponse()
-        cookieHelper.addCookie(response, JwtConstants.ACCESS_TOKEN_COOKIE, "access-token", 3600)
-        cookieHelper.addCookie(response, JwtConstants.REFRESH_TOKEN_COOKIE, "refresh-token", 604800)
+        cookieHelper.addCookie(apiHostRequest(), response, JwtConstants.ACCESS_TOKEN_COOKIE, "access-token", 3600)
 
         // when
         storeSetCookies(cookieManager, LOGIN_URI, response)
@@ -191,9 +255,14 @@ class CookieHelperTest {
         assertThat(getCookieHeader(cookieManager, GENERAL_API_URI))
             .contains("accessToken=access-token")
             .doesNotContain("legacy-access-token")
-        assertThat(getCookieHeader(cookieManager, REFRESH_API_URI))
-            .contains("refreshToken=refresh-token")
-            .doesNotContain("legacy-refresh-token")
+    }
+
+    private fun apiHostRequest(): MockHttpServletRequest {
+        return MockHttpServletRequest().apply { serverName = API_HOST }
+    }
+
+    private fun localhostRequest(): MockHttpServletRequest {
+        return MockHttpServletRequest().apply { serverName = LOCAL_HOST }
     }
 
     private fun addLegacyHostOnlyCookie(
@@ -238,10 +307,16 @@ class CookieHelperTest {
     companion object {
         private const val REFRESH_TOKEN_PATH = "/open-api/auth/refresh"
         private const val DOMAIN_ATTRIBUTE = "Domain=.techtaurant.com;"
-        private val LOGIN_URI = URI("https://api.techtaurant.com/oauth2/callback/google")
+        private const val OAUTH2_AUTHORIZATION_REQUEST_COOKIE = "oauth2_auth_request"
+        private const val API_HOST = "api.techtaurant.com"
+        private const val LOCAL_HOST = "localhost"
+        private val LOGIN_URI = URI("https://$API_HOST/oauth2/callback/google")
         private val FRONTEND_SERVER_URI = URI("https://www.techtaurant.com/")
-        private val GENERAL_API_URI = URI("https://api.techtaurant.com/api/users/me")
-        private val REFRESH_API_URI = URI("https://api.techtaurant.com$REFRESH_TOKEN_PATH")
-        private val LOGOUT_API_URI = URI("https://api.techtaurant.com/api/auth/logout")
+        private val FRONTEND_REFRESH_URI = URI("https://www.techtaurant.com$REFRESH_TOKEN_PATH")
+        private val GENERAL_API_URI = URI("https://$API_HOST/api/users/me")
+        private val REFRESH_API_URI = URI("https://$API_HOST$REFRESH_TOKEN_PATH")
+        private val LOGOUT_API_URI = URI("https://$API_HOST/api/auth/logout")
+        private val LOCAL_LOGIN_URI = URI("https://$LOCAL_HOST:8080/oauth2/callback/google")
+        private val LOCAL_GENERAL_API_URI = URI("https://$LOCAL_HOST:8080/api/users/me")
     }
 }

--- a/src/test/kotlin/com/techtaurant/mainserver/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepositoryTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/oauth/repository/HttpCookieOAuth2AuthorizationRequestRepositoryTest.kt
@@ -27,7 +27,7 @@ class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
         val response = MockHttpServletResponse()
         val authorizationRequest = createAuthorizationRequest()
 
-        every { cookieHelper.addCookie(any(), any(), any(), any()) } returns Unit
+        every { cookieHelper.addCookie(any(), any(), any(), any(), any()) } returns Unit
 
         // when
         repository.saveAuthorizationRequest(authorizationRequest, request, response)
@@ -35,6 +35,7 @@ class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
         // then
         verify {
             cookieHelper.addCookie(
+                request,
                 response,
                 HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_SUCCESS_REDIRECT_URI_COOKIE,
                 "/ko/oauth/callback?redirect=%2Fko%2Fpost%2Fwrite",
@@ -43,6 +44,7 @@ class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
         }
         verify {
             cookieHelper.addCookie(
+                request,
                 response,
                 HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_FAILURE_REDIRECT_URI_COOKIE,
                 "/ko/oauth/error",

--- a/src/test/kotlin/com/techtaurant/mainserver/security/service/DevTestAuthServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/service/DevTestAuthServiceTest.kt
@@ -14,6 +14,7 @@ import com.techtaurant.mainserver.user.infrastructure.out.UserRepository
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -53,6 +54,7 @@ class DevTestAuthServiceTest {
     fun `create dev test user with unique name policy`() {
         val identifier = "dev-user"
         val request = DevTestLoginRequest(identifier = identifier, password = "dev-password", role = UserRole.ADMIN)
+        val httpRequest = mockk<HttpServletRequest>()
         val response = mockk<HttpServletResponse>(relaxed = true)
         val userId = UUID.randomUUID()
         val createdUser =
@@ -72,7 +74,7 @@ class DevTestAuthServiceTest {
         every { jwtTokenProvider.createAccessToken(userId, UserRole.ADMIN) } returns "access-token"
         every { jwtTokenProvider.createRefreshToken(userId) } returns "refresh-token"
 
-        val result = devTestAuthService.execute(request, response)
+        val result = devTestAuthService.execute(request, httpRequest, response)
 
         assertEquals("access-token", result.accessToken)
         assertEquals("refresh-token", result.refreshToken)
@@ -87,6 +89,7 @@ class DevTestAuthServiceTest {
         }
         verify {
             cookieHelper.addCookie(
+                httpRequest,
                 response,
                 JwtConstants.ACCESS_TOKEN_COOKIE,
                 "access-token",
@@ -95,6 +98,7 @@ class DevTestAuthServiceTest {
         }
         verify {
             cookieHelper.addCookie(
+                httpRequest,
                 response,
                 JwtConstants.REFRESH_TOKEN_COOKIE,
                 "refresh-token",
@@ -109,6 +113,7 @@ class DevTestAuthServiceTest {
     fun `update existing dev test user role`() {
         val identifier = "existing-user"
         val request = DevTestLoginRequest(identifier = identifier, password = "dev-password", role = UserRole.ADMIN)
+        val httpRequest = mockk<HttpServletRequest>()
         val response = mockk<HttpServletResponse>(relaxed = true)
         val userId = UUID.randomUUID()
         val existingUser =
@@ -128,7 +133,7 @@ class DevTestAuthServiceTest {
         every { jwtTokenProvider.createAccessToken(userId, UserRole.ADMIN) } returns "access-token"
         every { jwtTokenProvider.createRefreshToken(userId) } returns "refresh-token"
 
-        val result = devTestAuthService.execute(request, response)
+        val result = devTestAuthService.execute(request, httpRequest, response)
 
         assertEquals(UserRole.ADMIN, existingUser.role)
         assertEquals("access-token", result.accessToken)

--- a/src/test/kotlin/com/techtaurant/mainserver/security/service/TokenRefreshServiceTest.kt
+++ b/src/test/kotlin/com/techtaurant/mainserver/security/service/TokenRefreshServiceTest.kt
@@ -65,7 +65,7 @@ class TokenRefreshServiceTest {
             }
 
         every { cookieHelper.getCookie(request, JwtConstants.REFRESH_TOKEN_COOKIE) } returns refreshTokenValue
-        every { cookieHelper.addCookie(any(), any(), any(), any()) } returns Unit
+        every { cookieHelper.addCookie(any(), any(), any(), any(), any()) } returns Unit
         every { jwtTokenProvider.validateAndGetUserId(refreshTokenValue) } returns userId
         every { tokenCacheManager.getRefreshToken(userId.toString()) } returns refreshTokenValue
         every { userRepository.findById(userId) } returns Optional.of(user)
@@ -79,6 +79,7 @@ class TokenRefreshServiceTest {
         // then
         verify {
             cookieHelper.addCookie(
+                request,
                 response,
                 JwtConstants.ACCESS_TOKEN_COOKIE,
                 newAccessToken,
@@ -87,6 +88,7 @@ class TokenRefreshServiceTest {
         }
         verify {
             cookieHelper.addCookie(
+                request,
                 response,
                 JwtConstants.REFRESH_TOKEN_COOKIE,
                 newRefreshToken,


### PR DESCRIPTION
## 배경

프론트엔드 서버가 자기 서브도메인에서 `accessToken` 쿠키를 읽을 수 있어야 한다.

기존 인증 쿠키는 `Domain` 속성 없이 발급돼 API 호스트(`api.techtaurant.com` / `dev-api.techtaurant.com`) 전용 host-only 쿠키였고, 브라우저가 프론트엔드 서버로는 쿠키를 보내지 않았다.

## 변경 사항

### 1. `accessToken`에만 `Domain=.techtaurant.com` 부여

`CookieHelper.addCookie`는 accessToken, refreshToken, OAuth2 state 4종, 개발용 로그인 토큰까지 4계열 쿠키에 공용으로 쓰인다. 부모 도메인이 필요한 것은 이번 요구사항의 대상인 `accessToken` 하나뿐이므로 `resolveCookieDomain`으로 대상을 좁혔다.

특히 `refreshToken`은 PR #168에서 `Path=/open-api/auth/refresh`로 전송 범위를 의도적으로 좁혀둔 대상이다. 도메인을 붙이면 `www.techtaurant.com/open-api/auth/refresh` 같은 형제 호스트 요청에도 refresh token이 실려 그 의도가 무효가 된다.

dev/prod API가 모두 `techtaurant.com` 하위라 값이 환경별로 갈리지 않으므로 SSM/secret이 아니라 코드 상수로 두었다.

### 2. 요청 호스트 인식

```kotlin
private fun resolveCookieDomain(request: HttpServletRequest, name: String): String? {
    if (name != JwtConstants.ACCESS_TOKEN_COOKIE) {
        return null
    }
    return ACCESS_TOKEN_COOKIE_DOMAIN.takeIf { isAccessTokenCookieDomainHost(request.serverName) }
}
```

`techtaurant.com` 하위가 아닌 호스트에서는 브라우저가 부모 도메인 쿠키를 거부하므로 `Domain`을 생략한다. 덕분에 `localhost:8080`으로 백엔드를 띄워도 OAuth 쿠키와 개발용 로그인 토큰이 정상 저장된다. 선행 판정에 `.`을 포함시켜 `eviltechtaurant.com` 같은 suffix 위장은 걸러진다.

`application.yml`의 `server.forward-headers-strategy: native` 덕분에 Tomcat이 `X-Forwarded-Host`를 반영하므로, ALB 뒤에서도 `request.serverName`은 `api.techtaurant.com`을 가리킨다.

### 3. 기존 host-only 쿠키 정리 (필수 동반 변경)

브라우저는 쿠키를 `(name, domain, path)`로 식별한다. `Domain` 없는 host-only 쿠키와 `Domain=.techtaurant.com` 쿠키는 **서로 다른 쿠키**라, 한쪽을 지우는 `Set-Cookie` 헤더로 다른 쪽이 사라지지 않는다.

이 정리가 없으면 배포 후 기존 로그인 사용자에게 아래 문제가 생긴다.

- 요청 헤더에 `accessToken=<옛것>; accessToken=<새것>`이 함께 실리고, RFC 6265 정렬상 먼저 생성된 옛 쿠키가 앞에 온다
- `CookieHelper.getCookie`가 `firstOrNull`이라 옛 토큰을 집는다
- 재로그인해도 옛 host-only 쿠키가 남아 있어 자연 만료까지 같은 상태가 반복된다

`expireOtherCookieVariants`가 지금 사용하지 않는 조합을 함께 만료시켜 한 이름당 하나만 남게 한다. 삭제 경로는 양쪽 변형을 모두 내보내므로 요청 호스트를 알 필요가 없고, 따라서 `LogoutService`와 `AuthApiController`는 변경이 없다.

## 테스트

`CookieHelperTest` 7건

| 테스트 | 검증 내용 |
| --- | --- |
| accessToken은 techtaurant.com 하위 도메인인 프론트엔드 서버에서도 읽을 수 있다 | `api.techtaurant.com`에서 발급한 accessToken이 `https://www.techtaurant.com`으로 전송됨 |
| refreshToken과 OAuth 쿠키는 API 호스트에만 남아 형제 도메인으로 전송되지 않는다 | `www.techtaurant.com/open-api/auth/refresh`에 쿠키가 실리지 않음 |
| techtaurant.com 하위가 아닌 호스트에서는 accessToken에 Domain을 붙이지 않는다 | localhost 발급 시 `Domain` 속성 없음 + 로컬에서 정상 전송 |
| Domain 없이 발급됐던 이전 accessToken은 새 쿠키를 내려줄 때 함께 만료된다 | 레거시 host-only 토큰이 요청 헤더에서 사라짐 |

`Set-Cookie` 문자열만 보는 단언은 실제 전송 결과를 증명하지 못하므로, `java.net.CookieManager`로 브라우저의 저장·전송 규칙을 재현해 "어느 URI에서 어떤 쿠키가 실제로 실리는가"를 단언한다.

```
./gradlew build   # BUILD SUCCESSFUL
500 tests, failures=0, errors=0
```

## 리뷰어가 알아야 할 점

- **인프라 변경 없음.** `techtaurant-infra`의 `ssm.tf` `COOKIE_*` 파라미터는 손대지 않았다.
- `addCookie`가 `HttpServletRequest`를 받게 되면서 개발용 로그인 경로(`DevTestAuthController` → `DevTestAuthService`)에 파라미터가 추가됐다. 나머지 호출부는 이미 request를 갖고 있어 인자 전달만 바뀐다.

## 관련 PR

- 루트 저장소 서브모듈 포인터 PR: https://github.com/techtaurant/techtaurant-total/pull/9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
